### PR TITLE
feat(music-player): add toggle for visual effects

### DIFF
--- a/apps/com.myriad.music-player/main.js
+++ b/apps/com.myriad.music-player/main.js
@@ -21,6 +21,7 @@ var i18n = {
     lyrics: '歌词',
     noLyrics: '暂无歌词',
     translate: '翻译',
+    visualFx: '动效',
     searchPlaceholder: '搜索歌曲...',
     vip: 'VIP',
     trial: '试听',
@@ -51,6 +52,7 @@ var i18n = {
     lyrics: 'Lyrics',
     noLyrics: 'No Lyrics',
     translate: 'Translate',
+    visualFx: 'Effects',
     searchPlaceholder: 'Search songs...',
     vip: 'VIP',
     trial: 'Trial',
@@ -81,6 +83,7 @@ var i18n = {
     lyrics: '歌詞',
     noLyrics: '歌詞なし',
     translate: '翻訳',
+    visualFx: '演出',
     searchPlaceholder: '曲を検索...',
     vip: 'VIP',
     trial: '試聴',
@@ -243,9 +246,15 @@ async function initAnimationConfig() {
   }
 }
 
-// 检查是否应该执行动画
+// 检查是否应该执行动画（系统级外层门控）
 function shouldAnimate() {
   return pageState.animConfig.shouldAnimate && pageState.animConfig.level !== 'none';
+}
+
+// 动态视觉效果是否启用：用户开关 ∧ 系统 shouldAnimate
+// 列表 EQ（updateListEq）不经此门控；歌词/UI 微动画亦不受影响
+function visualFxEnabled() {
+  return pageState.visualFxOn && shouldAnimate();
 }
 
 // ========================================
@@ -264,6 +273,7 @@ var pageState = {
   hasTranslation: false,   // 当前歌曲是否有翻译数据
   transLang: '',           // 翻译语言（'zh' | ''）
   transOn: false,          // 翻译显示开关（持久化于 Tapp.storage）
+  visualFxOn: true,        // 动态视觉效果开关（持久化于 Tapp.storage，默认开）
   lyricWordFrame: null,    // 逐字高亮 rAF 句柄
   lastKaraokeLine: -1,     // 上一次做逐字填充的行索引
   eqFrame: null,           // 列表均衡器频谱 rAF 句柄
@@ -518,6 +528,62 @@ function setLyricTransOn(on) {
   // 焦点目标可能未变但其他行的 y 全变了：无条件启动波浪把行送到新位
   if (shouldAnimate()) startLyricWave();
   else snapLyricItems();
+}
+
+// ========================================
+// 动态视觉效果开关（Aurora / 涟漪 / 背景漂移）
+// 列表 EQ 与歌词/UI 微动画不经此开关
+// ========================================
+
+function syncVisualFxUI() {
+  var btn = $('visual-fx-btn');
+  if (btn) {
+    btn.classList.toggle('active', pageState.visualFxOn);
+    btn.title = t('visualFx');
+    btn.setAttribute('aria-label', t('visualFx'));
+    btn.setAttribute('aria-pressed', pageState.visualFxOn ? 'true' : 'false');
+  }
+  document.documentElement.classList.toggle('visual-fx-off', !pageState.visualFxOn);
+}
+
+// 清除进行中的节奏涟漪动画
+function clearRhythmRipples() {
+  var els = document.getElementsByClassName('rhythm-ripple');
+  for (var i = 0; i < els.length; i++) {
+    els[i].classList.remove('run', 'big', 'accent', 'soft');
+  }
+}
+
+// 收敛 Aurora 包络与内联样式（关闭时冻结/熄灭）
+function dimAurora() {
+  aurora.env = [0, 0, 0];
+  aurora.lastOp = [NaN, NaN, NaN];
+  if (!aurora.el) {
+    aurora.el = $('artwork-aurora');
+    if (aurora.el) aurora.blobs = aurora.el.getElementsByClassName('aurora-blob');
+  }
+  if (aurora.blobs) {
+    for (var i = 0; i < aurora.blobs.length; i++) {
+      aurora.blobs[i].style.opacity = '0';
+    }
+  }
+}
+
+function setVisualFxOn(on) {
+  var next = !!on;
+  var prev = pageState.visualFxOn;
+  pageState.visualFxOn = next;
+  syncVisualFxUI();
+  if (prev === next) return;
+  if (!next) {
+    // 播放中途关闭：停背景漂移、清涟漪、熄 Aurora
+    stopBackgroundAnimation();
+    clearRhythmRipples();
+    dimAurora();
+  } else if (pageState.status && pageState.status.isPlaying && shouldAnimate()) {
+    // 播放中途打开：重启背景漂移（若系统允许动画）
+    startBackgroundAnimation();
+  }
 }
 
 function startLyricWave() {
@@ -3024,6 +3090,17 @@ function bindControls() {
       }
     });
   }
+
+  // 动态视觉效果开关（常显，与翻译按钮同组）
+  var visualFxBtn = document.getElementById('visual-fx-btn');
+  if (visualFxBtn) {
+    addClickHandler(visualFxBtn, function() {
+      setVisualFxOn(!pageState.visualFxOn);
+      if (Tapp.storage && Tapp.storage.set) {
+        Tapp.storage.set('visualFxOn', pageState.visualFxOn).catch(function() {});
+      }
+    });
+  }
   
   // 窗口大小变化时重置状态 - 使用节流（统一处理所有 resize 逻辑）
   var resizeTimeout = null;
@@ -3506,7 +3583,7 @@ var aurora = {
 };
 
 function renderAurora(ts) {
-  if (!shouldAnimate()) return;
+  if (!visualFxEnabled()) return;
   if (!aurora.el) {
     aurora.el = $('artwork-aurora');
     if (!aurora.el) return;
@@ -3591,6 +3668,7 @@ var rhythm = {
 //  'accent' 重音：大而亮的双波前（一眼区别于常规拍）
 //  'shift'  转折：中心全屏大波 + 内部微光（稀有仪式感）
 function fireRipple(strength, tier) {
+  if (!visualFxEnabled()) return;
   if (!rhythm.pool) {
     var els = document.getElementsByClassName('rhythm-ripple');
     if (!els || els.length === 0) return;
@@ -3651,7 +3729,7 @@ function fireRipple(strength, tier) {
 
 // 节奏检测（15fps 数据块调用）
 function rhythmTick(bands, ts) {
-  if (!bands || bands.length < 8 || !shouldAnimate()) return;
+  if (!bands || bands.length < 8 || !visualFxEnabled()) return;
   var i;
   var energy = 0;
   for (i = 0; i < 8; i++) energy += bands[i];
@@ -3814,7 +3892,7 @@ function gridTick() {
   if (i < b.length && b[i] <= pos + 0.017) {
     var isAcc = !!(beatGrid.accents && beatGrid.accents[i]);
     rhythm.beats.push(nowMs());
-    if (shouldAnimate()) {
+    if (visualFxEnabled()) {
       if (isAcc) {
         fireRipple(0.55 + rhythm.mood * 0.3 + Math.random() * 0.15, 'accent');
       } else {
@@ -3890,24 +3968,25 @@ function eqTickBody(ts) {
       }
     }
     // offsetParent 为 null 说明被 display:none 祖先隐藏，跳过对应消费方
+    // needEq 与动效开关无关（列表 EQ 始终可驱动）；Aurora/节奏频谱仅在 FX 开时需要
     var eq = getActiveEqEl();
     var needEq = !!(eq && eq.offsetParent !== null);
-    var needAurora = !!(aurora.el
-      ? aurora.el.offsetParent !== null
-      : $('artwork-aurora')) && shouldAnimate();
-    if (needEq || needAurora) {
+    var needFx = visualFxEnabled();
+    if (needEq || needFx) {
       Tapp.media.getSpectrum().then(function(r) {
         var s = (r && r.spectrum && r.spectrum.length >= 4) ? r.spectrum : [0, 0, 0, 0];
         if (needEq) updateListEq(s, eq);
-        // Aurora 数据样本：优先原始 8 频段；旧前端无 bands 时由 4 柱数据降级映射
-        if (r && r.bands && r.bands.length >= 8) {
-          aurora.bands = r.bands;
-        } else {
-          // 降级：s 为重排 4 柱（低-高-高-低），粗略映射三段
-          aurora.bands = [s[0], s[0], 0, s[2], s[2], s[1], s[3], 0];
+        if (needFx) {
+          // Aurora 数据样本：优先原始 8 频段；旧前端无 bands 时由 4 柱数据降级映射
+          if (r && r.bands && r.bands.length >= 8) {
+            aurora.bands = r.bands;
+          } else {
+            // 降级：s 为重排 4 柱（低-高-高-低），粗略映射三段
+            aurora.bands = [s[0], s[0], 0, s[2], s[2], s[1], s[3], 0];
+          }
+          // 节奏事件：重音/转折检测（触发即交给 CSS 合成器动画，无每帧渲染）
+          rhythmTick(aurora.bands, ts);
         }
-        // 节奏事件：重音/转折检测（触发即交给 CSS 合成器动画，无每帧渲染）
-        rhythmTick(aurora.bands, ts);
       }).catch(function(e) {
         logTickError('spectrumPoll', e);
       });
@@ -3915,7 +3994,7 @@ function eqTickBody(ts) {
   }
   // 网格跟拍逐帧比对（60fps 精度踩拍）
   gridTick();
-  // Aurora 渲染每帧运行（60fps 包络 + 公转），数据按 15fps 更新
+  // Aurora 渲染每帧运行（60fps 包络 + 公转），数据按 15fps 更新；内部再经 visualFxEnabled 门控
   renderAurora(ts);
 }
 
@@ -3927,8 +4006,8 @@ function ensureEqLoop() {
 
 // 启动背景动画（纯环境漂移：慢速 translate/rotate，不跟随节拍）
 function startBackgroundAnimation() {
-  // 检查动画级别
-  if (!shouldAnimate()) {
+  // 用户动效开关 ∧ 系统动画级别
+  if (!visualFxEnabled()) {
     return;
   }
   
@@ -4055,10 +4134,17 @@ function cleanup() {
         
         await initPage();
 
-        // 恢复翻译开关偏好（持久化；storage 权限已在 manifest 声明）
+        // 同步动效按钮文案/高亮（默认开；storage 再覆盖）
+        syncVisualFxUI();
+
+        // 恢复翻译 / 动效开关偏好（持久化；storage 权限已在 manifest 声明）
         if (Tapp.storage && Tapp.storage.get) {
           Tapp.storage.get('lyricTransOn').then(function(v) {
             if (v === true || v === 'true') setLyricTransOn(true);
+          }).catch(function() {});
+          Tapp.storage.get('visualFxOn').then(function(v) {
+            // 默认 true；仅显式 false 时关闭
+            if (v === false || v === 'false') setVisualFxOn(false);
           }).catch(function() {});
         }
 
@@ -4066,6 +4152,8 @@ function cleanup() {
         Tapp.ui.onLocaleChange(function(locale) {
           setLocale(normalizeLocale(locale));
           initPage();
+          syncVisualFxUI();
+          syncLyricTransUI();
         });
 
         // 监听主题变化（深色/浅色模式切换）

--- a/apps/com.myriad.music-player/main.js
+++ b/apps/com.myriad.music-player/main.js
@@ -270,9 +270,8 @@ var pageState = {
   autoScrollEnabled: true, // 自动滚动开关（点击歌词跳转时临时禁用）
   unsubscribe: null,
   unsubscribeProgress: null,
-  // 背景动画状态
+  // 背景动画状态（纯环境漂移，与节拍无关）
   bgAnimationFrame: null,
-  beatIntensity: 0,
   bgPhase: 0,
   // 统一动画调度器配置
   animConfig: {
@@ -3434,8 +3433,6 @@ function bindControls() {
 // 动态背景动画
 // ========================================
 
-// （原本地节拍检测已由节奏引擎 rhythm.groove/density 取代）
-
 // 检测是否为移动端（全局统一缓存）
 var isMobileDevice = null;
 var lastWindowWidth = 0;
@@ -3580,9 +3577,8 @@ var rhythm = {
   lastBeatT: 0,      // 常规节拍冷却
   beats: [],         // 4s 窗口内的节拍时间戳（估算节奏密度）
   density: 0,        // 节奏密度 0~1（≈2.5 拍/秒 → 1）
-  groove: 0,         // 节奏包络：每拍冲击、按密度决定衰减快慢 → 驱动背景震动
   mood: 0,           // 情绪值 0(缓和)~1(激烈)：绝对 MIR 特征回归的 arousal（唤醒度），
-                     // 决定视觉的「性格」——涟漪快慢、Aurora 节奏、光呼吸深浅
+                     // 决定视觉的「性格」——涟漪快慢、Aurora 节奏
   lowRate: 0,        // 低能量率（安静帧占比 EMA）：抒情歌动态呼吸大 → 高
   warm: 0,           // 预热计数：慢均线未稳定前不做转折判定（防开场误触发）
   dropAng: 0,        // 雨滴落点相位（黄金角步进，按拍序绕屏规律行进）
@@ -3680,26 +3676,22 @@ function rhythmTick(bands, ts) {
   var sigma = Math.sqrt(rhythm.fluxVar) || 0.001;
 
   // 三层节奏响应：
-  //  常规节拍（低门槛）：groove 冲击 + 小雨滴 —— 逐拍贴合，规律感的来源
+  //  常规节拍（低门槛）：密度采样 + 小雨滴 —— 逐拍贴合，规律感的来源
   //  重音（高门槛）：更大更亮的雨滴
   //  转折（下方）：中心大波
   var isBeat = flux > rhythm.fluxAvg + 1.1 * sigma && flux > 0.1;
   // live 重音门槛提高（2.8σ + 绝对下限 0.3）：明确的强调才算，
   // 稍微重一点的字不触发；有网格时重音完全交给离线标注
   var isAccent = flux > rhythm.fluxAvg + 2.8 * sigma && flux > 0.3;
-  // 节拍网格存在时，常规拍的 groove/雨滴由 gridTick 精确踩拍接管
+  // 节拍网格存在时，常规拍的密度/雨滴由 gridTick 精确踩拍接管
   var gridActive = beatGrid.beats !== null;
 
   if (isBeat && !gridActive) {
-    // groove 冲击（背景震动的能量源）
-    rhythm.groove = Math.min(1, rhythm.groove + 0.4 + Math.min(0.5, flux));
     rhythm.beats.push(ts);
   }
   // 节奏密度：4s 窗口内的拍数（≈2.5 拍/秒 → 1）
   while (rhythm.beats.length > 0 && ts - rhythm.beats[0] > 4000) rhythm.beats.shift();
   rhythm.density += (Math.min(1, rhythm.beats.length / 10) - rhythm.density) * 0.1;
-  // groove 衰减：节奏紧凑 → 快衰减（弹得脆）；缓和 → 慢衰减（绵软地涌）
-  rhythm.groove *= Math.exp(-(1.8 + rhythm.density * 4.2) * 0.066);
 
   // ---- 情绪值（arousal 回归，Tzanetakis & Cook 2002 / Yang et al. 2008）----
   // 关键：全部用绝对特征。自适应阈值派生的量（如 density）会把不同歌自动拉平，
@@ -3818,10 +3810,9 @@ function gridTick() {
   if (i >= b.length || (i > 0 && pos < b[i - 1] - 1)) i = 0;
   // 前进跳过已错过的拍（>80ms 视为错过，不补发）
   while (i < b.length && b[i] < pos - 0.08) i++;
-  // 到拍：groove 冲击 + 雨滴（离线标注的重音拍 → 重音波）
+  // 到拍：密度采样 + 雨滴（离线标注的重音拍 → 重音波）
   if (i < b.length && b[i] <= pos + 0.017) {
     var isAcc = !!(beatGrid.accents && beatGrid.accents[i]);
-    rhythm.groove = Math.min(1, rhythm.groove + (isAcc ? 0.7 : 0.45) + rhythm.mood * 0.2);
     rhythm.beats.push(nowMs());
     if (shouldAnimate()) {
       if (isAcc) {
@@ -3841,7 +3832,7 @@ function gridTick() {
 
 var eqLastUpdate = 0;
 var EQ_INTERVAL = 66; // ~15fps 数据轮询
-// 防崩溃壳：eqTick 驱动全部视觉效果（aurora/涟漪/光呼吸/网格踩拍/间奏点/自愈），
+// 防崩溃壳：eqTick 驱动全部视觉效果（aurora/涟漪/网格踩拍/间奏点/自愈），
 // 任何一帧异常若不捕获，循环静默死亡且句柄残留 → ensureEqLoop 永远无法重启 →
 // 所有效果永久失效。异常只丢当帧并记录，循环必须活着。
 function eqTick(ts) {
@@ -3926,37 +3917,22 @@ function eqTickBody(ts) {
   gridTick();
   // Aurora 渲染每帧运行（60fps 包络 + 公转），数据按 15fps 更新
   renderAurora(ts);
-  renderRhythmGlow();
 }
 
-// 光呼吸：透明度 = groove × 密度增益（量化去重，只在变化时写）
-var glowState = { el: null, last: -1 };
-function renderRhythmGlow() {
-  if (!shouldAnimate()) return;
-  if (!glowState.el) {
-    glowState.el = $('rhythm-glow');
-    if (!glowState.el) return;
-  }
-  var o = Math.round(rhythm.groove * (0.04 + rhythm.density * 0.06 + rhythm.mood * 0.07) * 1000);
-  if (o !== glowState.last) {
-    glowState.last = o;
-    glowState.el.style.opacity = (o / 1000).toFixed(3);
-  }
-}
 function ensureEqLoop() {
   if (pageState.status && pageState.status.isPlaying && !pageState.eqFrame) {
     pageState.eqFrame = requestAnimationFrame(eqTick);
   }
 }
 
-// 启动背景动画
+// 启动背景动画（纯环境漂移：慢速 translate/rotate，不跟随节拍）
 function startBackgroundAnimation() {
   // 检查动画级别
   if (!shouldAnimate()) {
     return;
   }
   
-  // 移动端禁用背景旋律动画（节省性能）
+  // 移动端禁用背景漂移（节省性能）
   if (checkIsMobile()) {
     return;
   }
@@ -3972,30 +3948,16 @@ function startBackgroundAnimation() {
     var isPlaying = pageState.status && pageState.status.isPlaying;
     
     if (!isPlaying) {
-      // 暂停时缓慢重置动画
-      pageState.beatIntensity *= 0.95;
-      if (pageState.beatIntensity < 0.01) {
-        pageState.beatIntensity = 0;
-        applyBackgroundTransform(0, pageState.bgPhase);
-        pageState.bgAnimationFrame = null;
-        return;
-      }
-      applyBackgroundTransform(pageState.beatIntensity, pageState.bgPhase);
-      pageState.bgAnimationFrame = requestAnimationFrame(updateBackground);
+      // 暂停时定格在当前环境相位
+      applyBackgroundTransform(pageState.bgPhase);
+      pageState.bgAnimationFrame = null;
       return;
     }
     
     if (timestamp - lastUpdateTime >= UPDATE_INTERVAL) {
       lastUpdateTime = timestamp;
       pageState.bgPhase += 0.008; // 缓慢相位变化
-
-      // 背景震动强度 = 节奏引擎的 groove 包络 × 密度增益：
-      // 缓和的歌 → 密度低 → 幅度小、衰减慢（轻轻地涌）；
-      // 紧凑的歌 → 密度高 → 幅度大、衰减快（跟着拍点弹）
-      // （groove/density 由 eq 循环的 15fps 频谱轮询驱动，这里不再重复
-      //  调 getSpectrum——此前每秒 ~20 次桥接往返取回的 energy 从未被使用）
-      pageState.beatIntensity = rhythm.groove * (0.45 + rhythm.density * 0.75);
-      applyBackgroundTransform(pageState.beatIntensity, pageState.bgPhase);
+      applyBackgroundTransform(pageState.bgPhase);
     }
     
     pageState.bgAnimationFrame = requestAnimationFrame(updateBackground);
@@ -4007,15 +3969,12 @@ function startBackgroundAnimation() {
 // 应用背景变换 - 使用缓存的元素引用
 var cachedBgArtworkRef = null;
 
-function applyBackgroundTransform(beatIntensity, phase) {
+function applyBackgroundTransform(phase) {
   if (!cachedBgArtworkRef) cachedBgArtworkRef = $('bg-artwork');
   if (!cachedBgArtworkRef) return;
   
-  // 节拍只做极轻的缩放呼吸（1.1 ~ 1.14），不注入位移/旋转抖动——
-  // 晃动读作故障，呼吸才读作音乐；节奏的主表达交给 rhythm-glow 光层
-  var scale = 1.1 + beatIntensity * 0.04;
-
-  // 缓慢位移与旋转（纯环境漂移，与节拍无关）
+  // 固定轻微放大 + 缓慢位移/旋转（纯环境漂移，与节拍无关）
+  var scale = 1.1;
   var sinPhase = Math.sin(phase);
   var cosPhase = Math.cos(phase * 0.7);
   var translateX = sinPhase * 15;
@@ -4024,7 +3983,7 @@ function applyBackgroundTransform(beatIntensity, phase) {
   
   // 应用变换 - 使用位运算快速取整避免toFixed开销
   cachedBgArtworkRef.style.transform = 
-    'scale(' + ((scale * 1000 | 0) / 1000) + ') ' +
+    'scale(' + scale + ') ' +
     'translate(' + (translateX | 0) + 'px,' + (translateY | 0) + 'px) ' +
     'rotate(' + ((rotate * 100 | 0) / 100) + 'deg)';
 }

--- a/apps/com.myriad.music-player/page.css
+++ b/apps/com.myriad.music-player/page.css
@@ -758,16 +758,25 @@ html, body {
   opacity: 1;
 }
 
-/* 翻译开关：歌词面板右下角浮钮（放在渐隐遮罩外层，不被 mask 吃掉） */
+/* 歌词面板右下角浮钮组：动效 + 翻译（放在渐隐遮罩外层，不被 mask 吃掉） */
 .panel-lyrics {
   position: relative;
 }
 
-.lyric-trans-btn {
+.lyrics-corner-btns {
   position: absolute;
   right: 28px;
   bottom: 24px;
   z-index: 5;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.lyric-corner-btn {
+  pointer-events: auto;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -788,28 +797,40 @@ html, body {
   touch-action: manipulation;
 }
 
-.lyric-trans-btn svg {
+.lyric-corner-btn svg {
   width: 18px;
   height: 18px;
   pointer-events: none;
 }
 
-.lyric-trans-btn:hover {
+.lyric-corner-btn:hover {
   background: color-mix(in srgb, var(--text-primary) 14%, transparent);
   color: var(--text-primary);
 }
 
-.lyric-trans-btn:active {
+.lyric-corner-btn:active {
   transform: scale(0.92);
 }
 
-.lyric-trans-btn.active {
+.lyric-corner-btn.active {
   background: linear-gradient(135deg, var(--music-primary), var(--music-secondary));
   color: #fff;
 }
 
-.lyric-trans-btn[hidden] {
+.lyric-corner-btn[hidden] {
   display: none;
+}
+
+/* 动效关闭：冻结/隐藏 Aurora 与涟漪；列表 EQ 与静态封面模糊不受影响 */
+:root.visual-fx-off .artwork-aurora {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.35s ease, visibility 0s linear 0.35s;
+}
+
+:root.visual-fx-off .rhythm-ripple {
+  opacity: 0 !important;
+  animation: none !important;
 }
 
 /* 多字符 token 的字母容器：作为整体参与换行，字母不被从中间拆断。
@@ -1962,12 +1983,16 @@ html, body {
     font-weight: 600;
   }
 
-  /* 移动端翻译开关：44px 触控热区 + 避开底部安全区 */
-  .lyric-trans-btn {
-    width: 44px;
-    height: 44px;
+  /* 移动端右下角浮钮组：44px 触控热区 + 避开底部安全区 */
+  .lyrics-corner-btns {
     right: 20px;
     bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+    gap: 12px;
+  }
+
+  .lyric-corner-btn {
+    width: 44px;
+    height: 44px;
   }
 
   .lyric-interlude {

--- a/apps/com.myriad.music-player/page.css
+++ b/apps/com.myriad.music-player/page.css
@@ -284,22 +284,6 @@ html, body {
   pointer-events: none;
 }
 
-/* 光呼吸：铺满背景的柔光，透明度随节奏 groove 起伏（替代背景震动的节奏表达）。
-   opacity 由 JS 每帧驱动 + 短过渡平滑，合成器友好 */
-.rhythm-glow {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-    ellipse at 50% 78%,
-    color-mix(in srgb, var(--music-primary) 40%, transparent),
-    transparent 65%
-  );
-  opacity: 0;
-  transition: opacity 0.12s linear;
-  will-change: opacity;
-  pointer-events: none;
-}
-
 /* 节奏涟漪：柔化的环形波带（radial-gradient 圆环），从封面中心荡开扫过背景。
    尺寸/圆心由 JS 在触发时按封面几何设置；扩散动画走合成器（scale+opacity） */
 .rhythm-ripple {

--- a/apps/com.myriad.music-player/page.html
+++ b/apps/com.myriad.music-player/page.html
@@ -74,10 +74,20 @@
         <div class="lyrics-scroll" id="lyrics-container">
           <div class="lyrics-empty" id="lyrics-empty">暂无歌词</div>
         </div>
-        <!-- 翻译开关（仅当前歌曲有用户语言的翻译时显示） -->
-        <button class="lyric-trans-btn" id="lyric-trans-btn" hidden aria-label="翻译" aria-pressed="false" title="翻译">
-          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v2h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"/></svg>
-        </button>
+        <!-- 右下角浮钮组：动效开关（常显）+ 翻译开关（有翻译时显示） -->
+        <div class="lyrics-corner-btns" id="lyrics-corner-btns">
+          <button class="lyric-corner-btn active" id="visual-fx-btn" aria-label="动效" aria-pressed="true" title="动效">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 2.2l1.05 3.15L16.2 6.4l-3.15 1.05L12 10.6l-1.05-3.15L7.8 6.4l3.15-1.05L12 2.2z"/>
+              <path d="M18.2 11.2l.72 2.16 2.16.72-2.16.72-.72 2.16-.72-2.16-2.16-.72 2.16-.72.72-2.16z"/>
+              <path d="M6.3 13.4l.62 1.86 1.86.62-1.86.62-.62 1.86-.62-1.86-1.86-.62 1.86-.62.62-1.86z"/>
+              <path d="M5 5.5l.45 1.35L6.8 7.3l-1.35.45L5 9.1l-.45-1.35L3.2 7.3l1.35-.45L5 5.5z" opacity="0.7"/>
+            </svg>
+          </button>
+          <button class="lyric-corner-btn lyric-trans-btn" id="lyric-trans-btn" hidden aria-label="翻译" aria-pressed="false" title="翻译">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v2h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"/></svg>
+          </button>
+        </div>
       </section>
       
       <!-- 播放列表面板 -->

--- a/apps/com.myriad.music-player/page.html
+++ b/apps/com.myriad.music-player/page.html
@@ -12,8 +12,6 @@
   <!-- 节奏涟漪层：节奏点从封面（音乐源头）荡出波环扫过背景
        重音=普通波，转折=更亮更慢的大波（CSS 合成器动画，JS 只在事件时刻切 class） -->
   <div class="rhythm-layer" aria-hidden="true">
-    <!-- 光呼吸：随 groove 明暗起伏（替代背景震动） -->
-    <div class="rhythm-glow" id="rhythm-glow"></div>
     <div class="rhythm-ripple"></div>
     <div class="rhythm-ripple"></div>
     <div class="rhythm-ripple"></div>


### PR DESCRIPTION
## Summary
Adds a user toggle for remaining dynamic visual effects in the music player, placed beside the lyric translate button.

**Gated when OFF**
- Aurora (`#artwork-aurora` / `renderAurora`)
- Rhythm ripples (`fireRipple` / beat-grid ripples)
- Background environmental drift (`startBackgroundAnimation` on `#bg-artwork`)

**Not gated**
- Playlist list-EQ spectrum (`updateListEq`) — always works when FX is off
- Lyrics / karaoke / UI micro-animations
- System `shouldAnimate()` remains the outer gate when the toggle is ON

**UI / state**
- Corner button group with shared styles; FX button always visible
- i18n: 动效 / Effects / 演出; sparkles icon; `aria-pressed` / active when ON
- `pageState.visualFxOn` default `true`, persisted as `visualFxOn` in `Tapp.storage`
- `visualFxEnabled() = visualFxOn && shouldAnimate()`
- Mid-play OFF: stop bg anim, clear ripple `.run`, dim aurora (`visual-fx-off` root class)
- Mid-play ON: restart bg anim if playing

## Base
Branched from `origin/ao/tapp-store-2/remove-music-glow-beat-scale` (PR #2).

## Test plan
- [ ] FX button visible beside translate (translate may be hidden); both fit in corner on desktop + mobile
- [ ] Default ON: aurora, ripples, bg drift behave as before (when system animation allows)
- [ ] Toggle OFF: aurora dimmed/hidden, no new ripples, bg drift stops; static cover blur/theme unchanged
- [ ] Toggle OFF: list-item EQ spectrum still animates while playing
- [ ] Toggle OFF: lyrics/karaoke still animate
- [ ] Toggle ON mid-play restarts bg drift (desktop)
- [ ] Preference persists across reload via storage
- [ ] Labels switch with locale (zh/en/ja)
- [ ] System animation level `none` still suppresses FX even when toggle ON