### PR TITLE
feat(music-player): full visual-FX performance pass

### DIFF
--- a/apps/com.myriad.music-player/main.js
+++ b/apps/com.myriad.music-player/main.js
@@ -21,6 +21,7 @@ var i18n = {
     lyrics: '歌词',
     noLyrics: '暂无歌词',
     translate: '翻译',
+    visualFx: '动效',
     searchPlaceholder: '搜索歌曲...',
     vip: 'VIP',
     trial: '试听',
@@ -51,6 +52,7 @@ var i18n = {
     lyrics: 'Lyrics',
     noLyrics: 'No Lyrics',
     translate: 'Translate',
+    visualFx: 'Effects',
     searchPlaceholder: 'Search songs...',
     vip: 'VIP',
     trial: 'Trial',
@@ -81,6 +83,7 @@ var i18n = {
     lyrics: '歌詞',
     noLyrics: '歌詞なし',
     translate: '翻訳',
+    visualFx: '演出',
     searchPlaceholder: '曲を検索...',
     vip: 'VIP',
     trial: '試聴',
@@ -243,9 +246,15 @@ async function initAnimationConfig() {
   }
 }
 
-// 检查是否应该执行动画
+// 检查是否应该执行动画（系统级外层门控）
 function shouldAnimate() {
   return pageState.animConfig.shouldAnimate && pageState.animConfig.level !== 'none';
+}
+
+// 动态视觉效果是否启用：用户开关 ∧ 系统 shouldAnimate
+// 列表 EQ（updateListEq）不经此门控；歌词/UI 微动画亦不受影响
+function visualFxEnabled() {
+  return pageState.visualFxOn && shouldAnimate();
 }
 
 // ========================================
@@ -264,6 +273,7 @@ var pageState = {
   hasTranslation: false,   // 当前歌曲是否有翻译数据
   transLang: '',           // 翻译语言（'zh' | ''）
   transOn: false,          // 翻译显示开关（持久化于 Tapp.storage）
+  visualFxOn: true,        // 动态视觉效果开关（持久化于 Tapp.storage，默认开）
   lyricWordFrame: null,    // 逐字高亮 rAF 句柄
   lastKaraokeLine: -1,     // 上一次做逐字填充的行索引
   eqFrame: null,           // 列表均衡器频谱 rAF 句柄
@@ -518,6 +528,62 @@ function setLyricTransOn(on) {
   // 焦点目标可能未变但其他行的 y 全变了：无条件启动波浪把行送到新位
   if (shouldAnimate()) startLyricWave();
   else snapLyricItems();
+}
+
+// ========================================
+// 动态视觉效果开关（Aurora / 涟漪 / 背景漂移）
+// 列表 EQ 与歌词/UI 微动画不经此开关
+// ========================================
+
+function syncVisualFxUI() {
+  var btn = $('visual-fx-btn');
+  if (btn) {
+    btn.classList.toggle('active', pageState.visualFxOn);
+    btn.title = t('visualFx');
+    btn.setAttribute('aria-label', t('visualFx'));
+    btn.setAttribute('aria-pressed', pageState.visualFxOn ? 'true' : 'false');
+  }
+  document.documentElement.classList.toggle('visual-fx-off', !pageState.visualFxOn);
+}
+
+// 清除进行中的节奏涟漪动画
+function clearRhythmRipples() {
+  var els = document.getElementsByClassName('rhythm-ripple');
+  for (var i = 0; i < els.length; i++) {
+    els[i].classList.remove('run', 'big', 'accent', 'soft');
+  }
+}
+
+// 收敛 Aurora 包络与内联样式（关闭时冻结/熄灭）
+function dimAurora() {
+  aurora.env = [0, 0, 0];
+  aurora.lastOp = [NaN, NaN, NaN];
+  if (!aurora.el) {
+    aurora.el = $('artwork-aurora');
+    if (aurora.el) aurora.blobs = aurora.el.getElementsByClassName('aurora-blob');
+  }
+  if (aurora.blobs) {
+    for (var i = 0; i < aurora.blobs.length; i++) {
+      aurora.blobs[i].style.opacity = '0';
+    }
+  }
+}
+
+function setVisualFxOn(on) {
+  var next = !!on;
+  var prev = pageState.visualFxOn;
+  pageState.visualFxOn = next;
+  syncVisualFxUI();
+  if (prev === next) return;
+  if (!next) {
+    // 播放中途关闭：停背景漂移、清涟漪、熄 Aurora
+    stopBackgroundAnimation();
+    clearRhythmRipples();
+    dimAurora();
+  } else if (pageState.status && pageState.status.isPlaying && shouldAnimate()) {
+    // 播放中途打开：重启背景漂移（若系统允许动画）
+    startBackgroundAnimation();
+  }
 }
 
 function startLyricWave() {
@@ -3024,6 +3090,17 @@ function bindControls() {
       }
     });
   }
+
+  // 动态视觉效果开关（常显，与翻译按钮同组）
+  var visualFxBtn = document.getElementById('visual-fx-btn');
+  if (visualFxBtn) {
+    addClickHandler(visualFxBtn, function() {
+      setVisualFxOn(!pageState.visualFxOn);
+      if (Tapp.storage && Tapp.storage.set) {
+        Tapp.storage.set('visualFxOn', pageState.visualFxOn).catch(function() {});
+      }
+    });
+  }
   
   // 窗口大小变化时重置状态 - 使用节流（统一处理所有 resize 逻辑）
   var resizeTimeout = null;
@@ -3506,7 +3583,7 @@ var aurora = {
 };
 
 function renderAurora(ts) {
-  if (!shouldAnimate()) return;
+  if (!visualFxEnabled()) return;
   if (!aurora.el) {
     aurora.el = $('artwork-aurora');
     if (!aurora.el) return;
@@ -3591,6 +3668,7 @@ var rhythm = {
 //  'accent' 重音：大而亮的双波前（一眼区别于常规拍）
 //  'shift'  转折：中心全屏大波 + 内部微光（稀有仪式感）
 function fireRipple(strength, tier) {
+  if (!visualFxEnabled()) return;
   if (!rhythm.pool) {
     var els = document.getElementsByClassName('rhythm-ripple');
     if (!els || els.length === 0) return;
@@ -3651,7 +3729,7 @@ function fireRipple(strength, tier) {
 
 // 节奏检测（15fps 数据块调用）
 function rhythmTick(bands, ts) {
-  if (!bands || bands.length < 8 || !shouldAnimate()) return;
+  if (!bands || bands.length < 8 || !visualFxEnabled()) return;
   var i;
   var energy = 0;
   for (i = 0; i < 8; i++) energy += bands[i];
@@ -3814,7 +3892,7 @@ function gridTick() {
   if (i < b.length && b[i] <= pos + 0.017) {
     var isAcc = !!(beatGrid.accents && beatGrid.accents[i]);
     rhythm.beats.push(nowMs());
-    if (shouldAnimate()) {
+    if (visualFxEnabled()) {
       if (isAcc) {
         fireRipple(0.55 + rhythm.mood * 0.3 + Math.random() * 0.15, 'accent');
       } else {
@@ -3890,24 +3968,25 @@ function eqTickBody(ts) {
       }
     }
     // offsetParent 为 null 说明被 display:none 祖先隐藏，跳过对应消费方
+    // needEq 与动效开关无关（列表 EQ 始终可驱动）；Aurora/节奏频谱仅在 FX 开时需要
     var eq = getActiveEqEl();
     var needEq = !!(eq && eq.offsetParent !== null);
-    var needAurora = !!(aurora.el
-      ? aurora.el.offsetParent !== null
-      : $('artwork-aurora')) && shouldAnimate();
-    if (needEq || needAurora) {
+    var needFx = visualFxEnabled();
+    if (needEq || needFx) {
       Tapp.media.getSpectrum().then(function(r) {
         var s = (r && r.spectrum && r.spectrum.length >= 4) ? r.spectrum : [0, 0, 0, 0];
         if (needEq) updateListEq(s, eq);
-        // Aurora 数据样本：优先原始 8 频段；旧前端无 bands 时由 4 柱数据降级映射
-        if (r && r.bands && r.bands.length >= 8) {
-          aurora.bands = r.bands;
-        } else {
-          // 降级：s 为重排 4 柱（低-高-高-低），粗略映射三段
-          aurora.bands = [s[0], s[0], 0, s[2], s[2], s[1], s[3], 0];
+        if (needFx) {
+          // Aurora 数据样本：优先原始 8 频段；旧前端无 bands 时由 4 柱数据降级映射
+          if (r && r.bands && r.bands.length >= 8) {
+            aurora.bands = r.bands;
+          } else {
+            // 降级：s 为重排 4 柱（低-高-高-低），粗略映射三段
+            aurora.bands = [s[0], s[0], 0, s[2], s[2], s[1], s[3], 0];
+          }
+          // 节奏事件：重音/转折检测（触发即交给 CSS 合成器动画，无每帧渲染）
+          rhythmTick(aurora.bands, ts);
         }
-        // 节奏事件：重音/转折检测（触发即交给 CSS 合成器动画，无每帧渲染）
-        rhythmTick(aurora.bands, ts);
       }).catch(function(e) {
         logTickError('spectrumPoll', e);
       });
@@ -3915,7 +3994,7 @@ function eqTickBody(ts) {
   }
   // 网格跟拍逐帧比对（60fps 精度踩拍）
   gridTick();
-  // Aurora 渲染每帧运行（60fps 包络 + 公转），数据按 15fps 更新
+  // Aurora 渲染每帧运行（60fps 包络 + 公转），数据按 15fps 更新；内部再经 visualFxEnabled 门控
   renderAurora(ts);
 }
 
@@ -3927,8 +4006,8 @@ function ensureEqLoop() {
 
 // 启动背景动画（纯环境漂移：慢速 translate/rotate，不跟随节拍）
 function startBackgroundAnimation() {
-  // 检查动画级别
-  if (!shouldAnimate()) {
+  // 用户动效开关 ∧ 系统动画级别
+  if (!visualFxEnabled()) {
     return;
   }
   
@@ -4055,10 +4134,17 @@ function cleanup() {
         
         await initPage();
 
-        // 恢复翻译开关偏好（持久化；storage 权限已在 manifest 声明）
+        // 同步动效按钮文案/高亮（默认开；storage 再覆盖）
+        syncVisualFxUI();
+
+        // 恢复翻译 / 动效开关偏好（持久化；storage 权限已在 manifest 声明）
         if (Tapp.storage && Tapp.storage.get) {
           Tapp.storage.get('lyricTransOn').then(function(v) {
             if (v === true || v === 'true') setLyricTransOn(true);
+          }).catch(function() {});
+          Tapp.storage.get('visualFxOn').then(function(v) {
+            // 默认 true；仅显式 false 时关闭
+            if (v === false || v === 'false') setVisualFxOn(false);
           }).catch(function() {});
         }
 
@@ -4066,6 +4152,8 @@ function cleanup() {
         Tapp.ui.onLocaleChange(function(locale) {
           setLocale(normalizeLocale(locale));
           initPage();
+          syncVisualFxUI();
+          syncLyricTransUI();
         });
 
         // 监听主题变化（深色/浅色模式切换）

--- a/apps/com.myriad.music-player/main.js
+++ b/apps/com.myriad.music-player/main.js
@@ -233,12 +233,18 @@ async function initAnimationConfig() {
       pageState.animConfig.level = level;
       pageState.animConfig.shouldAnimate = level !== 'none';
       
-      // 根据新级别调整动画
-      if (level === 'none') {
+      // 根据新级别调整动画（light：无背景漂移；none：全停）
+      if (level === 'none' || level === 'light') {
         stopBackgroundAnimation();
       } else if (pageState.status && pageState.status.isPlaying) {
         startBackgroundAnimation();
       }
+      if (level === 'none' || level === 'light') {
+        clearRhythmRipples();
+      }
+      syncFxCompositing();
+      // 帧率策略随 level 变化，立即重调度
+      if (pageState.status && pageState.status.isPlaying) restartEqLoop();
     });
   } catch (e) {
     // 使用默认配置
@@ -255,6 +261,19 @@ function shouldAnimate() {
 // 列表 EQ（updateListEq）不经此门控；歌词/UI 微动画亦不受影响
 function visualFxEnabled() {
   return pageState.visualFxOn && shouldAnimate();
+}
+
+// 系统动画级别为 light：降级重视觉（涟漪/背景漂移关闭，Aurora 简化）
+// 列表 EQ 与 visualFx 开关语义不变
+function isAnimLight() {
+  return pageState.animConfig.level === 'light';
+}
+
+// 播放中 + FX 开时挂 will-change 合成层；暂停/关 FX 时卸下以释放层
+function syncFxCompositing() {
+  var on = !!(pageState.visualFxOn && shouldAnimate() &&
+    pageState.status && pageState.status.isPlaying);
+  document.documentElement.classList.toggle('fx-compositing', on);
 }
 
 // ========================================
@@ -276,12 +295,13 @@ var pageState = {
   visualFxOn: true,        // 动态视觉效果开关（持久化于 Tapp.storage，默认开）
   lyricWordFrame: null,    // 逐字高亮 rAF 句柄
   lastKaraokeLine: -1,     // 上一次做逐字填充的行索引
-  eqFrame: null,           // 列表均衡器频谱 rAF 句柄
+  eqFrame: null,           // 视觉/EQ 循环 rAF 句柄
+  eqTimer: null,           // 低帧率维护/轮询 setTimeout 句柄（与 eqFrame 互斥）
   autoScrollEnabled: true, // 自动滚动开关（点击歌词跳转时临时禁用）
   unsubscribe: null,
   unsubscribeProgress: null,
-  // 背景动画状态（纯环境漂移，与节拍无关）
-  bgAnimationFrame: null,
+  // 背景漂移状态（由 eqTick 低帧率驱动，无独立 rAF）
+  bgDriftOn: false,        // 是否应在 eqTick 中推进背景相位
   bgPhase: 0,
   // 统一动画调度器配置
   animConfig: {
@@ -581,9 +601,13 @@ function setVisualFxOn(on) {
     clearRhythmRipples();
     dimAurora();
   } else if (pageState.status && pageState.status.isPlaying && shouldAnimate()) {
-    // 播放中途打开：重启背景漂移（若系统允许动画）
+    // 播放中途打开：重同步拍点索引（关 FX 时未逐帧 gridTick）+ 重启背景漂移
+    resyncBeatGridIdx();
     startBackgroundAnimation();
   }
+  syncFxCompositing();
+  // 调度模式随 FX 切换（60fps ↔ 低帧率维护），立即取消旧句柄并重入
+  if (pageState.status && pageState.status.isPlaying) restartEqLoop();
 }
 
 function startLyricWave() {
@@ -2610,11 +2634,14 @@ function updatePlayerUI(status) {
     }
   }
   
-  // 根据播放状态控制背景动画
+  // 根据播放状态控制背景漂移意图（实际推进在 eqTick）
   if (status.isPlaying) {
     startBackgroundAnimation();
+  } else {
+    // 暂停：冻结当前相位（不复位 transform）；卸 will-change
+    pageState.bgDriftOn = false;
   }
-  // 注意：暂停时动画会自动缓慢停止，不需要立即停止
+  syncFxCompositing();
 }
 
 // 歌词提前量（秒）- 补偿各种延迟
@@ -2913,13 +2940,16 @@ async function initPage() {
   // 页面可见性优化 - 不可见时暂停非关键动画（只绑一次）
   if (firstBind) document.addEventListener('visibilitychange', function() {
     if (document.hidden) {
-      // 页面不可见，暂停背景动画
+      // 页面不可见：停背景漂移意图 + 卸合成层提示
       stopBackgroundAnimation();
+      document.documentElement.classList.remove('fx-compositing');
     } else {
       // 页面恢复可见
       if (pageState.status && pageState.status.isPlaying && shouldAnimate()) {
         startBackgroundAnimation();
+        ensureEqLoop();
       }
+      syncFxCompositing();
     }
   }, { passive: true });
 }
@@ -3547,6 +3577,10 @@ function getActiveEqEl() {
   return c.eq;
 }
 
+// 列表 EQ 高度写回去重：量化到整数 % 后仅在变化时写 style
+var listEqLastEl = null;
+var listEqLastQ = [-1, -1, -1];
+
 // 用真实频谱驱动「列表当前播放项」的均衡器（3 根柱：低/中高/高，居中强调）
 // 加 .live 类禁用 CSS keyframe，改由 JS 设高度
 function updateListEq(spectrum, eq) {
@@ -3554,13 +3588,20 @@ function updateListEq(spectrum, eq) {
   var bars = eq.getElementsByTagName('span');
   if (bars.length < 3) return false;
   if (!eq.classList.contains('live')) eq.classList.add('live');
+  if (eq !== listEqLastEl) {
+    listEqLastEl = eq;
+    listEqLastQ[0] = listEqLastQ[1] = listEqLastQ[2] = -1;
+  }
   var v0 = spectrum[0] || 0;
   var v1 = Math.max(spectrum[1] || 0, spectrum[2] || 0);
   var v2 = spectrum[3] || 0;
-  // 平方增强对比 + 25%~100% 区间
-  bars[0].style.height = (25 + v0 * v0 * 75) + '%';
-  bars[1].style.height = (25 + v1 * v1 * 75) + '%';
-  bars[2].style.height = (25 + v2 * v2 * 75) + '%';
+  // 平方增强对比 + 25%~100% 区间，量化到整数 % 去重
+  var h0 = (25 + v0 * v0 * 75 + 0.5) | 0;
+  var h1 = (25 + v1 * v1 * 75 + 0.5) | 0;
+  var h2 = (25 + v2 * v2 * 75 + 0.5) | 0;
+  if (h0 !== listEqLastQ[0]) { listEqLastQ[0] = h0; bars[0].style.height = h0 + '%'; }
+  if (h1 !== listEqLastQ[1]) { listEqLastQ[1] = h1; bars[1].style.height = h1 + '%'; }
+  if (h2 !== listEqLastQ[2]) { listEqLastQ[2] = h2; bars[2].style.height = h2 + '%'; }
   return true;
 }
 
@@ -3583,18 +3624,23 @@ var aurora = {
 };
 
 function renderAurora(ts) {
+  // 调用方应已在 eqTickBody 用 visualFxEnabled 门控；此处双保险 + 隐藏检测
   if (!visualFxEnabled()) return;
   if (!aurora.el) {
     aurora.el = $('artwork-aurora');
     if (!aurora.el) return;
     aurora.blobs = aurora.el.getElementsByClassName('aurora-blob');
   }
+  // display:none / 无布局 → offsetParent null；visibility:hidden（visual-fx-off）也跳过
   if (aurora.el.offsetParent === null || !aurora.blobs || aurora.blobs.length < 3) return;
+  if (document.documentElement.classList.contains('visual-fx-off')) return;
 
   var dt = Math.min(0.1, (ts - (aurora.lastT || ts)) / 1000);
   aurora.lastT = ts;
-  // 公转速度随情绪：缓和 → 悠悠地转；激烈 → 明显加快
-  aurora.phase += dt * (0.16 + rhythm.mood * 0.5);
+  var light = isAnimLight();
+  // light：更慢公转，降低每帧感知成本
+  var orbit = light ? 0.08 : (0.16 + rhythm.mood * 0.5);
+  aurora.phase += dt * orbit;
 
   // 频段目标：低(0-1) / 中(3-4) / 高(5-7)
   var b = aurora.bands;
@@ -3608,25 +3654,35 @@ function renderAurora(ts) {
 
   // 攻击/释放包络（经典 VU 手感：起得快、落得慢）
   // 释放随情绪：缓和 → 长余韵（光慢慢消散）；激烈 → 收得利落
-  var aAtk = 1 - Math.exp(-dt / 0.055);
-  var aRel = 1 - Math.exp(-dt / (0.5 - rhythm.mood * 0.28));
+  var aAtk = 1 - Math.exp(-dt / (light ? 0.09 : 0.055));
+  var aRel = 1 - Math.exp(-dt / (light ? 0.55 : (0.5 - rhythm.mood * 0.28)));
   for (var i = 0; i < 3; i++) {
     var e = aurora.env[i];
     var tgt = targets[i];
     aurora.env[i] = e + (tgt - e) * (tgt > e ? aAtk : aRel);
   }
 
+  // light：振幅缩小，写 transform 时量化更粗以减少合成层更新
+  var amp = light ? 0.55 : 1;
+  var scBase = light ? 0.95 : 0.9;
+  var scGain = light ? 0.18 : 0.35;
   for (i = 0; i < 3; i++) {
     var el = aurora.blobs[i];
     var e2 = aurora.env[i];
     // 各光斑不同角速度/相位，避免同步感
     var ph = aurora.phase * (1 + i * 0.37) + i * 2.1;
-    var ox = Math.cos(ph) * (4 + i * 2);
-    var oy = Math.sin(ph * 0.8) * (3 + i * 2);
-    var sc = 0.9 + e2 * 0.35;
-    el.style.transform = 'translate(' + ox.toFixed(1) + '%,' + oy.toFixed(1) + '%) scale(' + sc.toFixed(3) + ')';
+    var ox = Math.cos(ph) * (4 + i * 2) * amp;
+    var oy = Math.sin(ph * 0.8) * (3 + i * 2) * amp;
+    var sc = scBase + e2 * scGain;
+    if (light) {
+      // 粗量化 transform 字符串，减少无感变化时的 style 写入
+      el.style.transform = 'translate(' + (ox | 0) + '%,' + (oy | 0) + '%) scale(' +
+        ((sc * 100 + 0.5) | 0) / 100 + ')';
+    } else {
+      el.style.transform = 'translate(' + ox.toFixed(1) + '%,' + oy.toFixed(1) + '%) scale(' + sc.toFixed(3) + ')';
+    }
     // opacity 量化去重（公转 transform 每帧必写，opacity 只在包络变化时写）
-    var op = Math.round((0.1 + e2 * 0.5) * 1000);
+    var op = Math.round((0.1 + e2 * (light ? 0.35 : 0.5)) * 1000);
     if (op !== aurora.lastOp[i]) {
       aurora.lastOp[i] = op;
       el.style.opacity = (op / 1000).toFixed(3);
@@ -3669,6 +3725,8 @@ var rhythm = {
 //  'shift'  转折：中心全屏大波 + 内部微光（稀有仪式感）
 function fireRipple(strength, tier) {
   if (!visualFxEnabled()) return;
+  // light 级别：跳过涟漪（高成本 class/回流），保留列表 EQ 与轻量 Aurora
+  if (isAnimLight()) return;
   if (!rhythm.pool) {
     var els = document.getElementsByClassName('rhythm-ripple');
     if (!els || els.length === 0) return;
@@ -3878,7 +3936,7 @@ function loadBeatGridForTrack(track) {
   });
 }
 
-// 每帧网格跟拍（由 eqTick 驱动）
+// 每帧网格跟拍（仅 FX 开时由 eqTick 调用；关 FX 时用 resyncBeatGridIdx 在重开时对齐）
 function gridTick() {
   var b = beatGrid.beats;
   if (!b) return;
@@ -3892,39 +3950,118 @@ function gridTick() {
   if (i < b.length && b[i] <= pos + 0.017) {
     var isAcc = !!(beatGrid.accents && beatGrid.accents[i]);
     rhythm.beats.push(nowMs());
-    if (visualFxEnabled()) {
-      if (isAcc) {
-        fireRipple(0.55 + rhythm.mood * 0.3 + Math.random() * 0.15, 'accent');
-      } else {
-        // 强度取当拍的真实低频能量：鼓点有轻有重，雨滴自然有大有小
-        var hit = aurora.bands
-          ? Math.min(1, (aurora.bands[0] + aurora.bands[1]) * 0.7)
-          : 0.4;
-        fireRipple(0.1 + hit * 0.6 + Math.random() * 0.12, 'beat');
-      }
+    // 调用方已保证 visualFxEnabled；light 时 fireRipple 内部短路
+    if (isAcc) {
+      fireRipple(0.55 + rhythm.mood * 0.3 + Math.random() * 0.15, 'accent');
+    } else {
+      // 强度取当拍的真实低频能量：鼓点有轻有重，雨滴自然有大有小
+      var hit = aurora.bands
+        ? Math.min(1, (aurora.bands[0] + aurora.bands[1]) * 0.7)
+        : 0.4;
+      fireRipple(0.1 + hit * 0.6 + Math.random() * 0.12, 'beat');
     }
     i++;
   }
   beatGrid.idx = i;
 }
 
+// FX 重开 / seek 后对齐拍点索引，避免关 FX 期间未扫描导致连发补拍
+function resyncBeatGridIdx() {
+  var b = beatGrid.beats;
+  if (!b || b.length === 0) return;
+  var pos = getLyricPosition();
+  var i = 0;
+  while (i < b.length && b[i] < pos - 0.08) i++;
+  beatGrid.idx = i;
+}
+
+// ---- eqTick 调度与频谱轮询 ----
+// 帧率策略（播放中）：
+//  - FX standard：rAF ~60fps（Aurora 包络 + grid 踩拍 + 背景漂移低频分支）
+//  - FX light：~20fps（轻量 Aurora，无涟漪/无 bg drift）
+//  - 仅列表 EQ：~15fps（频谱 + 间奏/自愈）
+//  - 零消费方：~8fps 维护（间奏点 + lyric heal），绝不空转 60fps
 var eqLastUpdate = 0;
-var EQ_INTERVAL = 66; // ~15fps 数据轮询
+var eqBgLastUpdate = 0;
+var EQ_INTERVAL = 66;       // ~15fps 频谱/间奏数据块
+var EQ_MAINT_MS = 125;      // ~8fps 零消费方维护
+var EQ_LIGHT_MS = 50;       // ~20fps light 级 Aurora
+var EQ_BG_MS = 50;          // 背景漂移 ~20fps（仅 standard + 非移动端）
+// getSpectrum 单飞：上一次 bridge Promise 未 settle 时跳过本拍，不排队
+var spectrumInFlight = false;
+// 循环在飞（含 body 执行中 / timer 等待），防止 progress 回调 ensureEqLoop 双开
+var eqLoopActive = false;
+
 // 防崩溃壳：eqTick 驱动全部视觉效果（aurora/涟漪/网格踩拍/间奏点/自愈），
 // 任何一帧异常若不捕获，循环静默死亡且句柄残留 → ensureEqLoop 永远无法重启 →
 // 所有效果永久失效。异常只丢当帧并记录，循环必须活着。
 function eqTick(ts) {
+  // 本帧 rAF 已消费；eqLoopActive 保持 true 直至停播或 cancel，挡住 ensureEqLoop 竞态
+  pageState.eqFrame = null;
   var isPlaying = pageState.status && pageState.status.isPlaying;
-  if (!isPlaying) { pageState.eqFrame = null; return; }
+  if (!isPlaying) {
+    cancelEqSchedule();
+    syncFxCompositing();
+    return;
+  }
   try {
     eqTickBody(ts);
   } catch (e) {
     logTickError('eqTick', e);
   }
-  pageState.eqFrame = requestAnimationFrame(eqTick);
+  scheduleEqNext();
+}
+
+// 取消 rAF / setTimeout 双通道调度
+function cancelEqSchedule() {
+  if (pageState.eqFrame != null) {
+    cancelAnimationFrame(pageState.eqFrame);
+    pageState.eqFrame = null;
+  }
+  if (pageState.eqTimer != null) {
+    clearTimeout(pageState.eqTimer);
+    pageState.eqTimer = null;
+  }
+  eqLoopActive = false;
+}
+
+// 按当前消费方选择下一帧调度方式
+function scheduleEqNext() {
+  if (!(pageState.status && pageState.status.isPlaying)) {
+    eqLoopActive = false;
+    return;
+  }
+  // 已有挂起的帧/定时器则不重复排（restartEqLoop 会先 cancel）
+  if (pageState.eqFrame != null || pageState.eqTimer != null) return;
+
+  eqLoopActive = true;
+  var needFx = visualFxEnabled();
+  if (needFx && !isAnimLight()) {
+    // standard FX：真 60fps rAF
+    pageState.eqFrame = requestAnimationFrame(eqTick);
+    return;
+  }
+  // light FX / 仅 EQ / 零消费：timer 节流，避免空 60fps
+  var delay;
+  if (needFx && isAnimLight()) {
+    delay = EQ_LIGHT_MS;
+  } else {
+    var eq = getActiveEqEl();
+    var needEq = !!(eq && eq.offsetParent !== null);
+    delay = needEq ? EQ_INTERVAL : EQ_MAINT_MS;
+  }
+  pageState.eqTimer = setTimeout(function() {
+    pageState.eqTimer = null;
+    pageState.eqFrame = requestAnimationFrame(eqTick);
+  }, delay);
 }
 
 function eqTickBody(ts) {
+  // 尽早解析 FX 门控，避免关 FX 时仍跑 grid/aurora/涟漪路径
+  var needFx = visualFxEnabled();
+  var light = needFx && isAnimLight();
+
+  // 数据块：频谱 / 间奏 / 自愈（~15fps；维护模式由外层 timer 控制调用频率）
   if (ts - eqLastUpdate >= EQ_INTERVAL) {
     eqLastUpdate = ts;
     // 间奏呼吸点：进度点亮 + 焦点跟随（15fps 足够）
@@ -3971,12 +4108,19 @@ function eqTickBody(ts) {
     // needEq 与动效开关无关（列表 EQ 始终可驱动）；Aurora/节奏频谱仅在 FX 开时需要
     var eq = getActiveEqEl();
     var needEq = !!(eq && eq.offsetParent !== null);
-    var needFx = visualFxEnabled();
-    if (needEq || needFx) {
+    // 单飞：上一次 getSpectrum 未 settle 则跳过本拍（不排队堆积）
+    if ((needEq || needFx) && !spectrumInFlight) {
+      spectrumInFlight = true;
+      var pollNeedEq = needEq;
+      var pollNeedFx = needFx;
+      var pollEq = eq;
+      var pollTs = ts;
       Tapp.media.getSpectrum().then(function(r) {
+        spectrumInFlight = false;
         var s = (r && r.spectrum && r.spectrum.length >= 4) ? r.spectrum : [0, 0, 0, 0];
-        if (needEq) updateListEq(s, eq);
-        if (needFx) {
+        if (pollNeedEq) updateListEq(s, pollEq);
+        // FX 可能在 Promise 飞行期间被关掉
+        if (pollNeedFx && visualFxEnabled()) {
           // Aurora 数据样本：优先原始 8 频段；旧前端无 bands 时由 4 柱数据降级映射
           if (r && r.bands && r.bands.length >= 8) {
             aurora.bands = r.bands;
@@ -3984,65 +4128,60 @@ function eqTickBody(ts) {
             // 降级：s 为重排 4 柱（低-高-高-低），粗略映射三段
             aurora.bands = [s[0], s[0], 0, s[2], s[2], s[1], s[3], 0];
           }
-          // 节奏事件：重音/转折检测（触发即交给 CSS 合成器动画，无每帧渲染）
-          rhythmTick(aurora.bands, ts);
+          // light：无涟漪/grid，mood 不驱动 Aurora → 跳过节奏引擎
+          if (!isAnimLight()) {
+            rhythmTick(aurora.bands, pollTs);
+          }
         }
       }).catch(function(e) {
+        spectrumInFlight = false;
         logTickError('spectrumPoll', e);
       });
     }
   }
-  // 网格跟拍逐帧比对（60fps 精度踩拍）
-  gridTick();
-  // Aurora 渲染每帧运行（60fps 包络 + 公转），数据按 15fps 更新；内部再经 visualFxEnabled 门控
+
+  // ---- 仅 FX 开：网格踩拍 / Aurora / 背景漂移 ----
+  if (!needFx) return;
+
+  // light：无涟漪网格触发（fireRipple 也会短路）；跳过 grid 扫描以省 pos 计算
+  if (!light) {
+    gridTick();
+  }
+
+  // Aurora：standard 每帧；light 随 ~20fps 调度
   renderAurora(ts);
+
+  // 背景漂移：并入 eqTick 低频分支（无独立 rAF）；mobile / light / 开关关闭时不跑
+  if (pageState.bgDriftOn && !light && !checkIsMobile()) {
+    if (ts - eqBgLastUpdate >= EQ_BG_MS) {
+      eqBgLastUpdate = ts;
+      pageState.bgPhase += 0.008;
+      applyBackgroundTransform(pageState.bgPhase);
+    }
+  }
 }
 
 function ensureEqLoop() {
-  if (pageState.status && pageState.status.isPlaying && !pageState.eqFrame) {
-    pageState.eqFrame = requestAnimationFrame(eqTick);
-  }
+  if (!(pageState.status && pageState.status.isPlaying)) return;
+  if (eqLoopActive || pageState.eqFrame != null || pageState.eqTimer != null) return;
+  eqLoopActive = true;
+  pageState.eqFrame = requestAnimationFrame(eqTick);
 }
 
-// 启动背景动画（纯环境漂移：慢速 translate/rotate，不跟随节拍）
+// 强制取消并重入（FX 开关 / anim level 变化时切换帧率策略）
+function restartEqLoop() {
+  cancelEqSchedule();
+  ensureEqLoop();
+}
+
+// 启动背景漂移意图（实际相位推进在 eqTick 低频分支）
 function startBackgroundAnimation() {
-  // 用户动效开关 ∧ 系统动画级别
-  if (!visualFxEnabled()) {
+  // 用户动效开关 ∧ 系统动画 ∧ 非 light ∧ 非移动端
+  if (!visualFxEnabled() || isAnimLight() || checkIsMobile()) {
+    pageState.bgDriftOn = false;
     return;
   }
-  
-  // 移动端禁用背景漂移（节省性能）
-  if (checkIsMobile()) {
-    return;
-  }
-  
-  if (pageState.bgAnimationFrame) return;
-  
-  var lastUpdateTime = 0;
-  // 根据动画级别调整帧率
-  var UPDATE_INTERVAL = pageState.animConfig.level === 'light' ? 100 : 50; // light模式~10fps，standard~20fps
-  
-  function updateBackground(timestamp) {
-    // 检查是否正在播放
-    var isPlaying = pageState.status && pageState.status.isPlaying;
-    
-    if (!isPlaying) {
-      // 暂停时定格在当前环境相位
-      applyBackgroundTransform(pageState.bgPhase);
-      pageState.bgAnimationFrame = null;
-      return;
-    }
-    
-    if (timestamp - lastUpdateTime >= UPDATE_INTERVAL) {
-      lastUpdateTime = timestamp;
-      pageState.bgPhase += 0.008; // 缓慢相位变化
-      applyBackgroundTransform(pageState.bgPhase);
-    }
-    
-    pageState.bgAnimationFrame = requestAnimationFrame(updateBackground);
-  }
-  
-  pageState.bgAnimationFrame = requestAnimationFrame(updateBackground);
+  pageState.bgDriftOn = true;
 }
 
 // 应用背景变换 - 使用缓存的元素引用
@@ -4067,12 +4206,9 @@ function applyBackgroundTransform(phase) {
     'rotate(' + ((rotate * 100 | 0) / 100) + 'deg)';
 }
 
-// 停止背景动画
+// 停止背景漂移意图并复位变换
 function stopBackgroundAnimation() {
-  if (pageState.bgAnimationFrame) {
-    cancelAnimationFrame(pageState.bgAnimationFrame);
-    pageState.bgAnimationFrame = null;
-  }
+  pageState.bgDriftOn = false;
   // 重置背景变换
   var bgArtwork = $('bg-artwork');
   if (bgArtwork) {
@@ -4095,19 +4231,18 @@ function cleanup() {
     cancelAnimationFrame(pageState.lyricWordFrame);
     pageState.lyricWordFrame = null;
   }
-  // 清理列表均衡器 rAF
-  if (pageState.eqFrame) {
-    cancelAnimationFrame(pageState.eqFrame);
-    pageState.eqFrame = null;
-  }
+  // 清理视觉/EQ 循环（rAF + 低帧率 timer）
+  cancelEqSchedule();
+  spectrumInFlight = false;
   // 清理歌词波浪引擎
   stopLyricWave();
   if (lyricResumeTimer) {
     clearTimeout(lyricResumeTimer);
     lyricResumeTimer = null;
   }
-  // 清理背景动画
+  // 清理背景漂移意图
   stopBackgroundAnimation();
+  document.documentElement.classList.remove('fx-compositing');
 }
 
 // ========================================

--- a/apps/com.myriad.music-player/main.js
+++ b/apps/com.myriad.music-player/main.js
@@ -270,9 +270,8 @@ var pageState = {
   autoScrollEnabled: true, // 自动滚动开关（点击歌词跳转时临时禁用）
   unsubscribe: null,
   unsubscribeProgress: null,
-  // 背景动画状态
+  // 背景动画状态（纯环境漂移，与节拍无关）
   bgAnimationFrame: null,
-  beatIntensity: 0,
   bgPhase: 0,
   // 统一动画调度器配置
   animConfig: {
@@ -3434,8 +3433,6 @@ function bindControls() {
 // 动态背景动画
 // ========================================
 
-// （原本地节拍检测已由节奏引擎 rhythm.groove/density 取代）
-
 // 检测是否为移动端（全局统一缓存）
 var isMobileDevice = null;
 var lastWindowWidth = 0;
@@ -3580,9 +3577,8 @@ var rhythm = {
   lastBeatT: 0,      // 常规节拍冷却
   beats: [],         // 4s 窗口内的节拍时间戳（估算节奏密度）
   density: 0,        // 节奏密度 0~1（≈2.5 拍/秒 → 1）
-  groove: 0,         // 节奏包络：每拍冲击、按密度决定衰减快慢 → 驱动背景震动
   mood: 0,           // 情绪值 0(缓和)~1(激烈)：绝对 MIR 特征回归的 arousal（唤醒度），
-                     // 决定视觉的「性格」——涟漪快慢、Aurora 节奏、光呼吸深浅
+                     // 决定视觉的「性格」——涟漪快慢、Aurora 节奏
   lowRate: 0,        // 低能量率（安静帧占比 EMA）：抒情歌动态呼吸大 → 高
   warm: 0,           // 预热计数：慢均线未稳定前不做转折判定（防开场误触发）
   dropAng: 0,        // 雨滴落点相位（黄金角步进，按拍序绕屏规律行进）
@@ -3680,26 +3676,22 @@ function rhythmTick(bands, ts) {
   var sigma = Math.sqrt(rhythm.fluxVar) || 0.001;
 
   // 三层节奏响应：
-  //  常规节拍（低门槛）：groove 冲击 + 小雨滴 —— 逐拍贴合，规律感的来源
+  //  常规节拍（低门槛）：密度采样 + 小雨滴 —— 逐拍贴合，规律感的来源
   //  重音（高门槛）：更大更亮的雨滴
   //  转折（下方）：中心大波
   var isBeat = flux > rhythm.fluxAvg + 1.1 * sigma && flux > 0.1;
   // live 重音门槛提高（2.8σ + 绝对下限 0.3）：明确的强调才算，
   // 稍微重一点的字不触发；有网格时重音完全交给离线标注
   var isAccent = flux > rhythm.fluxAvg + 2.8 * sigma && flux > 0.3;
-  // 节拍网格存在时，常规拍的 groove/雨滴由 gridTick 精确踩拍接管
+  // 节拍网格存在时，常规拍的密度/雨滴由 gridTick 精确踩拍接管
   var gridActive = beatGrid.beats !== null;
 
   if (isBeat && !gridActive) {
-    // groove 冲击（背景震动的能量源）
-    rhythm.groove = Math.min(1, rhythm.groove + 0.4 + Math.min(0.5, flux));
     rhythm.beats.push(ts);
   }
   // 节奏密度：4s 窗口内的拍数（≈2.5 拍/秒 → 1）
   while (rhythm.beats.length > 0 && ts - rhythm.beats[0] > 4000) rhythm.beats.shift();
   rhythm.density += (Math.min(1, rhythm.beats.length / 10) - rhythm.density) * 0.1;
-  // groove 衰减：节奏紧凑 → 快衰减（弹得脆）；缓和 → 慢衰减（绵软地涌）
-  rhythm.groove *= Math.exp(-(1.8 + rhythm.density * 4.2) * 0.066);
 
   // ---- 情绪值（arousal 回归，Tzanetakis & Cook 2002 / Yang et al. 2008）----
   // 关键：全部用绝对特征。自适应阈值派生的量（如 density）会把不同歌自动拉平，
@@ -3818,10 +3810,9 @@ function gridTick() {
   if (i >= b.length || (i > 0 && pos < b[i - 1] - 1)) i = 0;
   // 前进跳过已错过的拍（>80ms 视为错过，不补发）
   while (i < b.length && b[i] < pos - 0.08) i++;
-  // 到拍：groove 冲击 + 雨滴（离线标注的重音拍 → 重音波）
+  // 到拍：密度采样 + 雨滴（离线标注的重音拍 → 重音波）
   if (i < b.length && b[i] <= pos + 0.017) {
     var isAcc = !!(beatGrid.accents && beatGrid.accents[i]);
-    rhythm.groove = Math.min(1, rhythm.groove + (isAcc ? 0.7 : 0.45) + rhythm.mood * 0.2);
     rhythm.beats.push(nowMs());
     if (shouldAnimate()) {
       if (isAcc) {
@@ -3841,7 +3832,7 @@ function gridTick() {
 
 var eqLastUpdate = 0;
 var EQ_INTERVAL = 66; // ~15fps 数据轮询
-// 防崩溃壳：eqTick 驱动全部视觉效果（aurora/涟漪/光呼吸/网格踩拍/间奏点/自愈），
+// 防崩溃壳：eqTick 驱动全部视觉效果（aurora/涟漪/网格踩拍/间奏点/自愈），
 // 任何一帧异常若不捕获，循环静默死亡且句柄残留 → ensureEqLoop 永远无法重启 →
 // 所有效果永久失效。异常只丢当帧并记录，循环必须活着。
 function eqTick(ts) {
@@ -3926,37 +3917,22 @@ function eqTickBody(ts) {
   gridTick();
   // Aurora 渲染每帧运行（60fps 包络 + 公转），数据按 15fps 更新
   renderAurora(ts);
-  renderRhythmGlow();
 }
 
-// 光呼吸：透明度 = groove × 密度增益（量化去重，只在变化时写）
-var glowState = { el: null, last: -1 };
-function renderRhythmGlow() {
-  if (!shouldAnimate()) return;
-  if (!glowState.el) {
-    glowState.el = $('rhythm-glow');
-    if (!glowState.el) return;
-  }
-  var o = Math.round(rhythm.groove * (0.04 + rhythm.density * 0.06 + rhythm.mood * 0.07) * 1000);
-  if (o !== glowState.last) {
-    glowState.last = o;
-    glowState.el.style.opacity = (o / 1000).toFixed(3);
-  }
-}
 function ensureEqLoop() {
   if (pageState.status && pageState.status.isPlaying && !pageState.eqFrame) {
     pageState.eqFrame = requestAnimationFrame(eqTick);
   }
 }
 
-// 启动背景动画
+// 启动背景动画（纯环境漂移：慢速 translate/rotate，不跟随节拍）
 function startBackgroundAnimation() {
   // 检查动画级别
   if (!shouldAnimate()) {
     return;
   }
   
-  // 移动端禁用背景旋律动画（节省性能）
+  // 移动端禁用背景漂移（节省性能）
   if (checkIsMobile()) {
     return;
   }
@@ -3972,30 +3948,16 @@ function startBackgroundAnimation() {
     var isPlaying = pageState.status && pageState.status.isPlaying;
     
     if (!isPlaying) {
-      // 暂停时缓慢重置动画
-      pageState.beatIntensity *= 0.95;
-      if (pageState.beatIntensity < 0.01) {
-        pageState.beatIntensity = 0;
-        applyBackgroundTransform(0, pageState.bgPhase);
-        pageState.bgAnimationFrame = null;
-        return;
-      }
-      applyBackgroundTransform(pageState.beatIntensity, pageState.bgPhase);
-      pageState.bgAnimationFrame = requestAnimationFrame(updateBackground);
+      // 暂停时定格在当前环境相位
+      applyBackgroundTransform(pageState.bgPhase);
+      pageState.bgAnimationFrame = null;
       return;
     }
     
     if (timestamp - lastUpdateTime >= UPDATE_INTERVAL) {
       lastUpdateTime = timestamp;
       pageState.bgPhase += 0.008; // 缓慢相位变化
-
-      // 背景震动强度 = 节奏引擎的 groove 包络 × 密度增益：
-      // 缓和的歌 → 密度低 → 幅度小、衰减慢（轻轻地涌）；
-      // 紧凑的歌 → 密度高 → 幅度大、衰减快（跟着拍点弹）
-      // （groove/density 由 eq 循环的 15fps 频谱轮询驱动，这里不再重复
-      //  调 getSpectrum——此前每秒 ~20 次桥接往返取回的 energy 从未被使用）
-      pageState.beatIntensity = rhythm.groove * (0.45 + rhythm.density * 0.75);
-      applyBackgroundTransform(pageState.beatIntensity, pageState.bgPhase);
+      applyBackgroundTransform(pageState.bgPhase);
     }
     
     pageState.bgAnimationFrame = requestAnimationFrame(updateBackground);
@@ -4007,15 +3969,12 @@ function startBackgroundAnimation() {
 // 应用背景变换 - 使用缓存的元素引用
 var cachedBgArtworkRef = null;
 
-function applyBackgroundTransform(beatIntensity, phase) {
+function applyBackgroundTransform(phase) {
   if (!cachedBgArtworkRef) cachedBgArtworkRef = $('bg-artwork');
   if (!cachedBgArtworkRef) return;
   
-  // 节拍只做极轻的缩放呼吸（1.1 ~ 1.14），不注入位移/旋转抖动——
-  // 晃动读作故障，呼吸才读作音乐；节奏的主表达交给 rhythm-glow 光层
-  var scale = 1.1 + beatIntensity * 0.04;
-
-  // 缓慢位移与旋转（纯环境漂移，与节拍无关）
+  // 固定轻微放大 + 缓慢位移/旋转（纯环境漂移，与节拍无关）
+  var scale = 1.1;
   var sinPhase = Math.sin(phase);
   var cosPhase = Math.cos(phase * 0.7);
   var translateX = sinPhase * 15;
@@ -4024,7 +3983,7 @@ function applyBackgroundTransform(beatIntensity, phase) {
   
   // 应用变换 - 使用位运算快速取整避免toFixed开销
   cachedBgArtworkRef.style.transform = 
-    'scale(' + ((scale * 1000 | 0) / 1000) + ') ' +
+    'scale(' + scale + ') ' +
     'translate(' + (translateX | 0) + 'px,' + (translateY | 0) + 'px) ' +
     'rotate(' + ((rotate * 100 | 0) / 100) + 'deg)';
 }

--- a/apps/com.myriad.music-player/page.css
+++ b/apps/com.myriad.music-player/page.css
@@ -758,16 +758,25 @@ html, body {
   opacity: 1;
 }
 
-/* 翻译开关：歌词面板右下角浮钮（放在渐隐遮罩外层，不被 mask 吃掉） */
+/* 歌词面板右下角浮钮组：动效 + 翻译（放在渐隐遮罩外层，不被 mask 吃掉） */
 .panel-lyrics {
   position: relative;
 }
 
-.lyric-trans-btn {
+.lyrics-corner-btns {
   position: absolute;
   right: 28px;
   bottom: 24px;
   z-index: 5;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.lyric-corner-btn {
+  pointer-events: auto;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -788,28 +797,40 @@ html, body {
   touch-action: manipulation;
 }
 
-.lyric-trans-btn svg {
+.lyric-corner-btn svg {
   width: 18px;
   height: 18px;
   pointer-events: none;
 }
 
-.lyric-trans-btn:hover {
+.lyric-corner-btn:hover {
   background: color-mix(in srgb, var(--text-primary) 14%, transparent);
   color: var(--text-primary);
 }
 
-.lyric-trans-btn:active {
+.lyric-corner-btn:active {
   transform: scale(0.92);
 }
 
-.lyric-trans-btn.active {
+.lyric-corner-btn.active {
   background: linear-gradient(135deg, var(--music-primary), var(--music-secondary));
   color: #fff;
 }
 
-.lyric-trans-btn[hidden] {
+.lyric-corner-btn[hidden] {
   display: none;
+}
+
+/* 动效关闭：冻结/隐藏 Aurora 与涟漪；列表 EQ 与静态封面模糊不受影响 */
+:root.visual-fx-off .artwork-aurora {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.35s ease, visibility 0s linear 0.35s;
+}
+
+:root.visual-fx-off .rhythm-ripple {
+  opacity: 0 !important;
+  animation: none !important;
 }
 
 /* 多字符 token 的字母容器：作为整体参与换行，字母不被从中间拆断。
@@ -1962,12 +1983,16 @@ html, body {
     font-weight: 600;
   }
 
-  /* 移动端翻译开关：44px 触控热区 + 避开底部安全区 */
-  .lyric-trans-btn {
-    width: 44px;
-    height: 44px;
+  /* 移动端右下角浮钮组：44px 触控热区 + 避开底部安全区 */
+  .lyrics-corner-btns {
     right: 20px;
     bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+    gap: 12px;
+  }
+
+  .lyric-corner-btn {
+    width: 44px;
+    height: 44px;
   }
 
   .lyric-interlude {

--- a/apps/com.myriad.music-player/page.css
+++ b/apps/com.myriad.music-player/page.css
@@ -284,22 +284,6 @@ html, body {
   pointer-events: none;
 }
 
-/* 光呼吸：铺满背景的柔光，透明度随节奏 groove 起伏（替代背景震动的节奏表达）。
-   opacity 由 JS 每帧驱动 + 短过渡平滑，合成器友好 */
-.rhythm-glow {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-    ellipse at 50% 78%,
-    color-mix(in srgb, var(--music-primary) 40%, transparent),
-    transparent 65%
-  );
-  opacity: 0;
-  transition: opacity 0.12s linear;
-  will-change: opacity;
-  pointer-events: none;
-}
-
 /* 节奏涟漪：柔化的环形波带（radial-gradient 圆环），从封面中心荡开扫过背景。
    尺寸/圆心由 JS 在触发时按封面几何设置；扩散动画走合成器（scale+opacity） */
 .rhythm-ripple {

--- a/apps/com.myriad.music-player/page.css
+++ b/apps/com.myriad.music-player/page.css
@@ -125,6 +125,11 @@ html, body {
   contain: strict;
 }
 
+/* 播放中 + FX 开时才挂 will-change，暂停/关 FX 卸下以释放合成层 */
+:root.fx-compositing .bg-artwork {
+  will-change: transform;
+}
+
 .bg-overlay {
   position: absolute;
   inset: 0;
@@ -239,6 +244,10 @@ html, body {
   border-radius: 50%;
   filter: blur(48px);
   opacity: 0.1;
+  /* will-change 仅在 :root.fx-compositing 下挂载（见下） */
+}
+
+:root.fx-compositing .aurora-blob {
   will-change: transform, opacity;
 }
 
@@ -298,8 +307,12 @@ html, body {
     transparent 80%
   );
   opacity: 0;
-  will-change: transform, opacity;
+  /* will-change 仅在 :root.fx-compositing 下挂载 */
   pointer-events: none;
+}
+
+:root.fx-compositing .rhythm-ripple {
+  will-change: transform, opacity;
 }
 
 /* 波的时长由 JS 按情绪值设置：缓和 → 慢荡（~2.3s），激烈 → 快脆（~1.0s） */

--- a/apps/com.myriad.music-player/page.html
+++ b/apps/com.myriad.music-player/page.html
@@ -74,10 +74,20 @@
         <div class="lyrics-scroll" id="lyrics-container">
           <div class="lyrics-empty" id="lyrics-empty">暂无歌词</div>
         </div>
-        <!-- 翻译开关（仅当前歌曲有用户语言的翻译时显示） -->
-        <button class="lyric-trans-btn" id="lyric-trans-btn" hidden aria-label="翻译" aria-pressed="false" title="翻译">
-          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v2h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"/></svg>
-        </button>
+        <!-- 右下角浮钮组：动效开关（常显）+ 翻译开关（有翻译时显示） -->
+        <div class="lyrics-corner-btns" id="lyrics-corner-btns">
+          <button class="lyric-corner-btn active" id="visual-fx-btn" aria-label="动效" aria-pressed="true" title="动效">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 2.2l1.05 3.15L16.2 6.4l-3.15 1.05L12 10.6l-1.05-3.15L7.8 6.4l3.15-1.05L12 2.2z"/>
+              <path d="M18.2 11.2l.72 2.16 2.16.72-2.16.72-.72 2.16-.72-2.16-2.16-.72 2.16-.72.72-2.16z"/>
+              <path d="M6.3 13.4l.62 1.86 1.86.62-1.86.62-.62 1.86-.62-1.86-1.86-.62 1.86-.62.62-1.86z"/>
+              <path d="M5 5.5l.45 1.35L6.8 7.3l-1.35.45L5 9.1l-.45-1.35L3.2 7.3l1.35-.45L5 5.5z" opacity="0.7"/>
+            </svg>
+          </button>
+          <button class="lyric-corner-btn lyric-trans-btn" id="lyric-trans-btn" hidden aria-label="翻译" aria-pressed="false" title="翻译">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v2h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"/></svg>
+          </button>
+        </div>
       </section>
       
       <!-- 播放列表面板 -->

--- a/apps/com.myriad.music-player/page.html
+++ b/apps/com.myriad.music-player/page.html
@@ -12,8 +12,6 @@
   <!-- 节奏涟漪层：节奏点从封面（音乐源头）荡出波环扫过背景
        重音=普通波，转折=更亮更慢的大波（CSS 合成器动画，JS 只在事件时刻切 class） -->
   <div class="rhythm-layer" aria-hidden="true">
-    <!-- 光呼吸：随 groove 明暗起伏（替代背景震动） -->
-    <div class="rhythm-glow" id="rhythm-glow"></div>
     <div class="rhythm-ripple"></div>
     <div class="rhythm-ripple"></div>
     <div class="rhythm-ripple"></div>


### PR DESCRIPTION
## Summary

Performance pass for music-player dynamic visuals (`apps/com.myriad.music-player/main.js` + `page.css`), built on top of the visual-FX toggle + glow removal work.

### Product constraints preserved
- Visual FX toggle still gates: Aurora, ripples, background drift
- **List EQ spectrum remains independent** of the FX toggle
- Lyrics/karaoke loops left separate (no master-clock mega-refactor)
- System `shouldAnimate()` / mobile / reduced-motion still apply
- No re-add of rhythm-glow or beat-driven bg scale
- FX ON path keeps the same aesthetic (or imperceptibly smoother)

### P0
1. **Consumer-aware `eqTick` scheduling**
   - Standard FX ON: rAF ~60fps (Aurora envelope + beat grid)
   - Light FX ON: ~20fps timer
   - FX OFF + list EQ visible: ~15fps (spectrum + interlude/heal)
   - FX OFF + no EQ consumer: ~8fps maintenance only (interlude dots + lyric heal) — **no empty 60fps loop**
   - `restartEqLoop()` cleanly cancels rAF/timer and re-enters on FX toggle / anim level change
2. **`getSpectrum` single-flight** — skip ticks while a previous bridge Promise is in flight (no queue pile-up); still ~15fps when needed
3. **Skip FX work when off** — early return in `eqTickBody` before `gridTick` / `renderAurora` / ripples; beat-grid index resynced via `resyncBeatGridIdx()` on FX re-enable (no 60fps scan while off)

### P1
4. **Aurora short-circuit** — FX off / `visual-fx-off` / hidden element skip all per-frame work
5. **Background drift** — dedicated bg rAF removed; phase advanced from `eqTick` low-rate branch; pause freezes transform; mobile / FX off / light still disabled
6. **List EQ height dedupe** — quantized integer `%` writes only when value changes
7. **`will-change` lifecycle** — `:root.fx-compositing` class (playing + FX on) mounts compositor hints for aurora/ripples/bg; removed on pause / FX off / cleanup

### P2
8. **`animConfig.level === 'light'` policy** — no ripples, no bg drift, softer/cheaper Aurora; list EQ still works
9. **Optional unify** — bg drift driven from `eqTick` only; lyric word tick left alone
10. **Host push spectrum** — **not available in this repo**; follow-up for Myriad host runtime (push-based spectrum / `onSpectrum` would let the tapp drop pull polling entirely). Do not stub fake APIs.

## Verification checklist

| Check | Result |
|---|---|
| Grep: no leftover `beatIntensity` / `rhythm-glow` / `bgAnimationFrame` | ✅ none |
| `node --check apps/com.myriad.music-player/main.js` | ✅ SYNTAX OK |
| FX on + playing + playlist visible: spectrum ~15fps single-flight; EQ updates; aurora/ripples/grid active | ✅ path traced |
| FX off + playlist visible: spectrum for EQ only; no aurora/ripple/bg/grid fire | ✅ early `needFx` return |
| FX off + playlist hidden: no spectrum; ~8fps maintenance only | ✅ `EQ_MAINT_MS` schedule |
| Toggle FX mid-play: `restartEqLoop` + resync grid + clear ripples/dim aurora | ✅ `setVisualFxOn` |
| Mobile: still no bg drift | ✅ `checkIsMobile()` in start + eqTick |
| `level=light`: cheaper policy active | ✅ no ripples/bg, light aurora, ~20fps |
| Pause: loops stop; `fx-compositing` cleared | ✅ `eqTick` exit + `syncFxCompositing` |
| List EQ works with FX off | ✅ `needEq` independent of `visualFxEnabled()` |

## Residual risks / follow-ups
- **Host push spectrum**: pull `getSpectrum` remains; a host `onSpectrum` / push API would further cut bridge traffic (document only; no fake stubs).
- **Interlude/heal** still share the eq scheduler at low rate when FX is off; not moved fully onto progress events (acceptable; avoids dual sources of truth).
- **Playlist tab open mid-maint tick**: up to ~125ms before first EQ poll after becoming visible (imperceptible).
- **Light mode mood/rhythm engine** skipped entirely (ripples off); Aurora uses bands only with reduced motion — intentional cost tradeoff.
- Runtime behavior depends on Myriad host `Tapp.media.getSpectrum` / `getBeatGrid`; not unit-tested in-repo without host mocks.

## Test plan
- [ ] Play a track with FX ON: Aurora + ripples + bg drift (desktop) look unchanged
- [ ] Toggle FX OFF mid-play: effects stop; list EQ (playlist tab) still animates
- [ ] Hide playlist / switch to lyrics with FX OFF: CPU/rAF should drop (no 60fps empty visual loop)
- [ ] Toggle FX ON again: effects resume cleanly, no stuck ripples
- [ ] Pause/resume: will-change/compositing class tracks play state
- [ ] Mobile width: no bg drift
- [ ] If host exposes `animConfig.level=light`: no ripples/bg, softer aurora, EQ still live