### PR TITLE
feat(config-generator): v1.1 hardened docker-guard + updater-gateway topology

### DIFF
--- a/apps/com.myriad.config-generator/README.md
+++ b/apps/com.myriad.config-generator/README.md
@@ -1,18 +1,33 @@
 # Myriad 安装配置生成
 
-填写部署参数，生成 Compose、环境变量与 Nginx 配置。
+填写部署参数，生成与官方生产拓扑一致的 hardened Compose、环境变量与 Nginx 配置。
 
 ## 功能
 
-- `docker-compose.yml`：启动全部服务
-- `.env`：保存密钥、域名和版本
+- `docker-compose.yml`：proxy + frontend + backend + postgres + **docker-guard** + **updater** + **updater-gateway**
+- `.env`：密钥（含 `UPDATE_TOKEN`、`UPDATER_GATEWAY_SECRET`）、域名与 versioned 镜像 tag
 - Nginx 配置：将 HTTPS 流量转到 proxy
-- `DEPLOY.md`：启动、更新和救援步骤
+- `DEPLOY.md`：启动、拓扑、doctor、救援与 volume 权限提示
+
+## 安全拓扑（v1.1）
+
+| 网络 | 成员 | 说明 |
+|------|------|------|
+| `myriad-net` | proxy, frontend, backend, postgres | 业务平面 |
+| `myriad-admin-net` | backend, updater, updater-gateway, proxy | 管理平面 |
+| `myriad-docker-guard-net` (internal) | updater, docker-guard | 唯一 docker.sock 路径 |
+
+要点：
+
+- **仅 docker-guard** 挂载 `/var/run/docker.sock`；updater 经 `DOCKER_HOST=tcp://docker-guard:2375` 访问
+- **backend 不持有 `UPDATE_TOKEN`**，只持有 `UPDATER_GATEWAY_SECRET`，经 `http://updater-gateway:1104` 更新
+- backend 以非 root（uid 1000）运行；可用 `scripts/docker/deploy.sh` chown named volumes
+- 禁止 `:latest`；镜像 tag 从 Docker Hub 解析 versioned 标签
 
 ## 使用方法
 
 1. 填写域名。
-2. 设置 PostgreSQL 版本、数据库名和用户名，确认自动生成的密钥。
+2. 设置 PostgreSQL 版本、数据库名和用户名，确认自动生成的密钥（含网关密钥）。
 3. 如有现成的 Nginx SSL 配置，可选择上传。
 4. 点击“生成配置文件”并下载结果。
 
@@ -23,8 +38,8 @@ Nginx 请上传当前域名的站点配置，不要上传包含其他站点的�
 
 | 文件 | 说明 |
 |------|------|
-| `docker-compose.yml` | 服务编排 |
-| `.env` | 密钥、域名和版本 |
+| `docker-compose.yml` | hardened 服务编排 |
+| `.env` | 密钥、域名和版本（勿提交 Git） |
 | `<domain>.conf` | HTTPS 反向代理 |
 | `DEPLOY.md` | 部署步骤 |
 
