### PR TITLE
feat(quick-notes): UI polish — declutter, expand-first cards, typography

### DIFF
--- a/apps/com.myriad.quick-notes/main.js
+++ b/apps/com.myriad.quick-notes/main.js
@@ -28,6 +28,7 @@ var i18n = {
     notesCount: '条笔记',
     emptyTitle: '暂无笔记',
     emptySubtitle: '开始记录你的想法吧！',
+    emptyCta: '写一条便签',
     searchEmptyTitle: '无匹配笔记',
     searchEmptySubtitle: '试试其他关键词',
     justNow: '刚刚',
@@ -40,7 +41,8 @@ var i18n = {
     allCleared: '已清空所有笔记',
     charLimitReached: '已达字数上限（500）',
     notesTrimmed: '已达上限，已删除最旧的笔记',
-    clickToEdit: '点击编辑',
+    clickToExpand: '点击展开',
+    longNoteHint: '更多',
     pin: '置顶',
     unpin: '取消置顶',
     pinned: '已置顶',
@@ -53,6 +55,9 @@ var i18n = {
     close: '关闭',
     edit: '编辑',
     color: '颜色',
+    more: '更多',
+    search: '搜索',
+    sort: '排序',
     export: '导出',
     import: '导入',
     exportSuccess: '笔记已导出',
@@ -83,6 +88,7 @@ var i18n = {
     notesCount: 'notes',
     emptyTitle: 'No notes yet',
     emptySubtitle: 'Start writing your thoughts!',
+    emptyCta: 'Write a note',
     searchEmptyTitle: 'No matching notes',
     searchEmptySubtitle: 'Try a different keyword',
     justNow: 'just now',
@@ -95,7 +101,8 @@ var i18n = {
     allCleared: 'All notes cleared',
     charLimitReached: 'Character limit reached (500)',
     notesTrimmed: 'Limit reached; oldest notes removed',
-    clickToEdit: 'Click to edit',
+    clickToExpand: 'Tap to expand',
+    longNoteHint: 'More',
     pin: 'Pin',
     unpin: 'Unpin',
     pinned: 'Pinned',
@@ -108,6 +115,9 @@ var i18n = {
     close: 'Close',
     edit: 'Edit',
     color: 'Color',
+    more: 'More',
+    search: 'Search',
+    sort: 'Sort',
     export: 'Export',
     import: 'Import',
     exportSuccess: 'Notes exported',
@@ -138,6 +148,7 @@ var i18n = {
     notesCount: '件のメモ',
     emptyTitle: 'メモがありません',
     emptySubtitle: '思いを書き始めましょう！',
+    emptyCta: 'メモを書く',
     searchEmptyTitle: '一致するメモがありません',
     searchEmptySubtitle: '別のキーワードを試してください',
     justNow: 'たった今',
@@ -150,7 +161,8 @@ var i18n = {
     allCleared: 'すべてのメモを削除しました',
     charLimitReached: '文字数上限に達しました（500）',
     notesTrimmed: '上限に達したため、古いメモを削除しました',
-    clickToEdit: 'クリックして編集',
+    clickToExpand: 'タップして展開',
+    longNoteHint: '続き',
     pin: '固定',
     unpin: '固定解除',
     pinned: '固定中',
@@ -163,6 +175,9 @@ var i18n = {
     close: '閉じる',
     edit: '編集',
     color: '色',
+    more: 'その他',
+    search: '検索',
+    sort: '並び替え',
     export: 'エクスポート',
     import: 'インポート',
     exportSuccess: 'メモをエクスポートしました',
@@ -773,6 +788,9 @@ var pageState = {
   editingId: null,
   expandingId: null,
   draftColor: 0,
+  paletteOpen: false,
+  menuOpen: false,
+  skipCardAnimation: false,
   syncing: false
 };
 
@@ -877,6 +895,29 @@ function updateCharCount(input, charCount) {
   } else {
     charCount.classList.remove('char-count-limit');
   }
+
+  // 仅在聚焦、接近上限、或已输入较多时显示字数
+  var focused = false;
+  try {
+    focused = document.activeElement === input;
+  } catch (e) {}
+  var show = focused || len > 400 || len >= MAX_NOTE_CHARS;
+  if (show) {
+    charCount.classList.add('char-count-visible');
+  } else {
+    charCount.classList.remove('char-count-visible');
+  }
+}
+
+function focusPageInput() {
+  var input = document.getElementById('page-input');
+  if (!input) return;
+  try {
+    input.focus();
+    input.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  } catch (e) {
+    try { input.focus(); } catch (e2) {}
+  }
 }
 
 function renderEmptyState(area, isSearch) {
@@ -900,64 +941,20 @@ function renderEmptyState(area, isSearch) {
   empty.appendChild(icon);
   empty.appendChild(title);
   empty.appendChild(subtitle);
+
+  if (!isSearch) {
+    var cta = document.createElement('button');
+    cta.type = 'button';
+    cta.className = 'empty-cta';
+    cta.textContent = t('emptyCta');
+    cta.addEventListener('click', function(e) {
+      e.preventDefault();
+      focusPageInput();
+    });
+    empty.appendChild(cta);
+  }
+
   area.appendChild(empty);
-}
-
-function createIconButton(className, title, label, onClick) {
-  var btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = className;
-  btn.title = title;
-  btn.setAttribute('aria-label', label || title);
-  btn.addEventListener('click', function(e) {
-    e.stopPropagation();
-    e.preventDefault();
-    if (typeof onClick === 'function') onClick(e);
-  });
-  return btn;
-}
-
-function buildStickyActions(note) {
-  var actions = document.createElement('div');
-  actions.className = 'sticky-actions';
-
-  var pinBtn = createIconButton(
-    'sticky-action-btn sticky-pin' + (note.pinned ? ' active' : ''),
-    note.pinned ? t('unpin') : t('pin'),
-    note.pinned ? t('unpin') : t('pin'),
-    function() { togglePinNote(note.id); }
-  );
-  pinBtn.textContent = note.pinned ? '📌' : '📍';
-
-  var copyBtn = createIconButton(
-    'sticky-action-btn sticky-copy',
-    t('copy'),
-    t('copy'),
-    function() { copyNoteText(note.text); }
-  );
-  copyBtn.textContent = '⧉';
-
-  var expandBtn = createIconButton(
-    'sticky-action-btn sticky-expand',
-    t('expand'),
-    t('expand'),
-    function() { openNoteExpand(note.id); }
-  );
-  expandBtn.textContent = '⤢';
-
-  var deleteBtn = createIconButton(
-    'sticky-action-btn sticky-delete',
-    t('delete'),
-    t('delete'),
-    function() { deletePageNote(note.id); }
-  );
-  deleteBtn.textContent = '×';
-
-  actions.appendChild(pinBtn);
-  actions.appendChild(copyBtn);
-  actions.appendChild(expandBtn);
-  actions.appendChild(deleteBtn);
-  return actions;
 }
 
 function buildStickyEditUI(sticky, note) {
@@ -1102,12 +1099,15 @@ function renderPageNotes() {
   area.innerHTML = '';
   updateStatusPill();
   updateCreateColorPalette();
+  updateOverflowMenuLabels();
 
   var notesToRender = getDisplayNotes();
+  var skipAnim = pageState.skipCardAnimation || !!pageState.searchQuery;
 
   if (notesToRender.length === 0) {
     renderEmptyState(area, !!pageState.searchQuery);
     renderExpandOverlay();
+    pageState.skipCardAnimation = false;
     return;
   }
 
@@ -1121,8 +1121,11 @@ function renderPageNotes() {
     var colorIndex = getNoteColorIndex(note);
     sticky.className = 'sticky-note color-' + colorIndex;
     if (note.pinned) sticky.classList.add('pinned');
+    if (skipAnim) sticky.classList.add('no-animate');
     sticky.setAttribute('data-note-id', String(note.id));
-    sticky.style.animationDelay = (index * 0.05) + 's';
+    if (!skipAnim) {
+      sticky.style.animationDelay = (index * 0.05) + 's';
+    }
 
     if (pageState.editingId != null && String(pageState.editingId) === String(note.id)) {
       grid.appendChild(sticky);
@@ -1138,12 +1141,14 @@ function renderPageNotes() {
       pinMark.className = 'sticky-pin-mark';
       pinMark.textContent = '📌';
       pinMark.title = t('pinned');
+      pinMark.setAttribute('aria-label', t('pinned'));
       sticky.appendChild(pinMark);
     }
 
     var text = document.createElement('div');
     text.className = 'sticky-text';
-    if (isNoteLong(note.text)) text.classList.add('sticky-text-long');
+    var longNote = isNoteLong(note.text);
+    if (longNote) text.classList.add('sticky-text-long');
     text.textContent = note.text;
     content.appendChild(text);
 
@@ -1160,20 +1165,30 @@ function renderPageNotes() {
       footer.appendChild(spacer);
     }
 
-    footer.appendChild(buildStickyActions(note));
+    if (longNote) {
+      var hint = document.createElement('span');
+      hint.className = 'sticky-long-hint';
+      hint.textContent = t('longNoteHint') + '…';
+      footer.appendChild(hint);
+    }
+
     content.appendChild(footer);
     sticky.appendChild(content);
 
-    sticky.style.cursor = 'pointer';
-    sticky.title = t('clickToEdit');
+    sticky.title = t('clickToExpand');
+    sticky.setAttribute('role', 'button');
+    sticky.setAttribute('tabindex', '0');
+    sticky.setAttribute('aria-label', t('expand'));
 
-    sticky.addEventListener('click', function(e) {
-      if (e.target && e.target.closest && e.target.closest('.sticky-action-btn, .sticky-actions, .sticky-pin-mark')) {
-        return;
+    sticky.addEventListener('click', function() {
+      openNoteExpand(note.id);
+    });
+
+    sticky.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openNoteExpand(note.id);
       }
-      pageState.editingId = note.id;
-      pageState.expandingId = null;
-      renderPageNotes();
     });
 
     grid.appendChild(sticky);
@@ -1181,6 +1196,7 @@ function renderPageNotes() {
 
   area.appendChild(grid);
   renderExpandOverlay();
+  pageState.skipCardAnimation = false;
 }
 
 function renderExpandOverlay() {
@@ -1246,6 +1262,7 @@ function renderExpandOverlay() {
   pinBtn.type = 'button';
   pinBtn.className = 'sticky-edit-btn';
   pinBtn.textContent = note.pinned ? t('unpin') : t('pin');
+  pinBtn.setAttribute('aria-label', note.pinned ? t('unpin') : t('pin'));
   pinBtn.addEventListener('click', function() {
     togglePinNote(note.id);
   });
@@ -1254,6 +1271,7 @@ function renderExpandOverlay() {
   copyBtn.type = 'button';
   copyBtn.className = 'sticky-edit-btn';
   copyBtn.textContent = t('copy');
+  copyBtn.setAttribute('aria-label', t('copy'));
   copyBtn.addEventListener('click', function() {
     copyNoteText(note.text);
   });
@@ -1262,15 +1280,27 @@ function renderExpandOverlay() {
   editBtn.type = 'button';
   editBtn.className = 'sticky-edit-btn sticky-edit-save';
   editBtn.textContent = t('edit');
+  editBtn.setAttribute('aria-label', t('edit'));
   editBtn.addEventListener('click', function() {
     pageState.expandingId = null;
     pageState.editingId = note.id;
     renderPageNotes();
   });
 
+  var deleteBtn = document.createElement('button');
+  deleteBtn.type = 'button';
+  deleteBtn.className = 'sticky-edit-btn sticky-edit-danger';
+  deleteBtn.textContent = t('delete');
+  deleteBtn.setAttribute('aria-label', t('delete'));
+  deleteBtn.addEventListener('click', function() {
+    pageState.expandingId = null;
+    deletePageNote(note.id);
+  });
+
   actions.appendChild(pinBtn);
   actions.appendChild(copyBtn);
   actions.appendChild(editBtn);
+  actions.appendChild(deleteBtn);
 
   card.appendChild(header);
   card.appendChild(body);
@@ -1369,12 +1399,10 @@ async function addPageNote() {
   if (pageState.settings.saveHistory === false) {
     input.value = '';
     input.style.height = 'auto';
-    if (charCount) {
-      charCount.textContent = '0 / ' + MAX_NOTE_CHARS;
-      charCount.classList.remove('char-count-limit');
-    }
+    updateCharCount(input, charCount);
     pageState.notes = [];
     pageState.filteredNotes = [];
+    setPaletteOpen(false);
     await saveNotes();
     renderPageNotes();
     return;
@@ -1403,10 +1431,8 @@ async function addPageNote() {
 
   input.value = '';
   input.style.height = 'auto';
-  if (charCount) {
-    charCount.textContent = '0 / ' + MAX_NOTE_CHARS;
-    charCount.classList.remove('char-count-limit');
-  }
+  updateCharCount(input, charCount);
+  setPaletteOpen(false);
 
   await saveNotes();
   refreshFilteredNotes();
@@ -1760,9 +1786,36 @@ function openImportDialog() {
 // UI helpers
 // ========================================
 
+function updateColorToggleSwatch() {
+  var swatch = document.getElementById('color-toggle-swatch');
+  var toggle = document.getElementById('color-toggle');
+  if (swatch) {
+    swatch.className = 'color-toggle-swatch color-' + (normalizeColorIndex(pageState.draftColor) != null ? pageState.draftColor : 0);
+  }
+  if (toggle) {
+    if (pageState.paletteOpen) {
+      toggle.classList.add('active');
+      toggle.setAttribute('aria-expanded', 'true');
+    } else {
+      toggle.classList.remove('active');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+  }
+}
+
 function updateCreateColorPalette() {
   var host = document.getElementById('create-color-palette');
   if (!host) return;
+
+  updateColorToggleSwatch();
+
+  if (!pageState.paletteOpen) {
+    host.innerHTML = '';
+    host.hidden = true;
+    return;
+  }
+
+  host.hidden = false;
   host.innerHTML = '';
   var palette = buildColorPalette(pageState.draftColor, function(colorIndex) {
     pageState.draftColor = colorIndex;
@@ -1771,32 +1824,158 @@ function updateCreateColorPalette() {
   host.appendChild(palette);
 }
 
+function setPaletteOpen(open) {
+  pageState.paletteOpen = !!open;
+  updateCreateColorPalette();
+}
+
+function closeOverflowMenu() {
+  pageState.menuOpen = false;
+  var menu = document.getElementById('page-menu');
+  var toggle = document.getElementById('page-menu-toggle');
+  if (menu) menu.hidden = true;
+  if (toggle) {
+    toggle.classList.remove('active');
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+}
+
+function openOverflowMenu() {
+  pageState.menuOpen = true;
+  var menu = document.getElementById('page-menu');
+  var toggle = document.getElementById('page-menu-toggle');
+  updateOverflowMenuLabels();
+  if (menu) menu.hidden = false;
+  if (toggle) {
+    toggle.classList.add('active');
+    toggle.setAttribute('aria-expanded', 'true');
+  }
+}
+
+function toggleOverflowMenu() {
+  if (pageState.menuOpen) {
+    closeOverflowMenu();
+  } else {
+    openOverflowMenu();
+  }
+}
+
+function updateOverflowMenuLabels() {
+  var sortLabel = document.getElementById('menu-sort-label');
+  var sortNewest = document.getElementById('menu-sort-newest');
+  var sortOldest = document.getElementById('menu-sort-oldest');
+  var sortUpdated = document.getElementById('menu-sort-updated');
+  var exportBtn = document.getElementById('menu-export');
+  var importBtn = document.getElementById('menu-import');
+  var clearBtn = document.getElementById('menu-clear');
+  var menuToggle = document.getElementById('page-menu-toggle');
+  var searchToggle = document.getElementById('search-toggle');
+  var colorToggle = document.getElementById('color-toggle');
+  var sendBtn = document.getElementById('page-send');
+
+  if (sortLabel) sortLabel.textContent = t('sort');
+  if (sortNewest) {
+    sortNewest.textContent = t('sortNewest');
+    sortNewest.classList.toggle('active', normalizeSortOrder(pageState.settings.sortOrder) === 'newest');
+    sortNewest.setAttribute('aria-checked', normalizeSortOrder(pageState.settings.sortOrder) === 'newest' ? 'true' : 'false');
+  }
+  if (sortOldest) {
+    sortOldest.textContent = t('sortOldest');
+    sortOldest.classList.toggle('active', normalizeSortOrder(pageState.settings.sortOrder) === 'oldest');
+    sortOldest.setAttribute('aria-checked', normalizeSortOrder(pageState.settings.sortOrder) === 'oldest' ? 'true' : 'false');
+  }
+  if (sortUpdated) {
+    sortUpdated.textContent = t('sortUpdated');
+    sortUpdated.classList.toggle('active', normalizeSortOrder(pageState.settings.sortOrder) === 'updated');
+    sortUpdated.setAttribute('aria-checked', normalizeSortOrder(pageState.settings.sortOrder) === 'updated' ? 'true' : 'false');
+  }
+  if (exportBtn) exportBtn.textContent = t('export');
+  if (importBtn) importBtn.textContent = t('import');
+  if (clearBtn) clearBtn.textContent = t('clearAll');
+  if (menuToggle) {
+    menuToggle.title = t('more');
+    menuToggle.setAttribute('aria-label', t('more'));
+  }
+  if (searchToggle) {
+    searchToggle.title = t('search');
+    searchToggle.setAttribute('aria-label', t('search'));
+  }
+  if (colorToggle) {
+    colorToggle.title = t('color');
+    colorToggle.setAttribute('aria-label', t('color'));
+  }
+  if (sendBtn) {
+    sendBtn.title = t('add');
+    sendBtn.setAttribute('aria-label', t('add'));
+  }
+}
+
+async function persistSortOrder(order) {
+  var next = normalizeSortOrder(order);
+  pageState.settings.sortOrder = next;
+
+  try {
+    if (typeof Tapp !== 'undefined' && Tapp.settings) {
+      if (typeof Tapp.settings.set === 'function') {
+        await Tapp.settings.set('sortOrder', next);
+      } else if (typeof Tapp.settings.setAll === 'function') {
+        await Tapp.settings.setAll({ sortOrder: next });
+      }
+    }
+  } catch (e) {
+    console.error('[Notes] 保存排序失败:', e);
+  }
+
+  pageState.skipCardAnimation = true;
+  refreshFilteredNotes();
+  renderPageNotes();
+  updateOverflowMenuLabels();
+}
+
+function menuOutsideClickHandler(e) {
+  if (!pageState.menuOpen) return;
+  var wrap = document.querySelector('.status-menu-wrap');
+  if (!wrap) return;
+  if (e.target && wrap.contains(e.target)) return;
+  closeOverflowMenu();
+}
+
+function menuEscHandler(e) {
+  if (e.key === 'Escape' && pageState.menuOpen) {
+    closeOverflowMenu();
+  }
+}
+
 function initPage() {
   var input = document.getElementById('page-input');
   var sendBtn = document.getElementById('page-send');
-  var clearBtn = document.getElementById('page-clear');
-  var exportBtn = document.getElementById('page-export');
-  var importBtn = document.getElementById('page-import');
   var charCount = document.getElementById('char-count');
   var searchInput = document.getElementById('search-input');
   var searchToggle = document.getElementById('search-toggle');
   var statusPill = document.getElementById('status-pill');
+  var menuToggle = document.getElementById('page-menu-toggle');
+  var menuExport = document.getElementById('menu-export');
+  var menuImport = document.getElementById('menu-import');
+  var menuClear = document.getElementById('menu-clear');
+  var menuSortNewest = document.getElementById('menu-sort-newest');
+  var menuSortOldest = document.getElementById('menu-sort-oldest');
+  var menuSortUpdated = document.getElementById('menu-sort-updated');
+  var colorToggle = document.getElementById('color-toggle');
 
   if (input) {
     input.placeholder = t('placeholder');
     input.setAttribute('maxlength', String(MAX_NOTE_CHARS));
   }
-  if (sendBtn) sendBtn.title = t('add');
-  if (clearBtn) clearBtn.title = t('clearAll');
-  if (exportBtn) exportBtn.title = t('export');
-  if (importBtn) importBtn.title = t('import');
   if (searchInput) searchInput.placeholder = t('searchPlaceholder');
   if (charCount && input) updateCharCount(input, charCount);
 
+  updateOverflowMenuLabels();
   updateCreateColorPalette();
+  closeOverflowMenu();
 
   if (searchToggle && statusPill && searchInput) {
     searchToggle.onclick = function() {
+      closeOverflowMenu();
       var isSearching = statusPill.classList.toggle('searching');
       searchToggle.classList.toggle('active', isSearching);
 
@@ -1807,6 +1986,7 @@ function initPage() {
       } else {
         searchInput.value = '';
         filterNotes('');
+        pageState.skipCardAnimation = true;
         renderPageNotes();
       }
     };
@@ -1817,8 +1997,73 @@ function initPage() {
         searchToggle.classList.remove('active');
         searchInput.value = '';
         filterNotes('');
+        pageState.skipCardAnimation = true;
         renderPageNotes();
       }
+    };
+  }
+
+  if (menuToggle) {
+    menuToggle.onclick = function(e) {
+      e.stopPropagation();
+      e.preventDefault();
+      toggleOverflowMenu();
+    };
+  }
+
+  if (menuSortNewest) {
+    menuSortNewest.onclick = function() {
+      persistSortOrder('newest');
+      closeOverflowMenu();
+    };
+  }
+  if (menuSortOldest) {
+    menuSortOldest.onclick = function() {
+      persistSortOrder('oldest');
+      closeOverflowMenu();
+    };
+  }
+  if (menuSortUpdated) {
+    menuSortUpdated.onclick = function() {
+      persistSortOrder('updated');
+      closeOverflowMenu();
+    };
+  }
+
+  if (menuExport) {
+    menuExport.onclick = function() {
+      closeOverflowMenu();
+      exportNotes();
+    };
+  }
+  if (menuImport) {
+    menuImport.onclick = function() {
+      closeOverflowMenu();
+      openImportDialog();
+    };
+  }
+  if (menuClear) {
+    menuClear.onclick = function() {
+      closeOverflowMenu();
+      clearAllNotes();
+    };
+  }
+
+  // 触摸友好：点击外部 / Escape 关闭溢出菜单
+  try {
+    document.removeEventListener('click', menuOutsideClickHandler, true);
+    document.removeEventListener('touchstart', menuOutsideClickHandler, true);
+    document.removeEventListener('keydown', menuEscHandler);
+  } catch (e) {}
+  document.addEventListener('click', menuOutsideClickHandler, true);
+  document.addEventListener('touchstart', menuOutsideClickHandler, true);
+  document.addEventListener('keydown', menuEscHandler);
+
+  if (colorToggle) {
+    colorToggle.onclick = function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      setPaletteOpen(!pageState.paletteOpen);
     };
   }
 
@@ -1832,6 +2077,14 @@ function initPage() {
       updateCharCount(input, charCount);
     };
 
+    input.onfocus = function() {
+      updateCharCount(input, charCount);
+    };
+
+    input.onblur = function() {
+      updateCharCount(input, charCount);
+    };
+
     input.onpaste = function() {
       setTimeout(function() {
         if (input.value.length > MAX_NOTE_CHARS) {
@@ -1841,6 +2094,8 @@ function initPage() {
             title: t('charLimitReached'),
             type: 'warning'
           });
+        } else {
+          updateCharCount(input, charCount);
         }
       }, 0);
     };
@@ -1857,24 +2112,13 @@ function initPage() {
     sendBtn.onclick = addPageNote;
   }
 
-  if (clearBtn) {
-    clearBtn.onclick = clearAllNotes;
-  }
-
-  if (exportBtn) {
-    exportBtn.onclick = exportNotes;
-  }
-
-  if (importBtn) {
-    importBtn.onclick = openImportDialog;
-  }
-
   if (searchInput) {
     var searchTimeout;
     searchInput.oninput = function() {
       clearTimeout(searchTimeout);
       searchTimeout = setTimeout(function() {
         filterNotes(searchInput.value.trim());
+        pageState.skipCardAnimation = true;
         renderPageNotes();
       }, 200);
     };

--- a/apps/com.myriad.quick-notes/page.css
+++ b/apps/com.myriad.quick-notes/page.css
@@ -20,13 +20,17 @@
   --notes-error: #ef4444;
   --notes-success: #10b981;
   
-  /* 便利贴颜色 */
+  /* 便利贴颜色（浅色：柔和纸感） */
   --sticky-yellow: #fef3c7;
   --sticky-pink: #fce7f3;
   --sticky-blue: #dbeafe;
   --sticky-green: #dcfce7;
   --sticky-purple: #f3e8ff;
   --sticky-orange: #ffedd5;
+
+  /* 便利贴正文色 */
+  --sticky-text: #1f2937;
+  --sticky-text-muted: rgba(0, 0, 0, 0.42);
   
   /* 背景色 */
   --notes-bg-solid: #f8f9fa;
@@ -59,6 +63,12 @@
   --notes-shadow-glow: 0 0 20px rgba(var(--notes-primary-rgb), 0.2);
   --sticky-shadow: 2px 4px 12px rgba(0, 0, 0, 0.1);
   
+  /* 字体：干净系统栈，保留可读便签感 */
+  --notes-font: ui-rounded, system-ui, -apple-system, 'PingFang SC', 'Hiragino Sans GB',
+    'Hiragino Sans', 'Segoe UI', 'Noto Sans SC', 'Noto Sans JP', sans-serif;
+  --notes-font-note: ui-rounded, system-ui, -apple-system, 'PingFang SC', 'Hiragino Sans GB',
+    'Hiragino Sans', 'Segoe UI', 'Noto Sans SC', 'Noto Sans JP', sans-serif;
+  
   /* 过渡 */
   --notes-transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -77,13 +87,15 @@
   --notes-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   --notes-shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.5);
   
-  /* 深色便利贴颜色（降低亮度） */
-  --sticky-yellow: #44403c;
-  --sticky-pink: #4a3f4a;
-  --sticky-blue: #3b4a5a;
-  --sticky-green: #3b4a3f;
-  --sticky-purple: #4a3f5a;
-  --sticky-orange: #4a433b;
+  /* 深色便利贴：略提亮底色，保证正文对比 */
+  --sticky-yellow: #5c5346;
+  --sticky-pink: #5a4754;
+  --sticky-blue: #45566a;
+  --sticky-green: #45584a;
+  --sticky-purple: #544865;
+  --sticky-orange: #5a5042;
+  --sticky-text: #f8fafc;
+  --sticky-text-muted: rgba(255, 255, 255, 0.58);
 }
 
 /* ========================================
@@ -149,6 +161,7 @@
   inset: 0;
   z-index: 1;
   overflow: hidden;
+  font-family: var(--notes-font);
 }
 
 /* ========================================
@@ -181,6 +194,7 @@
 }
 
 .status-pill {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 12px;
@@ -192,6 +206,7 @@
   border-radius: 50px;
   box-shadow: var(--notes-shadow-lg);
   transition: var(--notes-transition);
+  overflow: visible;
 }
 
 .status-pill.searching {
@@ -270,6 +285,7 @@
   color: var(--notes-text);
   outline: none;
   transition: var(--notes-transition);
+  font-family: inherit;
 }
 
 .search-input::placeholder {
@@ -300,6 +316,7 @@
   cursor: pointer;
   color: var(--notes-text-secondary);
   transition: var(--notes-transition);
+  padding: 0;
 }
 
 .status-action-btn:hover {
@@ -327,6 +344,99 @@
 }
 
 /* ========================================
+   顶部溢出菜单
+   ======================================== */
+
+.status-menu-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.status-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 168px;
+  padding: 6px;
+  background: var(--notes-surface-elevated);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--notes-border);
+  border-radius: 14px;
+  box-shadow: var(--notes-shadow-lg);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.status-menu[hidden] {
+  display: none !important;
+}
+
+.status-menu-label {
+  padding: 6px 10px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--notes-text-secondary);
+  text-transform: none;
+  user-select: none;
+}
+
+.status-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 10px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--notes-text);
+  font-size: 13px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: var(--notes-transition);
+}
+
+.status-menu-item:hover,
+.status-menu-item:focus-visible {
+  background: rgba(var(--notes-primary-rgb), 0.1);
+  outline: none;
+}
+
+.status-menu-item.active {
+  background: rgba(var(--notes-primary-rgb), 0.14);
+  color: var(--notes-primary);
+  font-weight: 600;
+}
+
+.status-menu-item.active::after {
+  content: '✓';
+  font-size: 12px;
+  color: var(--notes-primary);
+}
+
+.status-menu-item-danger {
+  color: var(--notes-error);
+}
+
+.status-menu-item-danger:hover,
+.status-menu-item-danger:focus-visible {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--notes-error);
+}
+
+.status-menu-divider {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--notes-border);
+}
+
+/* ========================================
    笔记区域（便利贴网格）
    ======================================== */
 
@@ -335,7 +445,8 @@
   overflow-y: auto;
   overflow-x: hidden;
   padding: 8px 0;
-  padding-bottom: 100px; /* 为固定底部输入框留出空间 */
+  /* 为固定底部输入框留出空间（含展开色板时） */
+  padding-bottom: 140px;
   scroll-behavior: smooth;
   min-height: 0;
 }
@@ -381,6 +492,12 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  cursor: pointer;
+}
+
+/* 搜索/过滤重渲染时跳过入场动画 */
+.sticky-note.no-animate {
+  animation: none !important;
 }
 
 .sticky-note.pinned {
@@ -429,6 +546,14 @@
   background: linear-gradient(135deg, transparent 50%, rgba(255,255,255,0.4) 50%);
 }
 
+.dark .sticky-note::before {
+  border-color: transparent rgba(0,0,0,0.22) transparent transparent;
+}
+
+.dark .sticky-note::after {
+  background: linear-gradient(135deg, transparent 50%, rgba(255,255,255,0.12) 50%);
+}
+
 .sticky-note:hover {
   transform: translateY(-4px) rotate(-1deg);
   box-shadow: 4px 8px 20px rgba(0, 0, 0, 0.15);
@@ -456,18 +581,18 @@
 
 .sticky-text {
   font-size: 14px;
-  line-height: 1.5;
-  color: #1f2937;
+  line-height: 1.55;
+  color: var(--sticky-text);
   word-break: break-word;
   display: -webkit-box;
   -webkit-line-clamp: 6;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  font-family: 'Comic Sans MS', 'Segoe Print', cursive, sans-serif;
+  font-family: var(--notes-font-note);
 }
 
-.dark .sticky-text {
-  color: #e5e7eb;
+.sticky-text-long {
+  -webkit-line-clamp: 5;
 }
 
 .sticky-footer {
@@ -481,86 +606,20 @@
 
 .sticky-time {
   font-size: 11px;
-  color: rgba(0, 0, 0, 0.4);
-  font-family: sans-serif;
+  color: var(--sticky-text-muted);
+  font-family: var(--notes-font);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.dark .sticky-time {
-  color: rgba(255, 255, 255, 0.4);
-}
-
-.sticky-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
+.sticky-long-hint {
+  font-size: 11px;
+  color: var(--sticky-text-muted);
+  font-family: var(--notes-font);
   flex-shrink: 0;
-}
-
-.sticky-action-btn {
-  width: 22px;
-  height: 22px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.08);
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-  color: rgba(0, 0, 0, 0.45);
-  font-size: 12px;
-  line-height: 1;
-  opacity: 0;
-  transition: var(--notes-transition);
-  flex-shrink: 0;
-  padding: 0;
-}
-
-.sticky-action-btn.active {
-  opacity: 1;
-  background: rgba(var(--notes-primary-rgb), 0.18);
-}
-
-/* 支持 hover 的设备：悬停时显示操作 */
-@media (hover: hover) and (pointer: fine) {
-  .sticky-note:hover .sticky-action-btn,
-  .sticky-action-btn:focus-visible,
-  .sticky-action-btn.active {
-    opacity: 1;
-  }
-}
-
-/* 触屏 / 无 hover：操作按钮常驻可见 */
-@media (hover: none) {
-  .sticky-action-btn {
-    opacity: 1;
-  }
-}
-
-.sticky-action-btn:hover,
-.sticky-action-btn:focus-visible {
-  background: rgba(0, 0, 0, 0.14);
-  color: rgba(0, 0, 0, 0.75);
-}
-
-.sticky-action-btn.sticky-delete:hover,
-.sticky-action-btn.sticky-delete:focus-visible {
-  background: var(--notes-error);
-  color: white;
-}
-
-.dark .sticky-action-btn {
-  background: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.55);
-}
-
-.dark .sticky-action-btn:hover,
-.dark .sticky-action-btn:focus-visible {
-  background: rgba(255, 255, 255, 0.18);
-  color: rgba(255, 255, 255, 0.9);
+  opacity: 0.85;
 }
 
 /* ========================================
@@ -591,16 +650,16 @@
   padding: 8px;
   font-size: 14px;
   line-height: 1.5;
-  color: #1f2937;
+  color: var(--sticky-text);
   resize: vertical;
   outline: none;
-  font-family: 'Comic Sans MS', 'Segoe Print', cursive, sans-serif;
+  font-family: var(--notes-font-note);
 }
 
 .dark .sticky-edit-input {
-  background: rgba(0, 0, 0, 0.25);
-  border-color: rgba(255, 255, 255, 0.12);
-  color: #e5e7eb;
+  background: rgba(0, 0, 0, 0.28);
+  border-color: rgba(255, 255, 255, 0.14);
+  color: var(--sticky-text);
 }
 
 .sticky-edit-input:focus {
@@ -621,6 +680,14 @@
   font-weight: 600;
   cursor: pointer;
   transition: var(--notes-transition);
+  font-family: inherit;
+  background: rgba(0, 0, 0, 0.08);
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.dark .sticky-edit-btn {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.88);
 }
 
 .sticky-edit-cancel {
@@ -640,6 +707,16 @@
 
 .sticky-edit-save:hover {
   filter: brightness(1.05);
+}
+
+.sticky-edit-btn.sticky-edit-danger {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--notes-error);
+}
+
+.sticky-edit-btn.sticky-edit-danger:hover {
+  background: var(--notes-error);
+  color: white;
 }
 
 /* ========================================
@@ -664,6 +741,10 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
 }
 
+.dark .color-swatch {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
 .color-swatch:hover {
   transform: scale(1.1);
 }
@@ -680,10 +761,58 @@
 .color-swatch.color-4 { background: var(--sticky-purple); }
 .color-swatch.color-5 { background: var(--sticky-orange); }
 
+.composer-tools {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.color-toggle-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--notes-border);
+  border-radius: 50%;
+  background: var(--notes-surface);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: var(--notes-transition);
+}
+
+.color-toggle-btn:hover,
+.color-toggle-btn.active {
+  border-color: rgba(var(--notes-primary-rgb), 0.45);
+  box-shadow: 0 0 0 2px rgba(var(--notes-primary-rgb), 0.12);
+}
+
+.color-toggle-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+.color-toggle-swatch.color-0 { background: var(--sticky-yellow); }
+.color-toggle-swatch.color-1 { background: var(--sticky-pink); }
+.color-toggle-swatch.color-2 { background: var(--sticky-blue); }
+.color-toggle-swatch.color-3 { background: var(--sticky-green); }
+.color-toggle-swatch.color-4 { background: var(--sticky-purple); }
+.color-toggle-swatch.color-5 { background: var(--sticky-orange); }
+
 .create-color-palette {
   display: flex;
   align-items: center;
   min-width: 0;
+}
+
+.create-color-palette[hidden] {
+  display: none !important;
 }
 
 /* ========================================
@@ -742,18 +871,13 @@
 
 .note-expand-pin {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.55);
+  color: var(--sticky-text-muted);
 }
 
 .note-expand-time {
   font-size: 12px;
-  color: rgba(0, 0, 0, 0.45);
-  font-family: sans-serif;
-}
-
-.dark .note-expand-pin,
-.dark .note-expand-time {
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--sticky-text-muted);
+  font-family: var(--notes-font);
 }
 
 .note-expand-close {
@@ -769,6 +893,11 @@
   flex-shrink: 0;
 }
 
+.dark .note-expand-close {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
 .note-expand-close:hover {
   background: var(--notes-error);
   color: white;
@@ -780,15 +909,11 @@
   overflow-y: auto;
   font-size: 15px;
   line-height: 1.6;
-  color: #1f2937;
+  color: var(--sticky-text);
   word-break: break-word;
   white-space: pre-wrap;
-  font-family: 'Comic Sans MS', 'Segoe Print', cursive, sans-serif;
+  font-family: var(--notes-font-note);
   padding-right: 4px;
-}
-
-.dark .note-expand-body {
-  color: #e5e7eb;
 }
 
 .note-expand-actions,
@@ -844,7 +969,7 @@
 }
 
 /* ========================================
-   空状态（可见：图标 + 标题）
+   空状态（可见：图标 + 标题 + CTA）
    ======================================== */
 
 .notes-area.empty {
@@ -893,6 +1018,30 @@
   max-width: 240px;
 }
 
+.empty-cta {
+  margin-top: 6px;
+  border: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--notes-primary), var(--notes-secondary));
+  color: white;
+  box-shadow: 0 4px 12px rgba(var(--notes-primary-rgb), 0.28);
+  transition: var(--notes-transition);
+}
+
+.empty-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(var(--notes-primary-rgb), 0.36);
+}
+
+.empty-cta:active {
+  transform: translateY(0);
+}
+
 /* ========================================
    浮动输入区域（固定底部）
    ======================================== */
@@ -934,6 +1083,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
 }
 
 .page-input {
@@ -964,12 +1114,22 @@
 .char-count {
   font-size: 11px;
   color: var(--notes-text-secondary);
-  transition: var(--notes-transition);
+  transition: opacity 0.2s ease, color var(--notes-transition);
+  opacity: 0;
+  pointer-events: none;
+  flex-shrink: 0;
+  min-width: 52px;
+  text-align: right;
+}
+
+.char-count.char-count-visible {
+  opacity: 1;
 }
 
 .char-count.char-count-limit {
   color: var(--notes-error);
   font-weight: 600;
+  opacity: 1;
 }
 
 .page-send-btn {
@@ -987,6 +1147,7 @@
   transition: var(--notes-transition);
   flex-shrink: 0;
   box-shadow: 0 4px 12px rgba(var(--notes-primary-rgb), 0.3);
+  padding: 0;
 }
 
 .page-send-btn svg {
@@ -1051,6 +1212,10 @@
     font-size: 13px;
     -webkit-line-clamp: 5;
   }
+
+  .sticky-text-long {
+    -webkit-line-clamp: 4;
+  }
   
   .input-card {
     padding: 10px 12px;
@@ -1059,6 +1224,10 @@
   .page-send-btn {
     width: 40px;
     height: 40px;
+  }
+
+  .notes-area {
+    padding-bottom: 150px;
   }
 }
 

--- a/apps/com.myriad.quick-notes/page.html
+++ b/apps/com.myriad.quick-notes/page.html
@@ -25,31 +25,31 @@
           <input type="text" id="search-input" class="search-input" placeholder="..." autocomplete="off">
         </div>
         <div class="status-actions">
-          <button id="search-toggle" class="status-action-btn" title="Search">
+          <button id="search-toggle" class="status-action-btn" type="button" title="Search" aria-label="Search">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="11" cy="11" r="8"/>
               <path d="M21 21l-4.35-4.35"/>
             </svg>
           </button>
-          <button id="page-export" class="status-action-btn" title="Export">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M12 3v12"/>
-              <path d="M7 10l5 5 5-5"/>
-              <path d="M5 19h14"/>
-            </svg>
-          </button>
-          <button id="page-import" class="status-action-btn" title="Import">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M12 21V9"/>
-              <path d="M7 14l5-5 5 5"/>
-              <path d="M5 5h14"/>
-            </svg>
-          </button>
-          <button id="page-clear" class="status-action-btn" title="Clear All">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/>
-            </svg>
-          </button>
+          <div class="status-menu-wrap">
+            <button id="page-menu-toggle" class="status-action-btn" type="button" title="More" aria-label="More" aria-haspopup="true" aria-expanded="false">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <circle cx="5" cy="12" r="1.8"/>
+                <circle cx="12" cy="12" r="1.8"/>
+                <circle cx="19" cy="12" r="1.8"/>
+              </svg>
+            </button>
+            <div id="page-menu" class="status-menu" role="menu" hidden>
+              <div class="status-menu-label" id="menu-sort-label"></div>
+              <button type="button" class="status-menu-item" data-sort="newest" role="menuitemradio" id="menu-sort-newest"></button>
+              <button type="button" class="status-menu-item" data-sort="oldest" role="menuitemradio" id="menu-sort-oldest"></button>
+              <button type="button" class="status-menu-item" data-sort="updated" role="menuitemradio" id="menu-sort-updated"></button>
+              <div class="status-menu-divider" role="separator"></div>
+              <button type="button" class="status-menu-item" id="menu-export" role="menuitem"></button>
+              <button type="button" class="status-menu-item" id="menu-import" role="menuitem"></button>
+              <button type="button" class="status-menu-item status-menu-item-danger" id="menu-clear" role="menuitem"></button>
+            </div>
+          </div>
         </div>
       </div>
     </header>
@@ -63,12 +63,17 @@
         <div class="input-area">
           <textarea id="page-input" class="page-input" rows="1" placeholder="..."></textarea>
           <div class="input-footer">
-            <div id="create-color-palette" class="create-color-palette"></div>
+            <div class="composer-tools">
+              <button type="button" id="color-toggle" class="color-toggle-btn" title="Color" aria-label="Color" aria-expanded="false">
+                <span id="color-toggle-swatch" class="color-toggle-swatch color-0"></span>
+              </button>
+              <div id="create-color-palette" class="create-color-palette" hidden></div>
+            </div>
             <span id="char-count" class="char-count">0 / 500</span>
           </div>
         </div>
-        <button id="page-send" class="page-send-btn" title="Add">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+        <button id="page-send" class="page-send-btn" type="button" title="Add" aria-label="Add">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
             <path d="M12 5v14M5 12h14"/>
           </svg>
         </button>


### PR DESCRIPTION
## Summary

UI polish pass for `apps/com.myriad.quick-notes` (便携便签), stacked on #7 (`ao/tapp-store-9/quick-notes-round2`). **No version bump** (stays `1.0.0`).

### Changes
1. **Top bar declutter** — Keep search + title/count; move export / import / clear into a `⋯` overflow menu (touch: click toggle, click-outside / Escape close). Sort options live in the same menu.
2. **Card interaction** — Primary sticky click opens expand/read overlay; edit / copy / pin / delete live there. Card footer is minimal (time + long-note hint + pin mark).
3. **Typography + dark contrast** — Replace Comic Sans with system/ui-rounded stack; brighter dark sticky backgrounds and clearer sticky text colors.
4. **Composer declutter** — Color swatches collapsed behind a small color button; char count only when focused or length > ~400; list bottom padding clears the floating input.
5. **Empty CTA + in-page sort** — Empty state CTA focuses the page input; sort wired to existing `sortOrder` setting and persisted via `Tapp.settings` when available (manifest `sortOrder` unchanged).
6. **Light polish** — Skip pop-in animation while filtering/search re-renders; aria-labels on icon buttons.

### Out of scope
Markdown, folders, version bump, unrelated apps, masonry redesign. Widget left mostly as-is.

## Test plan
- [ ] Open page: only search + ⋯ in status pill
- [ ] ⋯ menu: export, import, clear (destructive), sort options; closes on outside tap / Escape
- [ ] Sticky click expands; edit/copy/pin/delete work from overlay
- [ ] Color palette toggles from composer color button; char count appears when focused or long
- [ ] Empty state CTA focuses input; sort persists after reload
- [ ] Dark mode sticky text is readable; fonts are system stack (not Comic Sans)
- [ ] Search filtering does not re-spam pop animations