### PR TITLE
feat(quick-notes): replace emoji UI icons with SVG

### DIFF
--- a/apps/com.myriad.quick-notes/main.js
+++ b/apps/com.myriad.quick-notes/main.js
@@ -215,6 +215,177 @@ function t(key) {
 // 工具函数
 // ========================================
 
+var SVG_NS = 'http://www.w3.org/2000/svg';
+
+/** Stroke/fill icon path defs (24×24). Keys used by createSvgIcon. */
+var SVG_ICON_DEFS = {
+  note: {
+    paths: [
+      'M8 2v3M16 2v3M3 9h18',
+      'M21 8.5V17c0 3-1.5 5-5 5H8c-3.5 0-5-2-5-5V8.5c0-3 1.5-5 5-5h8c3.5 0 5 2 5 5z',
+      'M8 14h4M8 18h8'
+    ]
+  },
+  search: {
+    circles: [{ cx: 11, cy: 11, r: 8 }],
+    paths: ['M21 21l-4.35-4.35']
+  },
+  pin: {
+    // Pushpin — readable at 10–12px badge sizes
+    strokeWidth: '2',
+    paths: [
+      'M12 17v5',
+      'M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z'
+    ]
+  },
+  pinOff: {
+    strokeWidth: '2',
+    paths: [
+      'M12 17v5',
+      'M15 9.34V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H7.89',
+      'M2 2l20 20',
+      'M9 9v1.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h11'
+    ]
+  },
+  copy: {
+    paths: [
+      'M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2',
+      'M9 2h6a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z'
+    ]
+  },
+  expand: {
+    paths: [
+      'M15 3h6v6',
+      'M9 21H3v-6',
+      'M21 3l-7 7',
+      'M3 21l7-7'
+    ]
+  },
+  edit: {
+    paths: [
+      'M12 20h9',
+      'M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z'
+    ]
+  },
+  delete: {
+    paths: [
+      'M3 6h18',
+      'M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2',
+      'M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6',
+      'M10 11v6M14 11v6'
+    ]
+  },
+  close: {
+    paths: ['M18 6L6 18M6 6l12 12']
+  },
+  more: {
+    fill: true,
+    circles: [
+      { cx: 5, cy: 12, r: 1.8 },
+      { cx: 12, cy: 12, r: 1.8 },
+      { cx: 19, cy: 12, r: 1.8 }
+    ]
+  },
+  export: {
+    paths: [
+      'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4',
+      'M17 8l-5-5-5 5',
+      'M12 3v12'
+    ]
+  },
+  import: {
+    paths: [
+      'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4',
+      'M7 10l5 5 5-5',
+      'M12 15V3'
+    ]
+  },
+  clear: {
+    paths: [
+      'M3 6h18',
+      'M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2',
+      'M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6'
+    ]
+  },
+  color: {
+    paths: [
+      'M12 3a9 9 0 1 0 0 18c.8 0 1.4-.6 1.4-1.3 0-.4-.15-.7-.35-1-.2-.3-.35-.65-.35-1.05A1.5 1.5 0 0 1 14.2 16H16a5 5 0 0 0 0-10h-.5'
+    ],
+    circles: [
+      { cx: 7.5, cy: 11.5, r: 1.2, fill: true },
+      { cx: 10.5, cy: 8, r: 1.2, fill: true },
+      { cx: 14.5, cy: 8, r: 1.2, fill: true }
+    ]
+  },
+  add: {
+    paths: ['M12 5v14M5 12h14']
+  },
+  plus: {
+    paths: ['M12 5v14M5 12h14']
+  },
+  check: {
+    paths: ['M20 6L9 17l-5-5']
+  }
+};
+
+/**
+ * Create a decorative SVG icon element (aria-hidden).
+ * @param {string} name - key in SVG_ICON_DEFS
+ * @param {number} [size=16]
+ * @returns {SVGElement}
+ */
+function createSvgIcon(name, size) {
+  size = size == null ? 16 : size;
+  var def = SVG_ICON_DEFS[name] || SVG_ICON_DEFS.note;
+  var svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('width', String(size));
+  svg.setAttribute('height', String(size));
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.setAttribute('focusable', 'false');
+  svg.setAttribute('class', 'svg-icon svg-icon-' + name);
+
+  if (def.fill) {
+    svg.setAttribute('fill', 'currentColor');
+  } else {
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', def.strokeWidth || '1.75');
+    svg.setAttribute('stroke-linecap', 'round');
+    svg.setAttribute('stroke-linejoin', 'round');
+  }
+
+  var i;
+  var paths = def.paths || [];
+  for (i = 0; i < paths.length; i++) {
+    var path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('d', paths[i]);
+    if (def.fill) path.setAttribute('fill', 'currentColor');
+    svg.appendChild(path);
+  }
+
+  var circles = def.circles || [];
+  for (i = 0; i < circles.length; i++) {
+    var c = circles[i];
+    var circle = document.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('cx', String(c.cx));
+    circle.setAttribute('cy', String(c.cy));
+    circle.setAttribute('r', String(c.r));
+    if (def.fill || c.fill) {
+      circle.setAttribute('fill', 'currentColor');
+      if (!def.fill) circle.setAttribute('stroke', 'none');
+    }
+    svg.appendChild(circle);
+  }
+
+  return svg;
+}
+
+/** Alias for createSvgIcon */
+function svgIcon(name, size) {
+  return createSvgIcon(name, size);
+}
+
 function generateNoteId() {
   return Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
 }
@@ -621,7 +792,7 @@ function renderWidgetNotes(size) {
     empty.className = 'notes-empty';
     var emptyIcon = document.createElement('span');
     emptyIcon.className = 'empty-icon';
-    emptyIcon.textContent = '📝';
+    emptyIcon.appendChild(createSvgIcon('note', 28));
     var emptyText = document.createElement('span');
     emptyText.className = 'empty-text';
     emptyText.textContent = t('emptyTitle');
@@ -646,9 +817,9 @@ function renderWidgetNotes(size) {
     if (note.pinned) {
       var pinBadge = document.createElement('span');
       pinBadge.className = 'note-pin-badge';
-      pinBadge.textContent = '📌';
       pinBadge.title = t('pinned');
       pinBadge.setAttribute('aria-label', t('pinned'));
+      pinBadge.appendChild(createSvgIcon('pin', 10));
       content.appendChild(pinBadge);
     }
 
@@ -667,9 +838,9 @@ function renderWidgetNotes(size) {
     var deleteBtn = document.createElement('button');
     deleteBtn.className = 'note-delete';
     deleteBtn.type = 'button';
-    deleteBtn.textContent = '×';
     deleteBtn.title = t('delete');
     deleteBtn.setAttribute('aria-label', t('delete'));
+    deleteBtn.appendChild(createSvgIcon('close', 14));
     deleteBtn.addEventListener('click', function(e) {
       e.stopPropagation();
       deleteWidgetNote(note.id, size);
@@ -928,7 +1099,7 @@ function renderEmptyState(area, isSearch) {
 
   var icon = document.createElement('div');
   icon.className = 'empty-icon';
-  icon.textContent = isSearch ? '🔍' : '📝';
+  icon.appendChild(createSvgIcon(isSearch ? 'search' : 'note', 40));
 
   var title = document.createElement('div');
   title.className = 'empty-title';
@@ -1139,9 +1310,9 @@ function renderPageNotes() {
     if (note.pinned) {
       var pinMark = document.createElement('span');
       pinMark.className = 'sticky-pin-mark';
-      pinMark.textContent = '📌';
       pinMark.title = t('pinned');
       pinMark.setAttribute('aria-label', t('pinned'));
+      pinMark.appendChild(createSvgIcon('pin', 12));
       sticky.appendChild(pinMark);
     }
 
@@ -1228,7 +1399,10 @@ function renderExpandOverlay() {
   if (note.pinned) {
     var pin = document.createElement('span');
     pin.className = 'note-expand-pin';
-    pin.textContent = '📌 ' + t('pinned');
+    pin.appendChild(createSvgIcon('pin', 12));
+    var pinLabel = document.createElement('span');
+    pinLabel.textContent = t('pinned');
+    pin.appendChild(pinLabel);
     headerLeft.appendChild(pin);
   }
   if (pageState.settings.showTimestamp) {
@@ -1241,9 +1415,9 @@ function renderExpandOverlay() {
   var closeBtn = document.createElement('button');
   closeBtn.type = 'button';
   closeBtn.className = 'note-expand-close';
-  closeBtn.textContent = '×';
   closeBtn.title = t('close');
   closeBtn.setAttribute('aria-label', t('close'));
+  closeBtn.appendChild(createSvgIcon('close', 16));
   closeBtn.addEventListener('click', function() {
     closeNoteExpand();
   });

--- a/apps/com.myriad.quick-notes/manifest.json
+++ b/apps/com.myriad.quick-notes/manifest.json
@@ -29,7 +29,7 @@
       "id": "notes",
       "name": "便签",
       "description": "快速查看和添加笔记",
-      "icon": "📝",
+      "icon": "note",
       "defaultSize": "2x2",
       "sizes": ["2x2", "4x2", "4x4"],
       "refreshPolicy": {

--- a/apps/com.myriad.quick-notes/page.css
+++ b/apps/com.myriad.quick-notes/page.css
@@ -221,10 +221,15 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
   color: white;
   flex-shrink: 0;
   transition: var(--notes-transition);
+}
+
+.status-avatar svg {
+  width: 16px;
+  height: 16px;
+  display: block;
 }
 
 .status-info {
@@ -412,12 +417,13 @@
   background: rgba(var(--notes-primary-rgb), 0.14);
   color: var(--notes-primary);
   font-weight: 600;
+  box-shadow: inset 3px 0 0 var(--notes-primary);
 }
 
+/* Selected sort: border indicator (no emoji check) */
 .status-menu-item.active::after {
-  content: '✓';
-  font-size: 12px;
-  color: var(--notes-primary);
+  content: '';
+  display: none;
 }
 
 .status-menu-item-danger {
@@ -508,10 +514,23 @@
   position: absolute;
   top: 6px;
   left: 8px;
-  font-size: 12px;
   line-height: 1;
   z-index: 2;
   pointer-events: none;
+  color: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sticky-pin-mark svg {
+  width: 12px;
+  height: 12px;
+  display: block;
+}
+
+.dark .sticky-pin-mark {
+  color: rgba(255, 255, 255, 0.55);
 }
 
 /* 便利贴颜色变体 */
@@ -872,6 +891,16 @@
 .note-expand-pin {
   font-size: 12px;
   color: var(--sticky-text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.note-expand-pin svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  opacity: 0.85;
 }
 
 .note-expand-time {
@@ -888,9 +917,18 @@
   background: rgba(0, 0, 0, 0.08);
   color: rgba(0, 0, 0, 0.55);
   cursor: pointer;
-  font-size: 18px;
   line-height: 1;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.note-expand-close svg {
+  width: 16px;
+  height: 16px;
+  display: block;
 }
 
 .dark .note-expand-close {
@@ -1001,9 +1039,31 @@
 }
 
 .notes-empty-state .empty-icon {
-  font-size: 48px;
   line-height: 1;
-  opacity: 0.7;
+  opacity: 0.55;
+  color: var(--notes-text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.notes-empty-state .empty-icon svg {
+  width: 40px;
+  height: 40px;
+  display: block;
+}
+
+/* Shared decorative SVG icons */
+.svg-icon {
+  display: block;
+  flex-shrink: 0;
+  pointer-events: none;
+}
+
+.status-action-btn svg {
+  width: 16px;
+  height: 16px;
+  display: block;
 }
 
 .notes-empty-state .empty-title {

--- a/apps/com.myriad.quick-notes/page.html
+++ b/apps/com.myriad.quick-notes/page.html
@@ -15,7 +15,13 @@
     <!-- 浮动状态胶囊（含搜索） -->
     <header class="status-header">
       <div id="status-pill" class="status-pill">
-        <div class="status-avatar">📝</div>
+        <div class="status-avatar" aria-hidden="true">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M8 2v3M16 2v3M3 9h18"/>
+            <path d="M21 8.5V17c0 3-1.5 5-5 5H8c-3.5 0-5-2-5-5V8.5c0-3 1.5-5 5-5h8c3.5 0 5 2 5 5z"/>
+            <path d="M8 14h4M8 18h8"/>
+          </svg>
+        </div>
         <div class="status-info">
           <span id="status-title" class="status-title"></span>
           <span id="status-subtitle" class="status-subtitle"></span>
@@ -26,7 +32,7 @@
         </div>
         <div class="status-actions">
           <button id="search-toggle" class="status-action-btn" type="button" title="Search" aria-label="Search">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <circle cx="11" cy="11" r="8"/>
               <path d="M21 21l-4.35-4.35"/>
             </svg>
@@ -73,7 +79,7 @@
           </div>
         </div>
         <button id="page-send" class="page-send-btn" type="button" title="Add" aria-label="Add">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M12 5v14M5 12h14"/>
           </svg>
         </button>

--- a/apps/com.myriad.quick-notes/widget-2x2.html
+++ b/apps/com.myriad.quick-notes/widget-2x2.html
@@ -10,7 +10,13 @@
     <!-- 头部 -->
     <div class="widget-header">
       <div class="widget-pill">
-        <span class="pill-icon">📝</span>
+        <span class="pill-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M8 2v3M16 2v3M3 9h18"/>
+            <path d="M21 8.5V17c0 3-1.5 5-5 5H8c-3.5 0-5-2-5-5V8.5c0-3 1.5-5 5-5h8c3.5 0 5 2 5 5z"/>
+            <path d="M8 14h4M8 18h8"/>
+          </svg>
+        </span>
         <span class="pill-text" id="widget-title"></span>
       </div>
       <span class="widget-count" id="widget-count">0</span>
@@ -24,7 +30,11 @@
     <!-- 输入区 -->
     <div class="widget-input-row">
       <input type="text" id="widget-input" placeholder="..." autocomplete="off">
-      <button id="widget-add" title="Add">+</button>
+      <button id="widget-add" type="button" title="Add" aria-label="Add">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 5v14M5 12h14"/>
+        </svg>
+      </button>
     </div>
   </div>
 </div>

--- a/apps/com.myriad.quick-notes/widget-4x2.html
+++ b/apps/com.myriad.quick-notes/widget-4x2.html
@@ -11,7 +11,13 @@
     <!-- 头部 -->
     <div class="widget-header">
       <div class="widget-pill">
-        <span class="pill-icon">📝</span>
+        <span class="pill-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M8 2v3M16 2v3M3 9h18"/>
+            <path d="M21 8.5V17c0 3-1.5 5-5 5H8c-3.5 0-5-2-5-5V8.5c0-3 1.5-5 5-5h8c3.5 0 5 2 5 5z"/>
+            <path d="M8 14h4M8 18h8"/>
+          </svg>
+        </span>
         <span class="pill-text" id="widget-title"></span>
       </div>
       <span class="widget-count" id="widget-count">0</span>
@@ -25,7 +31,11 @@
     <!-- 输入区 -->
     <div class="widget-input-row">
       <input type="text" id="widget-input" placeholder="..." autocomplete="off">
-      <button id="widget-add" title="Add">+</button>
+      <button id="widget-add" type="button" title="Add" aria-label="Add">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 5v14M5 12h14"/>
+        </svg>
+      </button>
     </div>
   </div>
 </div>

--- a/apps/com.myriad.quick-notes/widget-4x4.html
+++ b/apps/com.myriad.quick-notes/widget-4x4.html
@@ -11,7 +11,13 @@
     <!-- 头部 -->
     <div class="widget-header">
       <div class="widget-pill">
-        <span class="pill-icon">📝</span>
+        <span class="pill-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M8 2v3M16 2v3M3 9h18"/>
+            <path d="M21 8.5V17c0 3-1.5 5-5 5H8c-3.5 0-5-2-5-5V8.5c0-3 1.5-5 5-5h8c3.5 0 5 2 5 5z"/>
+            <path d="M8 14h4M8 18h8"/>
+          </svg>
+        </span>
         <span class="pill-text" id="widget-title"></span>
       </div>
       <span class="widget-count" id="widget-count">0</span>
@@ -25,7 +31,11 @@
     <!-- 输入区 -->
     <div class="widget-input-row">
       <input type="text" id="widget-input" placeholder="..." autocomplete="off">
-      <button id="widget-add" title="Add">+</button>
+      <button id="widget-add" type="button" title="Add" aria-label="Add">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 5v14M5 12h14"/>
+        </svg>
+      </button>
     </div>
   </div>
 </div>

--- a/apps/com.myriad.quick-notes/widget.css
+++ b/apps/com.myriad.quick-notes/widget.css
@@ -206,7 +206,17 @@
 }
 
 .pill-icon {
-  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--notes-primary);
+  flex-shrink: 0;
+}
+
+.pill-icon svg {
+  width: 14px;
+  height: 14px;
+  display: block;
 }
 
 .pill-text {
@@ -316,9 +326,18 @@
   position: absolute;
   top: -2px;
   right: 0;
-  font-size: 10px;
   line-height: 1;
   opacity: 0.9;
+  color: var(--notes-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.note-pin-badge svg {
+  width: 10px;
+  height: 10px;
+  display: block;
 }
 
 .note-text {
@@ -352,10 +371,16 @@
   border-radius: 50%;
   cursor: pointer;
   color: var(--notes-text-muted);
-  font-size: 16px;
   opacity: 0;
   transition: var(--notes-transition);
   flex-shrink: 0;
+  padding: 0;
+}
+
+.note-delete svg {
+  width: 14px;
+  height: 14px;
+  display: block;
 }
 
 /* 支持 hover 的设备：悬停时显示删除 */
@@ -406,8 +431,23 @@
 }
 
 .empty-icon {
-  font-size: 32px;
-  opacity: 0.6;
+  opacity: 0.55;
+  color: var(--notes-text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.empty-icon svg {
+  width: 28px;
+  height: 28px;
+  display: block;
+}
+
+.svg-icon {
+  display: block;
+  flex-shrink: 0;
+  pointer-events: none;
 }
 
 .empty-text {
@@ -470,8 +510,14 @@
     0 4px 12px rgba(var(--notes-primary-rgb), 0.35),
     0 1px 3px rgba(0, 0, 0, 0.1);
   color: white;
-  font-size: 20px;
-  font-weight: 300;
+  padding: 0;
+}
+
+.widget-input-row button svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+  stroke: white;
 }
 
 .widget-input-row button:hover {


### PR DESCRIPTION
## Summary
Replace all user-facing emoji/symbol UI icons in `com.myriad.quick-notes` (便携便签) with consistent inline SVGs (`stroke="currentColor"`, 24 viewBox), matching the existing search/menu icon style in `page.html`.

- Add `createSvgIcon` / `svgIcon` helpers in `main.js` with reusable paths (note, search, pin, pinOff, copy, expand, edit, delete, close, more, export, import, clear, color, add/plus, check)
- Decorative SVGs are `aria-hidden`; buttons keep i18n `aria-label` / `title`
- Version stays **1.0.0** (no bump)
- README decorative emoji left as-is

## Icons replaced
| Location | Before | After |
|----------|--------|-------|
| Page status avatar | 📝 | note SVG |
| Widget pill (2x2/4x2/4x4) | 📝 | note SVG |
| Widget empty state | 📝 | note SVG |
| Page empty state | 📝 / 🔍 | note / search SVG |
| Sticky pin mark | 📌 | pin SVG |
| Widget pin badge | 📌 | pin SVG |
| Expand overlay pin prefix | 📌 + text | pin SVG + i18n text |
| Widget delete | × | close SVG |
| Expand close | × | close SVG |
| Widget add button | + | plus SVG |
| Sort menu selected | `content: '✓'` | left border selected state |
| Manifest `widgets[].icon` | 📝 | `"note"` (string, non-emoji) |

## Tests
- `node` parse check of `main.js` (OK)
- Manifest JSON parse + version `1.0.0` verified
- Grep: no runtime emoji icons remain outside README

## Risks / follow-ups
- Host display of `widgets[].icon` as plain `"note"` may show text if the host renders that field literally; templates already use SVG for on-screen UI.
- Pin/expand/edit/copy/menu behaviors unchanged at the event-handler level.