@@ -36,11 +51,15 @@ chmod 600 .env
 docker compose up -d
 ```
 
+可选：源码仓库内 `scripts/docker/deploy.sh up`（补齐目录并对 backend volume chown）。
+
 ## 注意事项
 
-- 不要公开或提交 `.env`。
+- 不要公开或提交 `.env`（含 `UPDATE_TOKEN` 与 `UPDATER_GATEWAY_SECRET`）。
 - 1Panel 默认只在 `127.0.0.1:8080` 提供 proxy；也可选择所有网卡和其他端口。
+- 不要映射 docker-guard:2375、updater-gateway:1104、updater:1101 等到公网。
 - Nginx 只反代到 proxy，不要开放其他服务端口。
 - PostgreSQL 默认使用 18，数据库名、用户名、密码、CPU 和内存都可设置。
 - 更换 PostgreSQL 主版本前需先迁移数据。
 - 不要使用 `:latest` 镜像标签。
+- `COSIGN_VERIFY=off` 时需在 `.env` 额外设置双钥匙之一：`UPDATER_ALLOW_INSECURE_COSIGN=true` 或 `COSIGN_INSECURE_OK=true`。

--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -1,5 +1,5 @@
-// Myriad Config Generator v1.0.0
-// 生成 proxy + updater 单运行槽生产部署配置
+// Myriad Config Generator v1.1.0
+// 生成 hardened 生产部署配置（docker-guard + updater-gateway + 三网络）
 // 对齐 Myriad docker-compose.yml / .env.production.example / docs/updater-spec.md
 // 镜像 tag 在运行时从 Docker Hub 解析最新 versioned 标签（禁止 :latest）
 
@@ -8,14 +8,20 @@
 // ========================================
 
 // 与官方 docker-compose.yml 对齐：proxy 唯一宿主端口、pgdata bind mount、
-// 镜像 tag 由 .env 中 MYRIAD_TAG/PROXY_TAG/UPDATER_TAG 驱动。
-var DOCKER_COMPOSE_TEMPLATE = `# Myriad Docker Compose (v2 — proxy + updater)
+// docker-guard（唯一持有 docker.sock）、updater-gateway、三网络隔离、
+// backend 不持有 UPDATE_TOKEN，镜像 tag 由 .env 中 MYRIAD_TAG/PROXY_TAG/UPDATER_TAG 驱动。
+var DOCKER_COMPOSE_TEMPLATE = `# Myriad Docker Compose (v1.1 — hardened: proxy + docker-guard + updater-gateway)
 # 由 Myriad 安装配置生成器生成
 #
 # 架构:
+#   myriad-net:        proxy, frontend, backend, postgres
+#   myriad-admin-net:  backend, updater, updater-gateway, proxy (rescue)
+#   myriad-docker-guard-net (internal): updater, docker-guard
+#
 #   proxy (\${HTTP_BIND_ADDRESS:-127.0.0.1}:\${HTTP_PORT:-8080}) ──┬──► frontend:1102
 #                              └──► backend:1103 ──► postgres
-#   updater (内网) — 快照 pgdata / 切换版本 tag / 维护模式
+#                                     │
+#                                     └──► updater-gateway:1104 ──► updater ──► docker-guard ──► docker.sock
 #
 # 升级: 管理后台 → 关于 → 更新管理
 # 文档: docs/updater-spec.md / docs/UPDATER_QUICKSTART.md
@@ -24,7 +30,7 @@ var DOCKER_COMPOSE_TEMPLATE = `# Myriad Docker Compose (v2 — proxy + updater)
 #   1. 将本文件与 .env 放在同一目录
 #   2. mkdir -p pgdata state state/snapshots state/cache backups
 #   3. docker compose up -d
-#   或使用仓库 scripts/docker/deploy.sh up
+#   或使用仓库 scripts/docker/deploy.sh up（会 chown backend named volumes）
 
 services:
   postgres:
@@ -104,9 +110,10 @@ services:
       RUST_LOG: \${RUST_LOG:-info}
       TZ: Asia/Shanghai
       MYRIAD_VERSION: \${MYRIAD_TAG}
-      # backend 持有 UPDATE_TOKEN，浏览器只走 admin session
-      MYRIAD_UPDATER_URL: http://updater:1101
-      UPDATE_TOKEN: \${UPDATE_TOKEN}
+      # Server-side updater proxy: backend → updater-gateway（注入 X-Update-Token）。
+      # backend 不持有 UPDATE_TOKEN，只持有 UPDATER_GATEWAY_SECRET。
+      MYRIAD_UPDATER_URL: http://updater-gateway:1104
+      UPDATER_GATEWAY_SECRET: \${UPDATER_GATEWAY_SECRET}
     # 不暴露宿主端口；仅 proxy 对外
     depends_on:
       postgres: { condition: service_healthy }
@@ -119,12 +126,13 @@ services:
     volumes:
       - backend_cache:/app/cache
       - backend_data:/app/data
-    networks: [myriad-net]
+    networks: [myriad-net, myriad-admin-net]
     restart: unless-stopped
     security_opt: [no-new-privileges:true]
     read_only: false
     tmpfs: [/tmp]
-    user: "0:0"
+    # 以 Dockerfile USER myriad (uid 1000) 运行；勿强制 user 0:0。
+    # named volumes 需可写：deploy.sh / deploy.ps1 会 chown，或手动 chown 1000:1000。
     logging:
       driver: "json-file"
       options: { max-size: "10m", max-file: "3" }
@@ -171,18 +179,55 @@ services:
       PROXY_STATE_FILE: /state/maintenance.json
       PROXY_BACKEND_UPSTREAM: http://backend:1103
       PROXY_FRONTEND_UPSTREAM: http://frontend:1102
+      # Rescue 路径在 admin-net 上解析 updater（PROXY_ALLOW_DIRECT_UPDATER=true 时）。
       PROXY_UPDATER_UPSTREAM: http://updater:1101
+      # 外层 Nginx/Caddy/CDN 可信上游 IP/CIDR（逗号分隔）
+      PROXY_TRUSTED_UPSTREAMS: \${PROXY_TRUSTED_UPSTREAMS:-}
       # 默认关闭 /_updater/* 直连；推荐 /api/admin/updater/*
       PROXY_ALLOW_DIRECT_UPDATER: \${PROXY_ALLOW_DIRECT_UPDATER:-false}
       MYRIAD_VERSION: \${PROXY_TAG}
       TZ: Asia/Shanghai
     volumes:
       - ./state:/state:ro
-    networks: [myriad-net]
+    # 业务网 + admin-net（rescue 仍可解析 updater）
+    networks: [myriad-net, myriad-admin-net]
     restart: unless-stopped
     security_opt: [no-new-privileges:true]
     read_only: true
     tmpfs: [/tmp]
