### PR TITLE
feat(config-generator): polish UI and replace emoji with SVG

### DIFF
--- a/apps/com.myriad.config-generator/page.css
+++ b/apps/com.myriad.config-generator/page.css
@@ -169,9 +169,9 @@
 
 .page-content {
   position: relative;
-  max-width: 800px;
+  max-width: 840px;
   margin: 0 auto;
-  padding: 20px 20px 40px;
+  padding: 20px 20px 48px;
 }
 
 /* ========================================
@@ -182,8 +182,8 @@
   display: inline-flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 18px;
-  margin-bottom: 24px;
+  padding: 12px 18px 12px 12px;
+  margin-bottom: 20px;
   background: var(--config-surface-elevated);
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
@@ -201,7 +201,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
+  flex-shrink: 0;
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(var(--config-primary-rgb), 0.28);
+}
+
+.header-icon svg {
+  display: block;
   flex-shrink: 0;
 }
 
@@ -209,6 +215,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 
 .header-title {
@@ -216,12 +223,15 @@
   font-size: 15px;
   font-weight: 600;
   color: var(--config-text);
+  letter-spacing: -0.01em;
+  line-height: 1.3;
 }
 
 .header-subtitle {
   margin: 0;
   font-size: 12px;
   color: var(--config-text-secondary);
+  line-height: 1.35;
 }
 
 /* ========================================
@@ -231,7 +241,7 @@
 .config-form {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 .form-section {
@@ -242,32 +252,47 @@
   border-radius: var(--config-radius);
   padding: 20px;
   box-shadow: var(--config-shadow);
-  transition: var(--config-transition);
+  transition: border-color var(--config-transition), box-shadow var(--config-transition);
 }
 
 .form-section:hover {
-  border-color: rgba(var(--config-primary-rgb), 0.2);
+  border-color: rgba(var(--config-primary-rgb), 0.22);
+  box-shadow: var(--config-shadow), 0 0 0 1px rgba(var(--config-primary-rgb), 0.04);
 }
 
 .section-title {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin: 0 0 16px;
+  margin: 0 0 8px;
   font-size: 15px;
   font-weight: 600;
   color: var(--config-text);
+  letter-spacing: -0.01em;
 }
 
 .section-icon {
-  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border-radius: 9px;
+  background: rgba(var(--config-primary-rgb), 0.1);
+  color: var(--config-primary);
+  border: 1px solid rgba(var(--config-primary-rgb), 0.14);
+}
+
+.section-icon svg {
+  display: block;
 }
 
 .section-desc {
-  margin: -8px 0 16px;
+  margin: 0 0 16px;
   font-size: 13px;
   color: var(--config-text-secondary);
-  line-height: 1.5;
+  line-height: 1.55;
 }
 
 /* ========================================
@@ -321,14 +346,32 @@
 }
 
 .advanced-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
-  font-size: 11px;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
   color: var(--config-text-muted);
-  transition: transform var(--config-transition);
+  background: var(--config-input-bg);
+  border: 1px solid var(--config-border);
+  transition: transform var(--config-transition), color var(--config-transition), border-color var(--config-transition);
+}
+
+.advanced-chevron svg {
+  display: block;
 }
 
 .advanced-panel[open] > .advanced-summary .advanced-chevron {
   transform: rotate(180deg);
+  color: var(--config-primary);
+  border-color: rgba(var(--config-primary-rgb), 0.25);
+  background: rgba(var(--config-primary-rgb), 0.08);
+}
+
+.advanced-summary:hover .advanced-chevron {
+  color: var(--config-primary);
 }
 
 .advanced-panel[open] > .advanced-summary {
@@ -382,13 +425,26 @@
 }
 
 .section-warning-icon {
-  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
-  margin-top: 1px;
+  width: 28px;
+  height: 28px;
+  margin-top: 0;
+  border-radius: 8px;
+  color: var(--config-warning);
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.22);
+}
+
+.section-warning-icon svg {
+  display: block;
 }
 
 .section-warning-content {
   flex: 1;
+  min-width: 0;
 }
 
 .section-warning-title {
@@ -559,13 +615,26 @@
 }
 
 .section-info-icon {
-  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
-  margin-top: 1px;
+  width: 28px;
+  height: 28px;
+  margin-top: 0;
+  border-radius: 8px;
+  color: var(--config-primary);
+  background: rgba(var(--config-primary-rgb), 0.12);
+  border: 1px solid rgba(var(--config-primary-rgb), 0.18);
+}
+
+.section-info-icon svg {
+  display: block;
 }
 
 .section-info-content {
   flex: 1;
+  min-width: 0;
 }
 
 .section-info-title {
@@ -613,10 +682,30 @@
 }
 
 .resource-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 13px;
   font-weight: 600;
   color: var(--config-text);
-  margin-bottom: 12px;
+  margin-bottom: 8px;
+}
+
+.resource-label-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: 7px;
+  color: var(--config-primary);
+  background: rgba(var(--config-primary-rgb), 0.1);
+  border: 1px solid rgba(var(--config-primary-rgb), 0.12);
+}
+
+.resource-label-icon svg {
+  display: block;
 }
 
 .resource-group .form-row {
@@ -771,18 +860,28 @@
 }
 
 .upload-success .btn-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
   background: none;
   border: none;
+  border-radius: 6px;
   color: var(--config-text-muted);
-  font-size: 18px;
   cursor: pointer;
-  padding: 0 4px;
+  padding: 0;
   line-height: 1;
   transition: var(--config-transition);
 }
 
+.upload-success .btn-remove svg {
+  display: block;
+}
+
 .upload-success .btn-remove:hover {
   color: var(--config-error);
+  background: rgba(239, 68, 68, 0.1);
 }
 
 /* ========================================
@@ -792,7 +891,10 @@
 .form-actions {
   display: flex;
   justify-content: center;
-  padding-top: 8px;
+  padding-top: 4px;
+  position: sticky;
+  bottom: 12px;
+  z-index: 5;
 }
 
 .btn-primary {
@@ -808,11 +910,12 @@
   font-weight: 600;
   cursor: pointer;
   transition: var(--config-transition);
-  box-shadow: 0 4px 12px rgba(var(--config-primary-rgb), 0.3);
+  box-shadow: 0 8px 24px rgba(var(--config-primary-rgb), 0.35), 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .btn-primary svg {
   stroke: white;
+  flex-shrink: 0;
 }
 
 .btn-primary:hover {
@@ -840,10 +943,15 @@
   animation: fadeSlideIn 0.4s ease-out;
 }
 
+.results-intro {
+  margin: -4px 0 16px !important;
+  padding: 0 4px;
+}
+
 @keyframes fadeSlideIn {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(16px);
   }
   to {
     opacity: 1;
@@ -855,8 +963,8 @@
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  margin: 0 0 20px;
-  padding: 10px 16px;
+  margin: 0 0 12px;
+  padding: 10px 16px 10px 12px;
   background: var(--config-surface-elevated);
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
@@ -867,28 +975,52 @@
   color: var(--config-text);
 }
 
+.results-title-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: #fff;
+  background: linear-gradient(135deg, var(--config-primary), var(--config-secondary));
+  box-shadow: 0 3px 10px rgba(var(--config-primary-rgb), 0.28);
+}
+
+.results-title-icon svg {
+  display: block;
+}
+
 .result-card {
   background: var(--config-surface);
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
   border: 1px solid var(--config-border);
   border-radius: var(--config-radius);
-  margin-bottom: 16px;
+  margin-bottom: 14px;
   overflow: hidden;
   box-shadow: var(--config-shadow);
   animation: fadeSlideIn 0.4s ease-out backwards;
 }
 
-.result-card:nth-child(2) {
-  animation-delay: 0.1s;
+.result-card:last-child {
+  margin-bottom: 0;
 }
 
 .result-card:nth-child(3) {
-  animation-delay: 0.2s;
+  animation-delay: 0.05s;
 }
 
 .result-card:nth-child(4) {
-  animation-delay: 0.3s;
+  animation-delay: 0.1s;
+}
+
+.result-card:nth-child(5) {
+  animation-delay: 0.15s;
+}
+
+.result-card:nth-child(6) {
+  animation-delay: 0.2s;
 }
 
 .result-header {
@@ -896,23 +1028,36 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 10px;
-  padding: 14px 16px;
-  background: rgba(var(--config-primary-rgb), 0.03);
+  padding: 12px 14px;
+  background: rgba(var(--config-primary-rgb), 0.04);
   border-bottom: 1px solid var(--config-border);
 }
 
 .dark .result-header {
-  background: rgba(255, 255, 255, 0.02);
+  background: rgba(255, 255, 255, 0.03);
 }
 
 .result-icon {
-  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  color: var(--config-primary);
+  background: rgba(var(--config-primary-rgb), 0.1);
+  border: 1px solid rgba(var(--config-primary-rgb), 0.14);
+}
+
+.result-icon svg {
+  display: block;
 }
 
 .result-name {
   flex: 1;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 13px;
+  font-weight: 600;
   color: var(--config-text);
   font-family: 'SF Mono', Monaco, 'Consolas', monospace;
   min-width: 0;
@@ -989,18 +1134,23 @@
 
 @media (max-width: 640px) {
   .page-content {
-    padding: 16px 12px 32px;
+    padding: 16px 12px 40px;
   }
   
   .page-header {
-    padding: 10px 14px;
+    padding: 10px 14px 10px 10px;
     gap: 10px;
+    max-width: 100%;
   }
   
   .header-icon {
     width: 32px;
     height: 32px;
-    font-size: 16px;
+  }
+
+  .header-icon svg {
+    width: 16px;
+    height: 16px;
   }
   
   .header-title {
@@ -1019,6 +1169,12 @@
   .section-title {
     font-size: 14px;
   }
+
+  .section-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+  }
   
   .form-input {
     padding: 10px 12px;
@@ -1035,6 +1191,10 @@
     justify-content: center;
     padding: 12px 24px;
     font-size: 14px;
+  }
+
+  .form-actions {
+    bottom: 8px;
   }
   
   .result-header {

--- a/apps/com.myriad.config-generator/page.html
+++ b/apps/com.myriad.config-generator/page.html
@@ -12,7 +12,13 @@
   <div class="page-content">
     <!-- 标题区域 - 胶囊样式 -->
     <header class="page-header">
-      <div class="header-icon">⚙️</div>
+      <div class="header-icon" aria-hidden="true">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+          <polyline points="14 2 14 8 20 8"/>
+          <path d="M12 18v-6M9 15l3 3 3-3"/>
+        </svg>
+      </div>
       <div class="header-info">
         <h1 class="header-title">Myriad 安装配置生成</h1>
         <p class="header-subtitle">生成 Compose、.env、Nginx 和部署说明</p>
@@ -21,7 +27,12 @@
 
     <!-- 架构提示 -->
     <div class="section-info">
-      <span class="section-info-icon">ℹ️</span>
+      <span class="section-info-icon" aria-hidden="true">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10"/>
+          <path d="M12 16v-4M12 8h.01"/>
+        </svg>
+      </span>
       <div class="section-info-content">
         <span class="section-info-title">用途</span>
         为新的自托管 Myriad 生成启动配置、密钥、Nginx 配置和部署步骤。<br>
@@ -34,7 +45,13 @@
       <!-- 域名配置 -->
       <section class="form-section">
         <h2 class="section-title">
-          <span class="section-icon">🌐</span>
+          <span class="section-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M2 12h20"/>
+              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+            </svg>
+          </span>
           域名配置
         </h2>
         <p class="section-desc">
@@ -59,7 +76,13 @@
       <!-- 数据库 -->
       <section class="form-section">
         <h2 class="section-title">
-          <span class="section-icon">🗄️</span>
+          <span class="section-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <ellipse cx="12" cy="5" rx="9" ry="3"/>
+              <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>
+              <path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3"/>
+            </svg>
+          </span>
           数据库
         </h2>
         <p class="section-desc">
@@ -88,7 +111,7 @@
             <div class="input-with-action">
               <input type="text" id="db-password" class="form-input" placeholder="自动生成，也可自行填写" autocomplete="off">
               <button type="button" id="gen-db-password" class="btn-generate" title="生成随机密码">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
                 </svg>
               </button>
@@ -101,7 +124,12 @@
       <!-- 安全配置 -->
       <section class="form-section">
         <h2 class="section-title">
-          <span class="section-icon">🔐</span>
+          <span class="section-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+              <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
+          </span>
           安全配置
         </h2>
         <p class="section-desc">
@@ -112,7 +140,7 @@
           <div class="input-with-action">
             <input type="text" id="jwt-secret" class="form-input" placeholder="点击生成或自行填写（≥32 字符）" autocomplete="off">
             <button type="button" id="gen-jwt-secret" class="btn-generate" title="生成随机密钥">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
               </svg>
             </button>
@@ -126,7 +154,7 @@
           <div class="input-with-action">
             <input type="text" id="update-token" class="form-input" placeholder="点击生成或自行填写（≥32 字符）" autocomplete="off">
             <button type="button" id="gen-update-token" class="btn-generate" title="生成 UPDATE_TOKEN">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
               </svg>
             </button>
@@ -140,7 +168,14 @@
       <!-- 版本与更新器 -->
       <section class="form-section">
         <h2 class="section-title">
-          <span class="section-icon">🚀</span>
+          <span class="section-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
+              <path d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
+              <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
+              <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
+            </svg>
+          </span>
           版本与更新器
         </h2>
         <p class="section-desc">
@@ -149,7 +184,7 @@
         <div class="tag-status-row">
           <span id="tag-status" class="tag-status">正在获取最新版本…</span>
           <button type="button" id="btn-refresh-tags" class="btn-secondary" title="从 Docker Hub 刷新">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
             </svg>
             刷新最新版本
@@ -178,13 +213,22 @@
       <details class="advanced-panel form-section">
         <summary class="advanced-summary">
           <span class="advanced-summary-main">
-            <span class="section-icon">⚙️</span>
+            <span class="section-icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="3"/>
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+              </svg>
+            </span>
             <span class="advanced-summary-text">
               <span class="advanced-summary-title">高级选项</span>
               <span class="advanced-summary-sub">通道、签名、端口和资源限制</span>
             </span>
           </span>
-          <span class="advanced-chevron" aria-hidden="true">▼</span>
+          <span class="advanced-chevron" aria-hidden="true">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </span>
         </summary>
         <div class="advanced-body">
           <p class="section-desc">
@@ -238,7 +282,12 @@
           </div>
 
           <div class="section-warning">
-            <span class="section-warning-icon">📌</span>
+            <span class="section-warning-icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+                <circle cx="12" cy="10" r="3"/>
+              </svg>
+            </span>
             <div class="section-warning-content">
               <span class="section-warning-title">内网端口（固定，不要映射到公网）</span>
               frontend <code>1102</code> · backend <code>1103</code> · updater <code>1101</code> · postgres <code>5432</code>
@@ -251,7 +300,16 @@
           </p>
 
           <div class="resource-group">
-            <div class="resource-label">🗄️ PostgreSQL（数据库）</div>
+            <div class="resource-label">
+              <span class="resource-label-icon" aria-hidden="true">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <ellipse cx="12" cy="5" rx="9" ry="3"/>
+                  <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>
+                  <path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3"/>
+                </svg>
+              </span>
+              <span>PostgreSQL（数据库）</span>
+            </div>
             <p class="resource-desc">保存用户和业务数据。</p>
             <div class="form-row">
               <div class="form-group form-group-half">
@@ -268,7 +326,15 @@
           </div>
 
           <div class="resource-group">
-            <div class="resource-label">⚙️ Backend（后端 API）</div>
+            <div class="resource-label">
+              <span class="resource-label-icon" aria-hidden="true">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="2" y="3" width="20" height="14" rx="2"/>
+                  <path d="M8 21h8M12 17v4"/>
+                </svg>
+              </span>
+              <span>Backend（后端 API）</span>
+            </div>
             <p class="resource-desc">处理接口、同步和分析任务。</p>
             <div class="form-row">
               <div class="form-group form-group-half">
@@ -285,7 +351,15 @@
           </div>
 
           <div class="resource-group">
-            <div class="resource-label">🎨 Frontend（前端静态站）</div>
+            <div class="resource-label">
+              <span class="resource-label-icon" aria-hidden="true">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="3" y="3" width="18" height="18" rx="2"/>
+                  <path d="M3 9h18M9 21V9"/>
+                </svg>
+              </span>
+              <span>Frontend（前端静态站）</span>
+            </div>
             <p class="resource-desc">提供网页界面。</p>
             <div class="form-row">
               <div class="form-group form-group-half">
@@ -306,7 +380,15 @@
       <!-- Nginx 配置上传 -->
       <section class="form-section">
         <h2 class="section-title">
-          <span class="section-icon">📄</span>
+          <span class="section-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+              <polyline points="14 2 14 8 20 8"/>
+              <line x1="16" y1="13" x2="8" y2="13"/>
+              <line x1="16" y1="17" x2="8" y2="17"/>
+              <line x1="10" y1="9" x2="8" y2="9"/>
+            </svg>
+          </span>
           外层 Nginx（可选）
         </h2>
         <p class="section-desc">
@@ -314,7 +396,13 @@
         </p>
 
         <div class="section-warning">
-          <span class="section-warning-icon">⚠️</span>
+          <span class="section-warning-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+              <line x1="12" y1="9" x2="12" y2="13"/>
+              <line x1="12" y1="17" x2="12.01" y2="17"/>
+            </svg>
+          </span>
           <div class="section-warning-content">
             <span class="section-warning-title">上传要求</span>
             上传该域名的站点配置会保留 SSL，并补齐 Myriad 代理；不要上传包含其他站点的完整 nginx.conf。
@@ -328,18 +416,23 @@
             <div class="upload-box" id="upload-nginx-conf">
               <input type="file" id="file-nginx-conf" accept=".conf" hidden>
               <div class="upload-placeholder">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
                 </svg>
                 <span>点击上传或拖拽 .conf</span>
               </div>
               <div class="upload-success" hidden>
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
                   <polyline points="22 4 12 14.01 9 11.01"/>
                 </svg>
                 <span class="file-name"></span>
-                <button type="button" class="btn-remove" title="移除">×</button>
+                <button type="button" class="btn-remove" title="移除" aria-label="移除">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="18" y1="6" x2="6" y2="18"/>
+                    <line x1="6" y1="6" x2="18" y2="18"/>
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -350,18 +443,23 @@
             <div class="upload-box" id="upload-extra-nginx-conf">
               <input type="file" id="file-extra-nginx-conf" accept=".conf" hidden>
               <div class="upload-placeholder">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
                 </svg>
                 <span>可选：额外域名的 .conf</span>
               </div>
               <div class="upload-success" hidden>
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
                   <polyline points="22 4 12 14.01 9 11.01"/>
                 </svg>
                 <span class="file-name"></span>
-                <button type="button" class="btn-remove" title="移除">×</button>
+                <button type="button" class="btn-remove" title="移除" aria-label="移除">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="18" y1="6" x2="6" y2="18"/>
+                    <line x1="6" y1="6" x2="18" y2="18"/>
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -371,8 +469,10 @@
       <!-- 生成按钮 -->
       <div class="form-actions">
         <button type="button" id="btn-generate-all" class="btn-primary">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M12 5v14M5 12h14"/>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <polyline points="14 2 14 8 20 8"/>
+            <path d="M12 18v-6M9 15l3 3 3-3"/>
           </svg>
           生成配置文件
         </button>
@@ -381,26 +481,42 @@
 
     <!-- 生成结果 -->
     <div id="results-section" class="results-section" hidden>
-      <h2 class="results-title">📦 生成结果</h2>
-      <p class="section-desc" style="margin: -8px 0 16px; padding: 0 4px;">
+      <h2 class="results-title">
+        <span class="results-title-icon" aria-hidden="true">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
+            <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
+            <line x1="12" y1="22.08" x2="12" y2="12"/>
+          </svg>
+        </span>
+        生成结果
+      </h2>
+      <p class="section-desc results-intro">
         1Panel：复制 docker-compose.yml 到“编排”，复制 .env 到“环境变量”。
       </p>
 
       <!-- Docker Compose -->
       <div class="result-card">
         <div class="result-header">
-          <span class="result-icon">🐳</span>
+          <span class="result-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="2" y="2" width="20" height="8" rx="2"/>
+              <rect x="2" y="14" width="20" height="8" rx="2"/>
+              <line x1="6" y1="6" x2="6.01" y2="6"/>
+              <line x1="6" y1="18" x2="6.01" y2="18"/>
+            </svg>
+          </span>
           <span class="result-name">docker-compose.yml</span>
           <span class="result-badge">服务编排 · 启动用</span>
           <button type="button" class="btn-copy" data-target="docker-compose">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
             </svg>
             复制
           </button>
           <button type="button" class="btn-download" data-filename="docker-compose.yml" data-target="docker-compose">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
             </svg>
             下载
@@ -412,18 +528,22 @@
       <!-- .env -->
       <div class="result-card">
         <div class="result-header">
-          <span class="result-icon">🔑</span>
+          <span class="result-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/>
+            </svg>
+          </span>
           <span class="result-name">环境变量（.env）</span>
           <span class="result-badge">1Panel 环境变量框 · 勿公开</span>
           <button type="button" class="btn-copy" data-target="env">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
             </svg>
             复制到 1Panel
           </button>
           <button type="button" class="btn-download" data-filename=".env" data-target="env">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
             </svg>
             下载
@@ -435,18 +555,26 @@
       <!-- Main Nginx Config -->
       <div class="result-card" id="card-main-nginx">
         <div class="result-header">
-          <span class="result-icon">📄</span>
+          <span class="result-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+              <polyline points="14 2 14 8 20 8"/>
+              <line x1="16" y1="13" x2="8" y2="13"/>
+              <line x1="16" y1="17" x2="8" y2="17"/>
+              <line x1="10" y1="9" x2="8" y2="9"/>
+            </svg>
+          </span>
           <span class="result-name" id="name-main-nginx">example.com.conf</span>
           <span class="result-badge">外层反代 · 主域名</span>
           <button type="button" class="btn-copy" data-target="main-nginx">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
             </svg>
             复制
           </button>
           <button type="button" class="btn-download" data-filename="main.conf" data-target="main-nginx">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
             </svg>
             下载
@@ -458,18 +586,26 @@
       <!-- Extra Nginx Config -->
       <div class="result-card" id="card-extra-nginx" hidden>
         <div class="result-header">
-          <span class="result-icon">📄</span>
+          <span class="result-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+              <polyline points="14 2 14 8 20 8"/>
+              <line x1="16" y1="13" x2="8" y2="13"/>
+              <line x1="16" y1="17" x2="8" y2="17"/>
+              <line x1="10" y1="9" x2="8" y2="9"/>
+            </svg>
+          </span>
           <span class="result-name" id="name-extra-nginx">www.example.com.conf</span>
           <span class="result-badge">外层反代 · 额外域名</span>
           <button type="button" class="btn-copy" data-target="extra-nginx">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
             </svg>
             复制
           </button>
           <button type="button" class="btn-download" data-filename="extra.conf" data-target="extra-nginx">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
             </svg>
             下载
@@ -481,18 +617,23 @@
       <!-- Deploy notes -->
       <div class="result-card">
         <div class="result-header">
-          <span class="result-icon">📘</span>
+          <span class="result-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
+              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+            </svg>
+          </span>
           <span class="result-name">DEPLOY.md</span>
           <span class="result-badge">部署步骤 · 请先读</span>
           <button type="button" class="btn-copy" data-target="deploy-notes">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
             </svg>
             复制
           </button>
           <button type="button" class="btn-download" data-filename="DEPLOY.md" data-target="deploy-notes">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
             </svg>
             下载


### PR DESCRIPTION
## Summary
- Optimize `com.myriad.config-generator` page UI: clearer section hierarchy, icon badges, sticky generate action, refined spacing/shadows.
- Replace all page UI emojis with inline stroke SVGs (`currentColor`), consistent with quick-notes icon style.
- **Version kept at `1.0.0`** (no version bump).

## Files
- `apps/com.myriad.config-generator/page.html`
- `apps/com.myriad.config-generator/page.css`

## Notes
- Generated config comments in `main.js` still use `✅` as plain text in output files (not UI chrome).
- Manifest / store version fields unchanged.

## Test plan
- [ ] Install/open 安装配置生成 from store
- [ ] Confirm header/section/info/warning/result icons render as SVG in light and dark mode
- [ ] Generate config and verify copy/download still work
- [ ] Check mobile layout for form rows and result cards