### PR TITLE
fix(music-player): larger lyrics + FX-off on mobile only

### DIFF
--- a/apps/com.myriad.music-player/main.js
+++ b/apps/com.myriad.music-player/main.js
@@ -257,10 +257,10 @@ function shouldAnimate() {
   return pageState.animConfig.shouldAnimate && pageState.animConfig.level !== 'none';
 }
 
-// 动态视觉效果是否启用：用户开关 ∧ 系统 shouldAnimate
-// 列表 EQ（updateListEq）不经此门控；歌词/UI 微动画亦不受影响
+// 动态视觉效果是否启用：用户开关 ∧ 系统 shouldAnimate ∧ 非移动端
+// 移动端强制关闭 Aurora / 涟漪 / 背景漂移；列表 EQ / 歌词微动画不经此门控
 function visualFxEnabled() {
-  return pageState.visualFxOn && shouldAnimate();
+  return pageState.visualFxOn && shouldAnimate() && !checkIsMobile();
 }
 
 // 系统动画级别为 light：降级重视觉（涟漪/背景漂移关闭，Aurora 简化）
@@ -269,9 +269,9 @@ function isAnimLight() {
   return pageState.animConfig.level === 'light';
 }
 
-// 播放中 + FX 开时挂 will-change 合成层；暂停/关 FX 时卸下以释放层
+// 播放中 + FX 有效启用时挂 will-change 合成层；暂停/关 FX/移动端时卸下
 function syncFxCompositing() {
-  var on = !!(pageState.visualFxOn && shouldAnimate() &&
+  var on = !!(visualFxEnabled() &&
     pageState.status && pageState.status.isPlaying);
   document.documentElement.classList.toggle('fx-compositing', on);
 }
@@ -293,7 +293,7 @@ var pageState = {
   hasTranslation: false,   // 当前歌曲是否有翻译数据
   transLang: '',           // 翻译语言（'zh' | ''）
   transOn: false,          // 翻译显示开关（持久化于 Tapp.storage）
-  visualFxOn: false,       // 动态视觉效果强制关闭（不再从 storage 恢复；开关 UI 已隐藏）
+  visualFxOn: true,        // 动态视觉效果开关（持久化于 Tapp.storage，默认开；移动端运行时强制 off）
   lyricWordFrame: null,    // 逐字高亮 rAF 句柄
   lastKaraokeLine: -1,     // 上一次做逐字填充的行索引
   eqFrame: null,           // 视觉/EQ 循环 rAF 句柄
@@ -559,12 +559,15 @@ function setLyricTransOn(on) {
 function syncVisualFxUI() {
   var btn = $('visual-fx-btn');
   if (btn) {
+    // 按钮态反映用户偏好（桌面可点）；移动端按钮由 CSS 隐藏
     btn.classList.toggle('active', pageState.visualFxOn);
     btn.title = t('visualFx');
     btn.setAttribute('aria-label', t('visualFx'));
     btn.setAttribute('aria-pressed', pageState.visualFxOn ? 'true' : 'false');
   }
-  document.documentElement.classList.toggle('visual-fx-off', !pageState.visualFxOn);
+  // 移动端始终挂 visual-fx-off；桌面按用户偏好
+  var effectiveOn = pageState.visualFxOn && !checkIsMobile();
+  document.documentElement.classList.toggle('visual-fx-off', !effectiveOn);
 }
 
 // 清除进行中的节奏涟漪动画
@@ -591,18 +594,50 @@ function dimAurora() {
 }
 
 function setVisualFxOn(on) {
-  // 产品策略：强制关闭 Aurora / 节奏涟漪 / 背景漂移；忽略传入 true
-  var next = false;
+  var next = !!on;
   var prev = pageState.visualFxOn;
   pageState.visualFxOn = next;
   syncVisualFxUI();
   if (prev === next) return;
-  // 关闭时：停背景漂移、清涟漪、熄 Aurora
-  stopBackgroundAnimation();
-  clearRhythmRipples();
-  dimAurora();
+  // 移动端仅更新偏好与 UI 类；运行时 FX 始终关
+  if (checkIsMobile() || !next) {
+    stopBackgroundAnimation();
+    clearRhythmRipples();
+    dimAurora();
+  } else if (pageState.status && pageState.status.isPlaying && shouldAnimate()) {
+    // 桌面打开：重同步拍点 + 重启背景漂移
+    resyncBeatGridIdx();
+    startBackgroundAnimation();
+  }
   syncFxCompositing();
   // 调度模式随 FX 切换（60fps ↔ 低帧率维护），立即取消旧句柄并重入
+  if (pageState.status && pageState.status.isPlaying) restartEqLoop();
+}
+
+// 视口跨移动/桌面边界时：移动强制收敛 FX；桌面按偏好恢复
+var lastVisualFxMobile = null;
+function applyVisualFxViewportPolicy() {
+  var mobile = checkIsMobile();
+  if (lastVisualFxMobile === mobile) {
+    syncVisualFxUI();
+    return;
+  }
+  lastVisualFxMobile = mobile;
+  syncVisualFxUI();
+  if (mobile) {
+    stopBackgroundAnimation();
+    clearRhythmRipples();
+    dimAurora();
+    syncFxCompositing();
+    if (pageState.status && pageState.status.isPlaying) restartEqLoop();
+    return;
+  }
+  // 切回桌面：按用户偏好恢复
+  if (pageState.visualFxOn && pageState.status && pageState.status.isPlaying && shouldAnimate()) {
+    resyncBeatGridIdx();
+    startBackgroundAnimation();
+  }
+  syncFxCompositing();
   if (pageState.status && pageState.status.isPlaying) restartEqLoop();
 }
 
@@ -3262,8 +3297,18 @@ function bindControls() {
     });
   }
 
-  // 动态视觉效果开关已强制关闭并隐藏；保留 DOM 路径但不绑定切换
-  
+  // 动态视觉效果开关（桌面可点；移动端 CSS 隐藏且 visualFxEnabled 强制 off）
+  var visualFxBtn = document.getElementById('visual-fx-btn');
+  if (visualFxBtn) {
+    addClickHandler(visualFxBtn, function() {
+      if (checkIsMobile()) return;
+      setVisualFxOn(!pageState.visualFxOn);
+      if (Tapp.storage && Tapp.storage.set) {
+        Tapp.storage.set('visualFxOn', pageState.visualFxOn).catch(function() {});
+      }
+    });
+  }
+
   // 窗口大小变化时重置状态 - 使用节流（统一处理所有 resize 逻辑）
   var resizeTimeout = null;
   window.addEventListener('resize', function() {
@@ -3277,6 +3322,8 @@ function bindControls() {
       refreshPlaylistView();
       // 歌词波浪引擎布局随尺寸重测（否则旧布局被 measured 锁死）
       relayoutLyricsIfNeeded();
+      // 移动↔桌面：强制/恢复背景特效策略
+      applyVisualFxViewportPolicy();
       // 全局移动端缓存会在 checkIsMobile 调用时自动更新
       if (!isMobile() && playerRight) {
         playerRight.classList.remove('mobile-visible');
@@ -4399,15 +4446,22 @@ function cleanup() {
         // 应用初始主题（深色/浅色模式）
         applyTheme(results[1]);
         
-        // 动效强制关闭（不从 storage 恢复 true）；须在 initPage 前挂上 visual-fx-off
-        setVisualFxOn(false);
-
         await initPage();
 
-        // 恢复翻译开关偏好（持久化；storage 权限已在 manifest 声明）
+        // 同步动效按钮文案/高亮；移动端再强制 visual-fx-off
+        syncVisualFxUI();
+        applyVisualFxViewportPolicy();
+
+        // 恢复翻译 / 动效开关偏好（持久化；storage 权限已在 manifest 声明）
+        // 桌面可读 storage；移动端偏好仍保存，但运行时 FX 强制关
         if (Tapp.storage && Tapp.storage.get) {
           Tapp.storage.get('lyricTransOn').then(function(v) {
             if (v === true || v === 'true') setLyricTransOn(true);
+          }).catch(function() {});
+          Tapp.storage.get('visualFxOn').then(function(v) {
+            // 默认 true；仅显式 false 时关闭（移动端仍只更新偏好，不启 FX）
+            if (v === false || v === 'false') setVisualFxOn(false);
+            else applyVisualFxViewportPolicy();
           }).catch(function() {});
         }
 

--- a/apps/com.myriad.music-player/main.js
+++ b/apps/com.myriad.music-player/main.js
@@ -293,7 +293,7 @@ var pageState = {
   hasTranslation: false,   // 当前歌曲是否有翻译数据
   transLang: '',           // 翻译语言（'zh' | ''）
   transOn: false,          // 翻译显示开关（持久化于 Tapp.storage）
-  visualFxOn: true,        // 动态视觉效果开关（持久化于 Tapp.storage，默认开）
+  visualFxOn: false,       // 动态视觉效果强制关闭（不再从 storage 恢复；开关 UI 已隐藏）
   lyricWordFrame: null,    // 逐字高亮 rAF 句柄
   lastKaraokeLine: -1,     // 上一次做逐字填充的行索引
   eqFrame: null,           // 视觉/EQ 循环 rAF 句柄
@@ -591,21 +591,16 @@ function dimAurora() {
 }
 
 function setVisualFxOn(on) {
-  var next = !!on;
+  // 产品策略：强制关闭 Aurora / 节奏涟漪 / 背景漂移；忽略传入 true
+  var next = false;
   var prev = pageState.visualFxOn;
   pageState.visualFxOn = next;
   syncVisualFxUI();
   if (prev === next) return;
-  if (!next) {
-    // 播放中途关闭：停背景漂移、清涟漪、熄 Aurora
-    stopBackgroundAnimation();
-    clearRhythmRipples();
-    dimAurora();
-  } else if (pageState.status && pageState.status.isPlaying && shouldAnimate()) {
-    // 播放中途打开：重同步拍点索引（关 FX 时未逐帧 gridTick）+ 重启背景漂移
-    resyncBeatGridIdx();
-    startBackgroundAnimation();
-  }
+  // 关闭时：停背景漂移、清涟漪、熄 Aurora
+  stopBackgroundAnimation();
+  clearRhythmRipples();
+  dimAurora();
   syncFxCompositing();
   // 调度模式随 FX 切换（60fps ↔ 低帧率维护），立即取消旧句柄并重入
   if (pageState.status && pageState.status.isPlaying) restartEqLoop();
@@ -3267,16 +3262,7 @@ function bindControls() {
     });
   }
 
-  // 动态视觉效果开关（常显，与翻译按钮同组）
-  var visualFxBtn = document.getElementById('visual-fx-btn');
-  if (visualFxBtn) {
-    addClickHandler(visualFxBtn, function() {
-      setVisualFxOn(!pageState.visualFxOn);
-      if (Tapp.storage && Tapp.storage.set) {
-        Tapp.storage.set('visualFxOn', pageState.visualFxOn).catch(function() {});
-      }
-    });
-  }
+  // 动态视觉效果开关已强制关闭并隐藏；保留 DOM 路径但不绑定切换
   
   // 窗口大小变化时重置状态 - 使用节流（统一处理所有 resize 逻辑）
   var resizeTimeout = null;
@@ -4413,19 +4399,15 @@ function cleanup() {
         // 应用初始主题（深色/浅色模式）
         applyTheme(results[1]);
         
+        // 动效强制关闭（不从 storage 恢复 true）；须在 initPage 前挂上 visual-fx-off
+        setVisualFxOn(false);
+
         await initPage();
 
-        // 同步动效按钮文案/高亮（默认开；storage 再覆盖）
-        syncVisualFxUI();
-
-        // 恢复翻译 / 动效开关偏好（持久化；storage 权限已在 manifest 声明）
+        // 恢复翻译开关偏好（持久化；storage 权限已在 manifest 声明）
         if (Tapp.storage && Tapp.storage.get) {
           Tapp.storage.get('lyricTransOn').then(function(v) {
             if (v === true || v === 'true') setLyricTransOn(true);
-          }).catch(function() {});
-          Tapp.storage.get('visualFxOn').then(function(v) {
-            // 默认 true；仅显式 false 时关闭
-            if (v === false || v === 'false') setVisualFxOn(false);
           }).catch(function() {});
         }
 

--- a/apps/com.myriad.music-player/page.css
+++ b/apps/com.myriad.music-player/page.css
@@ -4,8 +4,8 @@
    CSS 变量 - 动态主题色（从封面颜色同步）
    ======================================== */
 :root {
-  /* 歌词基准字号：手机 34px → 平板随宽度 → 桌面 44px（全部消费方共用此变量） */
-  --lyric-fs: clamp(34px, 5.5vw, 44px);
+  /* 歌词基准字号：桌面 26→40px；移动端在 max-width:768 内覆盖加大 */
+  --lyric-fs: clamp(26px, 5vw, 40px);
   /* 动态音乐颜色 - 由 JS 从播放器的封面颜色同步 */
   --music-primary: #fc3c44;
   --music-secondary: #ff6b6b;
@@ -832,11 +832,6 @@ html, body {
 
 .lyric-corner-btn[hidden] {
   display: none;
-}
-
-/* 动效开关已强制关闭：移动端/桌面端均隐藏，不再提供用户开关 */
-#visual-fx-btn {
-  display: none !important;
 }
 
 /* 动效关闭：冻结/隐藏 Aurora 与涟漪；列表 EQ 与静态封面模糊不受影响 */
@@ -1893,6 +1888,16 @@ html, body {
    响应式设计 - 移动端优先
    ======================================== */
 @media (max-width: 768px) {
+  /* 仅移动端：歌词字号明显加大（桌面仍用 :root 原 clamp） */
+  :root {
+    --lyric-fs: clamp(34px, 5.5vw, 44px);
+  }
+
+  /* 仅移动端：隐藏动效开关（桌面保留可点） */
+  #visual-fx-btn {
+    display: none !important;
+  }
+
   #tapp-content {
     grid-template-rows: 1fr auto;
     gap: 6px;

--- a/apps/com.myriad.music-player/page.css
+++ b/apps/com.myriad.music-player/page.css
@@ -4,8 +4,8 @@
    CSS 变量 - 动态主题色（从封面颜色同步）
    ======================================== */
 :root {
-  /* 歌词基准字号：手机 26px → 平板随宽度 → 桌面 40px（全部消费方共用此变量） */
-  --lyric-fs: clamp(26px, 5vw, 40px);
+  /* 歌词基准字号：手机 34px → 平板随宽度 → 桌面 44px（全部消费方共用此变量） */
+  --lyric-fs: clamp(34px, 5.5vw, 44px);
   /* 动态音乐颜色 - 由 JS 从播放器的封面颜色同步 */
   --music-primary: #fc3c44;
   --music-secondary: #ff6b6b;
@@ -832,6 +832,11 @@ html, body {
 
 .lyric-corner-btn[hidden] {
   display: none;
+}
+
+/* 动效开关已强制关闭：移动端/桌面端均隐藏，不再提供用户开关 */
+#visual-fx-btn {
+  display: none !important;
 }
 
 /* 动效关闭：冻结/隐藏 Aurora 与涟漪；列表 EQ 与静态封面模糊不受影响 */
@@ -2013,7 +2018,7 @@ html, body {
   .lyric-interlude {
     left: 12px;
     right: 12px;
-    height: calc(1.35 * var(--lyric-fs, 26px) + 16px);
+    height: calc(1.35 * var(--lyric-fs, 34px) + 16px);
     padding: 8px 6px;
   }
   

--- a/apps/com.myriad.music-player/page.html
+++ b/apps/com.myriad.music-player/page.html
@@ -74,9 +74,9 @@
         <div class="lyrics-scroll" id="lyrics-container">
           <div class="lyrics-empty" id="lyrics-empty">暂无歌词</div>
         </div>
-        <!-- 右下角浮钮组：动效开关（强制关闭并隐藏）+ 翻译开关（有翻译时显示） -->
+        <!-- 右下角浮钮组：动效开关（桌面常显；移动端 CSS 隐藏）+ 翻译开关（有翻译时显示） -->
         <div class="lyrics-corner-btns" id="lyrics-corner-btns">
-          <button class="lyric-corner-btn" id="visual-fx-btn" hidden aria-hidden="true" aria-label="动效" aria-pressed="false" title="动效">
+          <button class="lyric-corner-btn active" id="visual-fx-btn" aria-label="动效" aria-pressed="true" title="动效">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 2.2l1.05 3.15L16.2 6.4l-3.15 1.05L12 10.6l-1.05-3.15L7.8 6.4l3.15-1.05L12 2.2z"/>
               <path d="M18.2 11.2l.72 2.16 2.16.72-2.16.72-.72 2.16-.72-2.16-2.16-.72 2.16-.72.72-2.16z"/>

--- a/apps/com.myriad.music-player/page.html
+++ b/apps/com.myriad.music-player/page.html
@@ -74,9 +74,9 @@
         <div class="lyrics-scroll" id="lyrics-container">
           <div class="lyrics-empty" id="lyrics-empty">暂无歌词</div>
         </div>
-        <!-- 右下角浮钮组：动效开关（常显）+ 翻译开关（有翻译时显示） -->
+        <!-- 右下角浮钮组：动效开关（强制关闭并隐藏）+ 翻译开关（有翻译时显示） -->
         <div class="lyrics-corner-btns" id="lyrics-corner-btns">
-          <button class="lyric-corner-btn active" id="visual-fx-btn" aria-label="动效" aria-pressed="true" title="动效">
+          <button class="lyric-corner-btn" id="visual-fx-btn" hidden aria-hidden="true" aria-label="动效" aria-pressed="false" title="动效">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 2.2l1.05 3.15L16.2 6.4l-3.15 1.05L12 10.6l-1.05-3.15L7.8 6.4l3.15-1.05L12 2.2z"/>
               <path d="M18.2 11.2l.72 2.16 2.16.72-2.16.72-.72 2.16-.72-2.16-2.16-.72 2.16-.72.72-2.16z"/>


### PR DESCRIPTION
## Summary
Mobile-only adjustments for `com.myriad.music-player` (desktop behavior unchanged).

1. **Larger lyrics (mobile only)**
   - `:root` keeps original `--lyric-fs: clamp(26px, 5vw, 40px)`
   - `@media (max-width: 768px)` overrides to `clamp(34px, 5.5vw, 44px)`
   - Mobile `.lyric-interlude` fallback aligned to 34px

2. **Background FX force-off + hide toggle (mobile only)**
   - CSS: `#visual-fx-btn { display: none }` only inside mobile media query
   - JS: `visualFxEnabled()` requires `!checkIsMobile()`; preference `visualFxOn` + storage still work on desktop
   - `applyVisualFxViewportPolicy()` on init/resize: mobile forces off Aurora/ripples/drift; desktop restores user preference

## Scope
`apps/com.myriad.music-player/` — `page.css`, `page.html`, `main.js`

## How mobile-only is guaranteed
| Concern | Desktop (>768) | Mobile (≤768) |
|---------|----------------|---------------|
| Lyric size | original clamp 26–40 | clamp 34–44 via media query |
| FX toggle button | visible, clickable | CSS `display:none` |
| Aurora / ripples / drift | user toggle + storage | forced off (`visualFxEnabled` + `visual-fx-off`) |
| storage `visualFxOn` | read/write | preference kept; runtime FX still off |

Breakpoint aligns CSS `max-width: 768px` with JS `checkIsMobile()` (`innerWidth <= 768`).

## Test plan
- [ ] **Desktop ≥769px**: lyric size matches pre-change; FX button visible; toggle on/off persists via storage; Aurora/ripples/drift work when on
- [ ] **Mobile ≤768px**: lyrics clearly larger; FX button hidden; no Aurora/ripples/bg drift while playing
- [ ] **Resize across 768**: mobile→desktop restores preference FX; desktop→mobile force-off + hide button

## Risks
- Preference stored while on mobile is applied when returning to desktop (intended).