+    logging:
+      driver: "json-file"
+      options: { max-size: "10m", max-file: "3" }
+
+  docker-guard:
+    # 唯一挂载宿主 docker.sock 的服务。校验 Docker API 后再转发到守护进程。
+    image: \${UPDATER_IMAGE:-docker.io/somekawahitomi/myriad-updater}:\${UPDATER_TAG}
+    container_name: myriad-docker-guard
+    entrypoint: ["/usr/bin/tini", "--", "/usr/local/bin/myriad-docker-guard"]
+    environment:
+      UPDATE_TOKEN: \${UPDATE_TOKEN}
+      COMPOSE_PROJECT_NAME: \${COMPOSE_PROJECT_NAME:-myriad}
+      MYRIAD_DOCKER_NETWORK: \${MYRIAD_DOCKER_NETWORK:-myriad-net}
+      MYRIAD_ADMIN_NETWORK: \${MYRIAD_ADMIN_NETWORK:-myriad-admin-net}
+      MYRIAD_DOCKER_GUARD_NETWORK: \${MYRIAD_DOCKER_GUARD_NETWORK:-myriad-docker-guard-net}
+      DOCKER_GUARD_COMPOSE_DIR: /host/compose
+      DOCKER_GUARD_ENV_FILE: /host/compose/.env
+      DOCKER_GUARD_ALLOWED_IMAGES: \${BACKEND_IMAGE:-docker.io/somekawahitomi/myriad-backend},\${FRONTEND_IMAGE:-docker.io/somekawahitomi/myriad-frontend},\${UPDATER_IMAGE:-docker.io/somekawahitomi/myriad-updater},postgres
+      RUST_LOG: \${DOCKER_GUARD_LOG:-info}
+      TZ: Asia/Shanghai
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./:/host/compose:ro
+    networks: [myriad-docker-guard-net]
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    tmpfs: [/tmp, /run]
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:2375/_ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     logging:
       driver: "json-file"
       options: { max-size: "10m", max-file: "3" }
@@ -197,22 +242,55 @@ services:
       REGISTRY_MIRROR: \${REGISTRY_MIRROR:-}
       MYRIAD_GITHUB_REPO: \${MYRIAD_GITHUB_REPO:-Myriad-You/Myriad}
       CHECK_INTERVAL_SECS: \${CHECK_INTERVAL_SECS:-3600}
+      UPDATER_STATE_DIR: /host/compose/state
       UPDATER_ENV_FILE: /host/compose/.env
-      # 当前 updater 的安全默认值是 strict
+      # 走 compose 根 bind 内的路径，避免独立 pgdata 挂载点 rename EBUSY
+      UPDATER_PGDATA: /host/compose/pgdata
+      UPDATER_COMPOSE_DIR: /host/compose
+      DOCKER_HOST: tcp://docker-guard:2375
+      DOCKER_GUARD_SELF_UPDATE_URL: http://docker-guard:2375/_myriad/self-update
+      # cosign: strict（默认）| soft | off
+      # off 时需同时设 UPDATER_ALLOW_INSECURE_COSIGN=true 或 COSIGN_INSECURE_OK=true
       COSIGN_VERIFY: \${COSIGN_VERIFY:-strict}
+      UPDATER_ALLOW_INSECURE_COSIGN: \${UPDATER_ALLOW_INSECURE_COSIGN:-}
+      COSIGN_INSECURE_OK: \${COSIGN_INSECURE_OK:-}
       COMPOSE_PROJECT_NAME: \${COMPOSE_PROJECT_NAME:-myriad}
       MYRIAD_DOCKER_NETWORK: \${MYRIAD_DOCKER_NETWORK:-myriad-net}
       MYRIAD_VERSION: \${UPDATER_TAG}
       TZ: Asia/Shanghai
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./pgdata:/host/pgdata
-      - ./state:/state
-      - ./backups:/backups
+      # 单一部署根 bind；state / snapshots / pgdata / .env 均在 /host/compose 下
       - ./:/host/compose
-    networks: [myriad-net]
+    # admin-net 连 gateway/backend/proxy；guard-net 连 docker-guard。不进 myriad-net。
+    networks: [myriad-admin-net, myriad-docker-guard-net]
+    depends_on:
+      docker-guard: { condition: service_healthy }
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
     # 故意不设 read_only：需要写 state / 快照 / .env
+    logging:
+      driver: "json-file"
+      options: { max-size: "10m", max-file: "3" }
+
+  updater-gateway:
+    # 与 updater 同镜像；薄代理为 backend 注入 UPDATE_TOKEN。
+    # 仅 admin-net：无 compose bind、无 docker.sock。
+    image: \${UPDATER_IMAGE:-docker.io/somekawahitomi/myriad-updater}:\${UPDATER_TAG}
+    container_name: myriad-updater-gateway
+    entrypoint: ["/usr/bin/tini", "--", "/usr/local/bin/myriad-updater-gateway"]
+    environment:
+      UPDATE_TOKEN: \${UPDATE_TOKEN}
+      UPDATER_GATEWAY_SECRET: \${UPDATER_GATEWAY_SECRET}
+      UPDATER_UPSTREAM: http://updater:1101
+      GATEWAY_LISTEN: 0.0.0.0:1104
+      TZ: Asia/Shanghai
+    networks: [myriad-admin-net]
+    depends_on:
+      - updater
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    tmpfs: [/tmp, /run]
     logging:
       driver: "json-file"
       options: { max-size: "10m", max-file: "3" }
@@ -228,6 +306,14 @@ networks:
     ipam:
       config:
         - subnet: 172.28.0.0/16
+  myriad-admin-net:
+    # 非 internal：backend 双归属业务网 + 管理网；DNS 解析 updater-gateway
+    name: \${MYRIAD_ADMIN_NETWORK:-myriad-admin-net}
+    driver: bridge
+  myriad-docker-guard-net:
+    name: \${MYRIAD_DOCKER_GUARD_NETWORK:-myriad-docker-guard-net}
+    driver: bridge
+    internal: true
 `;
 
 // .env 生产模板（密钥与域名由生成器填入）
@@ -248,14 +334,24 @@ UPDATER_TAG={{UPDATER_TAG}}
 # 业务镜像仓库（不含 tag）。commit 更新与 last-good 回滚固定依赖这两项。
 BACKEND_IMAGE=docker.io/somekawahitomi/myriad-backend
 FRONTEND_IMAGE=docker.io/somekawahitomi/myriad-frontend
+# PROXY_IMAGE=docker.io/somekawahitomi/myriad-proxy
+# UPDATER_IMAGE=docker.io/somekawahitomi/myriad-updater
 
 COMPOSE_PROJECT_NAME=myriad
 
-# 可选：同机多套部署时再改
+# 可选：同机多套部署时再改网络名
 # MYRIAD_DOCKER_NETWORK=myriad-net
+# MYRIAD_ADMIN_NETWORK=myriad-admin-net
+# MYRIAD_DOCKER_GUARD_NETWORK=myriad-docker-guard-net
 
-# Updater API 鉴权 token（≥32 字符，仅服务端持有）
+# Updater API 鉴权 token（≥32 字符）
+# 注入：updater + updater-gateway + docker-guard（自更新）。backend 进程不持有。
 UPDATE_TOKEN={{UPDATE_TOKEN}}
+
+# Backend ↔ updater-gateway 共享密钥（≥32 字符）
+# 注入：backend + updater-gateway。frontend 不持有。
+# 泄露 ≈ 可经 admin-net 上的 gateway 驱动更新（仍优于把 UPDATE_TOKEN 放进 backend）。
+UPDATER_GATEWAY_SECRET={{UPDATER_GATEWAY_SECRET}}
 
 # stable | preview（当前 updater 仅接受这两个值）
 CHANNEL={{CHANNEL}}
@@ -263,7 +359,7 @@ CHANNEL={{CHANNEL}}
 # release（GitHub Release）| commit（CI dev-<sha>）；首次部署默认 release
 UPDATE_MODE=release
 
-# 可选：提升 GitHub API rate limit
+# 可选：提升 GitHub API rate limit / 私有仓库
 # GITHUB_TOKEN=
 
 # 可选：镜像 mirror 前缀
@@ -276,11 +372,19 @@ CHECK_INTERVAL_SECS=3600
 HTTP_BIND_ADDRESS={{HTTP_BIND_ADDRESS}}
 HTTP_PORT={{HTTP_PORT}}
 
+# 可选：外层 Nginx/Caddy/CDN 代理的 IP 或 CIDR（逗号分隔）
+# 只有列出的直接上游才允许通过 X-Forwarded-For / X-Real-IP 传递真实客户端 IP
+# PROXY_TRUSTED_UPSTREAMS=192.0.2.10/32
+
 # 是否启用 /_updater/* 直连救援通道（默认 false，推荐走 admin API）
 PROXY_ALLOW_DIRECT_UPDATER=false
 
 # cosign 签名验证: off | soft | strict
+#   off    - 不验证（需同时设置下方双钥匙之一，见注释）
+#   soft   - 验证失败仅打 warning，不阻止升级
+#   strict - 验证失败直接拒绝升级（默认，推荐生产）
 COSIGN_VERIFY={{COSIGN_VERIFY}}
+{{COSIGN_INSECURE_HINT}}
 
 # -----------------------------------------------------------------------------
 # REQUIRED SECURITY SETTINGS
@@ -310,11 +414,13 @@ PUBLIC_API_URL=
 # =============================================================================
 # 安全检查清单
 # =============================================================================
-# ✅ POSTGRES_PASSWORD / JWT_SECRET / UPDATE_TOKEN 已生成
+# ✅ POSTGRES_PASSWORD / JWT_SECRET / UPDATE_TOKEN / UPDATER_GATEWAY_SECRET 已生成
+# ✅ backend 环境无 UPDATE_TOKEN（仅 UPDATER_GATEWAY_SECRET）
 # ✅ CORS_ORIGINS 为实际 HTTPS 域名
 # ✅ pgdata 为 ./pgdata bind mount（updater 快照依赖）
+# ✅ 仅 proxy 映射宿主端口；勿暴露 guard:2375 / gateway:1104 / updater:1101
 # ✅ 外层 HTTPS 入口代理到 HTTP_PORT，不要直连 backend:1103
-# ✅ .env 权限建议 chmod 600
+# ✅ .env 权限建议 chmod 600，勿提交 Git
 # =============================================================================
 `;
 
@@ -407,7 +513,19 @@ var DEFAULT_EXTRA_NGINX_TEMPLATE = `server {
 // 部署说明（生成结果中的文本卡片）
 var DEPLOY_NOTES_TEMPLATE = `# Myriad 部署说明
 
-将 \`docker-compose.yml\` 和 \`.env\` 放在同一目录。\`.env\` 包含密钥，不要公开或提交到 Git。
+将 \`docker-compose.yml\` 和 \`.env\` 放在同一目录。\`.env\` 含 UPDATE_TOKEN / UPDATER_GATEWAY_SECRET 等密钥，**不要公开或提交到 Git**（建议 \`chmod 600 .env\`）。
+
+## 拓扑（hardened）
+
+| 网络 | 成员 | 说明 |
+|------|------|------|
+| myriad-net | proxy, frontend, backend, postgres | 业务平面 |
+| myriad-admin-net | backend, updater, updater-gateway, proxy | 管理平面（更新 / 救援） |
+| myriad-docker-guard-net (internal) | updater, docker-guard | 唯一可触达 docker.sock 的路径 |
+
+数据流：浏览器 → 外层 HTTPS → proxy → frontend/backend；管理更新：backend → updater-gateway → updater → docker-guard → docker.sock。
+
+**不要**把 docker-guard:2375、updater-gateway:1104、updater:1101、backend:1103、frontend:1102、postgres:5432 映射到公网。仅 proxy 的 \`HTTP_PORT\` 应对宿主开放（1Panel 推荐绑定 127.0.0.1）。
 
 ## 1Panel
 
@@ -427,22 +545,49 @@ docker compose ps
 docker compose logs -f --tail=100
 \`\`\`
 
+### 可选：官方 deploy 脚本
+
+若你从 Myriad 源码仓库部署，可用 \`scripts/docker/deploy.sh up\`（或 Windows 的 \`deploy.ps1\`）。脚本会补齐目录，并 chown backend 的 named volumes（uid 1000），避免非 root backend 写 \`/app/cache\` / \`/app/data\` 失败。
+
+### backend 非 root 与 volume
+
+backend 以 Dockerfile 用户 \`myriad\` (uid 1000) 运行，**不要**再写 \`user: "0:0"\`。若未用 deploy 脚本，首次启动前可：
+
+\`\`\`bash
+# 在 compose 项目目录，确保 named volume 可写（路径因 Docker 驱动而异；
+# 更简单：先 up 再 exec 调整，或直接用 deploy.sh）
+docker compose up -d
+\`\`\`
+
+若 backend 日志出现 permission denied 写 cache/data，用 deploy 脚本重建 volume 权限，或在宿主对对应 volume 执行 \`chown -R 1000:1000\`。
+
+## 健康检查 / doctor
+
+\`\`\`bash
+docker compose ps
+docker compose exec backend wget -qO- http://localhost:1103/health
+# 若镜像内含 doctor：
+docker compose exec updater myriad-doctor
+# 或仓库脚本（源码树内）：
+# scripts/docker/doctor.sh
+\`\`\`
+
 ## HTTPS
 
 - 将 https://{{MAIN_DOMAIN}} 反代到 \`127.0.0.1:{{HTTP_PORT}}\`。
 - proxy 当前监听 \`{{HTTP_BIND_ADDRESS}}:{{HTTP_PORT}}\`；选择 \`127.0.0.1\` 时只能从本机访问。
-- 不要把 backend、frontend、postgres 或 updater 端口暴露到公网。
+- 可选在 \`.env\` 设置 \`PROXY_TRUSTED_UPSTREAMS\` 为外层反代 IP/CIDR。
 
 ## 首次使用和更新
 
 1. 打开 https://{{MAIN_DOMAIN}} 并完成管理员初始化。
-2. 以后在“设置 → 关于 → 更新管理”中升级。
+2. 以后在“设置 → 关于 → 更新管理”中升级（走 backend admin session → updater-gateway，浏览器看不到 UPDATE_TOKEN）。
 
-当前更新通道：\`{{CHANNEL}}\`。
+当前更新通道：\`{{CHANNEL}}\`。cosign 策略：\`{{COSIGN_VERIFY}}\`。
 
 ## 数据库
 
-- 数据保存在 \`./pgdata\`。
+- 数据保存在 \`./pgdata\`（bind mount；updater 快照依赖文件级路径）。
 - 更换 PostgreSQL 主版本前需先执行 \`pg_upgrade\` 或 dump/restore。
 
 ## 救援
@@ -452,13 +597,15 @@ docker exec myriad-updater myriad-rescue status
 docker exec myriad-updater myriad-rescue exit-maintenance --force
 \`\`\`
 
+backend 宕机时，可临时设 \`PROXY_ALLOW_DIRECT_UPDATER=true\` 走 proxy 的 \`/_updater/*\`（默认关闭）。
+
 ## 当前版本
 
 | 变量 | 当前值 | 说明 |
 |------|--------|------|
 | MYRIAD_TAG | {{MYRIAD_TAG}} | backend + frontend |
 | PROXY_TAG | {{PROXY_TAG}} | proxy |
-| UPDATER_TAG | {{UPDATER_TAG}} | 更新器 |
+| UPDATER_TAG | {{UPDATER_TAG}} | updater / docker-guard / updater-gateway |
 
 不要使用 \`:latest\`，否则无法可靠回滚。
 `;
@@ -479,7 +626,7 @@ function generateSecret(length) {
   return out;
 }
 
-// UPDATE_TOKEN：URL-safe 风格（对齐 deploy.sh）
+// UPDATE_TOKEN / UPDATER_GATEWAY_SECRET：URL-safe 风格（对齐 deploy.sh）
 function generateUpdateToken() {
   var charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
   var out = '';
@@ -489,6 +636,10 @@ function generateUpdateToken() {
     out += charset[array[i] % charset.length];
   }
   return out;
+}
+
+function generateUpdaterGatewaySecret() {
+  return generateUpdateToken();
 }
 
 function generateJwtSecret() {
@@ -1009,6 +1160,7 @@ var state = {
   dbPassword: '',
   jwtSecret: '',
   updateToken: '',
+  updaterGatewaySecret: '',
   nginxConfig: null,
   nginxFileName: '',
   extraNginxConfig: null,
@@ -1043,12 +1195,14 @@ function initPage() {
   var dbPasswordInput = document.getElementById('db-password');
   var jwtSecretInput = document.getElementById('jwt-secret');
   var updateTokenInput = document.getElementById('update-token');
+  var gatewaySecretInput = document.getElementById('updater-gateway-secret');
   var dbNameInput = document.getElementById('db-name');
   var dbUserInput = document.getElementById('db-user');
 
   var genDbPasswordBtn = document.getElementById('gen-db-password');
   var genJwtSecretBtn = document.getElementById('gen-jwt-secret');
   var genUpdateTokenBtn = document.getElementById('gen-update-token');
+  var genGatewaySecretBtn = document.getElementById('gen-updater-gateway-secret');
   var generateAllBtn = document.getElementById('btn-generate-all');
 
   var uploadNginx = document.getElementById('upload-nginx-conf');
@@ -1112,6 +1266,13 @@ function initPage() {
     animateButton(genUpdateTokenBtn);
   });
 
+  if (genGatewaySecretBtn && gatewaySecretInput) {
+    genGatewaySecretBtn.addEventListener('click', function() {
+      gatewaySecretInput.value = generateUpdaterGatewaySecret();
+      animateButton(genGatewaySecretBtn);
+    });
+  }
+
   if (refreshTagsBtn) {
     refreshTagsBtn.addEventListener('click', function() {
       // 用户明确刷新：覆盖自动/当前值为最新
@@ -1149,6 +1310,7 @@ function initPage() {
       var dbPassword = dbPasswordInput.value.trim();
       var jwtSecret = jwtSecretInput.value.trim();
       var updateToken = updateTokenInput.value.trim();
+      var gatewaySecret = gatewaySecretInput ? gatewaySecretInput.value.trim() : '';
       var dbName = dbNameInput.value.trim();
       var dbUser = dbUserInput.value.trim();
 
@@ -1200,12 +1362,17 @@ function initPage() {
         updateToken = generateUpdateToken();
         updateTokenInput.value = updateToken;
       }
+      if (!gatewaySecret || gatewaySecret.length < 32) {
+        gatewaySecret = generateUpdaterGatewaySecret();
+        if (gatewaySecretInput) gatewaySecretInput.value = gatewaySecret;
+      }
 
       state.mainDomain = mainDomain;
       state.extraDomain = extraDomain;
       state.dbPassword = dbPassword;
       state.jwtSecret = jwtSecret;
       state.updateToken = updateToken;
+      state.updaterGatewaySecret = gatewaySecret;
       state.dbName = dbName;
       state.dbUser = dbUser;
 
@@ -1323,6 +1490,7 @@ function initPage() {
   genDbPasswordBtn.click();
   genJwtSecretBtn.click();
   genUpdateTokenBtn.click();
+  if (genGatewaySecretBtn) genGatewaySecretBtn.click();
 
   // 启动时解析 Docker Hub 最新 versioned tag（不写死版本号）
   refreshLatestTags(tagInputs, channelSelect, { notify: false });
@@ -1425,6 +1593,10 @@ function generateConfigs() {
     encodeURIComponent(state.dbPassword) +
     '@postgres:5432/' + encodeURIComponent(state.dbName);
 
+  var cosignInsecureHint = state.cosignVerify === 'off'
+    ? '# COSIGN_VERIFY=off 时需双钥匙确认（二选一取消注释）：\n# UPDATER_ALLOW_INSECURE_COSIGN=true\n# COSIGN_INSECURE_OK=true'
+    : '# COSIGN_VERIFY=off 时的双钥匙确认（默认不要设置；二选一即可）：\n# UPDATER_ALLOW_INSECURE_COSIGN=true\n# COSIGN_INSECURE_OK=true';
+
   var map = {
     DB_VERSION: state.dbVersion,
     POSTGRES_DB: state.dbName,
@@ -1439,6 +1611,7 @@ function generateConfigs() {
     DATABASE_URL: databaseUrl,
     JWT_SECRET: state.jwtSecret,
     UPDATE_TOKEN: state.updateToken,
+    UPDATER_GATEWAY_SECRET: state.updaterGatewaySecret,
     MAIN_DOMAIN: state.mainDomain,
     EXTRA_DOMAIN: state.extraDomain || '',
     CORS_ORIGINS: corsOrigins,
@@ -1448,7 +1621,8 @@ function generateConfigs() {
     PROXY_TAG: state.proxyTag,
     UPDATER_TAG: state.updaterTag,
     CHANNEL: state.channel,
-    COSIGN_VERIFY: state.cosignVerify
+    COSIGN_VERIFY: state.cosignVerify,
+    COSIGN_INSECURE_HINT: cosignInsecureHint
   };
 
   var dockerCompose = applyPlaceholders(DOCKER_COMPOSE_TEMPLATE, map);

--- a/apps/com.myriad.config-generator/manifest.json
+++ b/apps/com.myriad.config-generator/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "com.myriad.config-generator",
   "name": "Myriad 安装配置生成",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "minSystemVersion": "0.2.1",
-  "description": "填写部署参数，生成 Compose、环境变量与 Nginx 配置",
+  "description": "生成 hardened 生产 Compose（docker-guard + updater-gateway）、.env 与 Nginx",
   "category": "developer",
   "main": "main.js",
   "author": {

--- a/apps/com.myriad.config-generator/page.html
+++ b/apps/com.myriad.config-generator/page.html
@@ -1,4 +1,4 @@
-<!-- Myriad Config Generator Page v1.0.0 -->
+<!-- Myriad Config Generator Page v1.1.0 -->
 
 <!-- 背景层 -->
 <div id="tapp-background">
@@ -35,8 +35,8 @@
       </span>
       <div class="section-info-content">
         <span class="section-info-title">用途</span>
-        为新的自托管 Myriad 生成启动配置、密钥、Nginx 配置和部署步骤。<br>
-        1Panel：YAML 粘到“编排”，生成的 .env 全文粘到“环境变量”。
+        为新的自托管 Myriad 生成 hardened 生产配置（proxy + docker-guard + updater-gateway、三网络隔离）、密钥、Nginx 与部署步骤。<br>
+        backend 不持有 UPDATE_TOKEN，经 updater-gateway 更新。1Panel：YAML 粘到“编排”，.env 全文粘到“环境变量”。
       </div>
     </div>
 
@@ -160,7 +160,21 @@
             </button>
           </div>
           <span class="form-hint">
-            backend 调用 updater 时使用。不要发到聊天或截图中。
+            注入 updater / updater-gateway / docker-guard。backend 进程不持有。不要发到聊天或截图中。
+          </span>
+        </div>
+        <div class="form-group">
+          <label for="updater-gateway-secret">网关共享密钥 (UPDATER_GATEWAY_SECRET)</label>
+          <div class="input-with-action">
+            <input type="text" id="updater-gateway-secret" class="form-input" placeholder="点击生成或自行填写（≥32 字符）" autocomplete="off">
+            <button type="button" id="gen-updater-gateway-secret" class="btn-generate" title="生成 UPDATER_GATEWAY_SECRET">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
+              </svg>
+            </button>
+          </div>
+          <span class="form-hint">
+            backend ↔ updater-gateway 共享密钥。泄露仍可能经 gateway 驱动更新，请与 UPDATE_TOKEN 同等保管。
           </span>
         </div>
       </section>
@@ -255,7 +269,7 @@
                 <option value="off">off — 不验证（仅兼容无签名旧 release）</option>
               </select>
               <span class="form-hint">
-                strict 最安全；只有旧版本没有签名时才降级。
+                strict 最安全；off 时 .env 会注明双钥匙（UPDATER_ALLOW_INSECURE_COSIGN / COSIGN_INSECURE_OK）。
               </span>
             </div>
           </div>
@@ -290,7 +304,7 @@
             </span>
             <div class="section-warning-content">
               <span class="section-warning-title">内网端口（固定，不要映射到公网）</span>
-              frontend <code>1102</code> · backend <code>1103</code> · updater <code>1101</code> · postgres <code>5432</code>
+              frontend <code>1102</code> · backend <code>1103</code> · updater <code>1101</code> · updater-gateway <code>1104</code> · docker-guard <code>2375</code> · postgres <code>5432</code>
             </div>
           </div>
 

--- a/index.json
+++ b/index.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://myriad.app/schemas/tapp-store-v1.json",
   "name": "Myriad Official Tapp Store",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "api_version": "2",
   "base_url": "https://raw.githubusercontent.com/Myriad-You/tapp-store/main",
-  "updated_at": "2026-07-17T02:00:00Z",
+  "updated_at": "2026-07-17T07:06:00Z",
   "maintainer": {
     "name": "Myriad Team",
     "email": "tapp@myriad.app",
@@ -100,9 +100,9 @@
     {
       "id": "com.myriad.config-generator",
       "name": "Myriad 安装配置生成",
-      "version": "1.0.0",
-      "description": "填写部署参数，生成 Compose、环境变量与 Nginx 配置",
-      "long_description": "输入域名、数据库与资源设置，生成 docker-compose、.env、外层 Nginx 与部署说明，可直接用于 1Panel。",
+      "version": "1.1.0",
+      "description": "生成 hardened 生产 Compose（docker-guard + updater-gateway）、.env 与 Nginx",
+      "long_description": "输入域名、数据库与资源设置，生成与官方生产拓扑一致的 docker-compose（三网络、docker-guard、updater-gateway）、含 UPDATE_TOKEN / UPDATER_GATEWAY_SECRET 的 .env、外层 Nginx 与部署说明，可直接用于 1Panel。",
       "author": {
         "name": "Myriad Team",
         "url": "https://github.com/Myriad-You"
@@ -123,13 +123,13 @@
         "page_styles": "apps/com.myriad.config-generator/page.css",
         "page_template": "apps/com.myriad.config-generator/page.html"
       },
-      "size": 51200,
+      "size": 131072,
       "downloads": 0,
       "rating": 0,
       "featured": true,
       "verified": true,
       "created_at": "2025-12-14T00:00:00Z",
-      "updated_at": "2026-07-17T00:00:00Z"
+      "updated_at": "2026-07-17T07:06:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Align `com.myriad.config-generator` generated Compose/`.env`/deploy notes with Myriad’s production hardened layout (`docker-compose.yml` / `.env.production.example`).
- Generated stack now includes **docker-guard** (sole `docker.sock`), **updater-gateway**, and three networks (`myriad-net`, `myriad-admin-net`, internal `myriad-docker-guard-net`).
- Backend no longer receives `UPDATE_TOKEN`; uses `UPDATER_GATEWAY_SECRET` + `MYRIAD_UPDATER_URL=http://updater-gateway:1104`. Non-root (no `user: 0:0`).
- UI auto-generates both `UPDATE_TOKEN` and `UPDATER_GATEWAY_SECRET`; cosign dual-key comments when verify is off.
- Bump app **1.1.0**, store index **1.8.5**.

## Files
- `apps/com.myriad.config-generator/main.js` — templates, state, generateConfigs
- `apps/com.myriad.config-generator/page.html` — gateway secret field + architecture blurb
- `apps/com.myriad.config-generator/manifest.json` / `README.md`
- `index.json`

## Test plan
- [ ] Open config-generator page; confirm gateway secret field auto-fills next to UPDATE_TOKEN
- [ ] Generate with sample domain; verify compose has docker-guard, updater-gateway, three networks
- [ ] Confirm backend env has `UPDATER_GATEWAY_SECRET` and `MYRIAD_UPDATER_URL=http://updater-gateway:1104`, **no** `UPDATE_TOKEN`
- [ ] Confirm only docker-guard mounts docker.sock; updater uses `DOCKER_HOST=tcp://docker-guard:2375`
- [ ] Confirm proxy still uses `${HTTP_BIND_ADDRESS:-127.0.0.1}:${HTTP_PORT:-8080}:80`
- [ ] Confirm no `:latest` tags; Postgres still form-driven
- [ ] Set COSIGN_VERIFY=off and check .env dual-key comments
- [ ] Verify manifest/index versions are 1.1.0 / store 1.8.5