### PR TITLE
fix(config-generator): post-federation outer deploy alignment

### DIFF
--- a/apps/com.myriad.config-generator/README.md
+++ b/apps/com.myriad.config-generator/README.md
@@ -8,8 +8,8 @@
 |------|------|
 | `docker-compose.yml` | proxy / frontend / backend / backend-volume-init / postgres / docker-guard / updater / updater-gateway |
 | `.env` | 密钥与 tag（勿提交） |
-| `<domain>.conf` | 外层反代到 proxy |
-| `DEPLOY.md` | 启动与救援 |
+| `<domain>.conf` | 外层整站反代到 proxy（含 ACME 本地挑战） |
+| `DEPLOY.md` | 启动、联邦与救援 |
 
 ## 网络
 
@@ -20,18 +20,44 @@
 | `myriad-docker-guard-net` (internal) | updater, docker-guard |
 
 - backend-volume-init 使用 `network_mode: none`
-- 仅 docker-guard 挂 sock
+- 仅 docker-guard 挂 sock；仅 proxy 映射宿主端口
 - backend 只持 `UPDATER_GATEWAY_SECRET`，经 gateway 更新
 - backend-volume-init 会在 backend 启动前修复持久卷权限
 - 禁止 `:latest`
 
+## 联邦 / Federation
+
+外层反代必须 **整站** 指向 Myriad proxy，**不要只反代 `/api`**（否则 WebFinger/inbox 联邦会挂）。
+
+| 配置 | 说明 |
+|------|------|
+| `BASE_URL` / `FRONTEND_URL` | 公网 HTTPS 源站，用于 Actor URL；联邦必填 |
+| `PROXY_TAG` | 与 `MYRIAD_TAG` 独立；proxy 有 AP 路由变更时单独 bump |
+| 外层 Nginx | `location /` → proxy；`/.well-known/acme-challenge/` 本地；其余 `.well-known` 走 proxy |
+
+必须到达 proxy 的路径：
+
+- `/.well-known/webfinger`
+- `/.well-known/nodeinfo`
+- `/nodeinfo/2.1`
+- `/inbox`
+- `/users/`
+- `/api/*`（含联邦 WebSocket `/api/federation/*/ws`）
+
+冒烟（期望 JSON，不是 HTML）：
+
+```bash
+curl -sS "https://YOUR_DOMAIN/.well-known/webfinger?resource=acct:USER@YOUR_DOMAIN" | head -c 200
+curl -sS "https://YOUR_DOMAIN/.well-known/nodeinfo" | head -c 200
+```
+
 ## 用法
 
 1. 填域名 / 数据库，确认密钥  
-2. 可选上传 Nginx 站点配置  
+2. 可选上传 Nginx 站点配置（会规范为整站反代 + ACME 本地挑战）  
 3. 生成并下载  
 
-1Panel：YAML → 编排，`.env` → 环境变量。
+1Panel：YAML → 编排，`.env` → 环境变量；站点反代到 `HTTP_BIND_ADDRESS:HTTP_PORT`。
 
 ```bash
 mkdir -p pgdata state backups
@@ -44,5 +70,6 @@ docker compose up -d
 ## 注意
 
 - 勿公开 `.env`
-- 仅 proxy 映射宿主端口
+- 仅 proxy 映射宿主端口（`HTTP_BIND_ADDRESS` 默认本机绑定，适配 1Panel）
 - cosign=`off` 时需双钥匙（见生成的 `.env`）
+- `PROXY_TRUSTED_UPSTREAMS` 空=信任私网/回环上游；切勿 `0.0.0.0/0`

--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -154,6 +154,10 @@ services:
       driver: "json-file"
       options: { max-size: "10m", max-file: "3" }
 
+  # proxy: only public host port. Routes SPA, /api, health, and federation public paths
+  # (/.well-known/webfinger|nodeinfo, /nodeinfo/2.1, /inbox, /users/*). Outer TLS
+  # must whole-site reverse-proxy here — not /api-only. Preserve public Host for
+  # ActivityPub HTTP Signatures. Bind stays HTTP_BIND_ADDRESS:HTTP_PORT (1Panel-friendly).
   proxy:
     image: \${PROXY_IMAGE:-docker.io/somekawahitomi/myriad-proxy}:\${PROXY_TAG}
     container_name: myriad-proxy
@@ -291,6 +295,7 @@ var ENV_TEMPLATE = `# Myriad .env — chmod 600，勿提交 Git
 # 禁止 :latest
 
 MYRIAD_TAG={{MYRIAD_TAG}}
+# PROXY_TAG is separate from MYRIAD_TAG — bump when proxy gains AP routing / federation fixes
 PROXY_TAG={{PROXY_TAG}}
 UPDATER_TAG={{UPDATER_TAG}}
 BACKEND_IMAGE=docker.io/somekawahitomi/myriad-backend
@@ -312,6 +317,8 @@ CHECK_INTERVAL_SECS=3600
 
 HTTP_BIND_ADDRESS={{HTTP_BIND_ADDRESS}}
 HTTP_PORT={{HTTP_PORT}}
+# PROXY_TRUSTED_UPSTREAMS: empty trusts private/loopback peers only (outer 1Panel/Nginx).
+# Never set 0.0.0.0/0 (would trust forged X-Forwarded-* from anyone).
 # PROXY_TRUSTED_UPSTREAMS=
 PROXY_ALLOW_DIRECT_UPDATER=false
 
@@ -325,12 +332,16 @@ DATABASE_URL={{DATABASE_URL}}
 JWT_SECRET={{JWT_SECRET}}
 
 CORS_ORIGINS={{CORS_ORIGINS}}
+# BASE_URL / FRONTEND_URL = public HTTPS origin (required for federation Actor URLs)
 BASE_URL=https://{{MAIN_DOMAIN}}
 FRONTEND_URL=https://{{MAIN_DOMAIN}}
 PUBLIC_API_URL=
 # RUST_LOG=info
 `;
 
+// Whole-site reverse proxy to Myriad proxy (NOT /api-only). Federation paths that
+// MUST reach proxy: /.well-known/webfinger, /.well-known/nodeinfo, /nodeinfo/2.1,
+// /inbox, /users/, plus /api/* (federation WS under /api/federation/*/ws).
 var DEFAULT_NGINX_TEMPLATE = `server {
     listen 80;
     server_name {{MAIN_DOMAIN}};
@@ -339,6 +350,15 @@ var DEFAULT_NGINX_TEMPLATE = `server {
     access_log /www/sites/{{MAIN_DOMAIN}}/log/access.log main;
     error_log /www/sites/{{MAIN_DOMAIN}}/log/error.log;
 
+    # ACME (1Panel/certbot): local root BEFORE catch-all. Other /.well-known/* via proxy.
+    location ^~ /.well-known/acme-challenge/ {
+        root /www/sites/{{MAIN_DOMAIN}}/index;
+        allow all;
+    }
+
+    # Whole-site → Myriad proxy (SPA + /api + federation). Do NOT proxy only /api.
+    # Must reach proxy: /.well-known/webfinger, /.well-known/nodeinfo, /nodeinfo/2.1,
+    # /inbox, /users/, /api/* (incl. WS /api/federation/*/ws). Preserve Host for HTTP Signatures.
     location / {
         proxy_pass http://127.0.0.1:{{HTTP_PORT}};
 
@@ -364,6 +384,7 @@ var DEFAULT_NGINX_TEMPLATE = `server {
         access_log off;
     }
 
+    # Block dangerous extensions under .well-known; do NOT block webfinger/nodeinfo.
     if ( $uri ~ "^/\\.well-known/.*\\.(php|jsp|py|js|css|lua|ts|go|zip|tar\\.gz|rar|7z|sql|bak)$" ) {
         return 403;
     }
@@ -380,6 +401,15 @@ var DEFAULT_EXTRA_NGINX_TEMPLATE = `server {
     access_log /www/sites/{{EXTRA_DOMAIN}}/log/access.log main;
     error_log /www/sites/{{EXTRA_DOMAIN}}/log/error.log;
 
+    # ACME (1Panel/certbot): local root BEFORE catch-all. Other /.well-known/* via proxy.
+    location ^~ /.well-known/acme-challenge/ {
+        root /www/sites/{{EXTRA_DOMAIN}}/index;
+        allow all;
+    }
+
+    # Whole-site → Myriad proxy (SPA + /api + federation). Do NOT proxy only /api.
+    # Must reach proxy: /.well-known/webfinger, /.well-known/nodeinfo, /nodeinfo/2.1,
+    # /inbox, /users/, /api/* (incl. WS /api/federation/*/ws). Preserve Host for HTTP Signatures.
     location / {
         proxy_pass http://127.0.0.1:{{HTTP_PORT}};
 
@@ -400,6 +430,7 @@ var DEFAULT_EXTRA_NGINX_TEMPLATE = `server {
         client_max_body_size 50M;
     }
 
+    # Block dangerous extensions under .well-known; do NOT block webfinger/nodeinfo.
     if ( $uri ~ "^/\\.well-known/.*\\.(php|jsp|py|js|css|lua|ts|go|zip|tar\\.gz|rar|7z|sql|bak)$" ) {
         return 403;
     }
@@ -423,9 +454,28 @@ var DEPLOY_NOTES_TEMPLATE = `# Myriad 部署
 
 \`backend-volume-init\` 使用 \`network_mode: none\`；仅 proxy 开宿主端口。
 
+## 联邦 / Federation
+
+- \`BASE_URL\` / \`FRONTEND_URL\` = 公网 HTTPS 源站（如 \`https://{{MAIN_DOMAIN}}\`），用于 Actor URL；联邦必填。
+- 外层 Nginx/Caddy 必须 **整站** 反代到 Myriad proxy（\`HTTP_BIND_ADDRESS:HTTP_PORT\`），**不要只反代 /api**。
+- 以下路径必须到达 proxy（再由 proxy 转 backend）：
+  - \`/.well-known/webfinger\`
+  - \`/.well-known/nodeinfo\`
+  - \`/nodeinfo/2.1\`
+  - \`/inbox\`
+  - \`/users/\`
+  - \`/api/*\`（含联邦 WebSocket \`/api/federation/*/ws\`）
+- ACME：\`/.well-known/acme-challenge/\` 由外层 Nginx 本地提供；其余 \`.well-known\` 仍走 proxy。
+- 冒烟（期望 JSON，不是 HTML）：
+
+\`\`\`bash
+curl -sS "https://{{MAIN_DOMAIN}}/.well-known/webfinger?resource=acct:USER@{{MAIN_DOMAIN}}" | head -c 200
+curl -sS "https://{{MAIN_DOMAIN}}/.well-known/nodeinfo" | head -c 200
+\`\`\`
+
 ## 1Panel
 
-编排贴 YAML；环境变量贴 \`.env\`；启动。
+编排贴 YAML；环境变量贴 \`.env\`；启动。站点反代到 proxy 端口，勿改成仅 /api。
 
 ## 启动
 
@@ -441,11 +491,13 @@ docker compose pull && docker compose up -d
 
 ## HTTPS
 
-https://{{MAIN_DOMAIN}} → \`{{HTTP_BIND_ADDRESS}}:{{HTTP_PORT}}\`
+https://{{MAIN_DOMAIN}} → \`{{HTTP_BIND_ADDRESS}}:{{HTTP_PORT}}\`（整站反代）
 
 ## 更新
 
 设置 → 关于 → 更新管理 · \`{{CHANNEL}}\` · cosign \`{{COSIGN_VERIFY}}\`
+
+proxy 有 AP 路由变更时需单独 bump \`PROXY_TAG\`（与 \`MYRIAD_TAG\` 独立）。
 
 ## 数据
 
@@ -809,9 +861,15 @@ async function refreshLatestTags(inputs, channelSelect, opts) {
   return tagFetchState.inflight;
 }
 
+// Whole-site reverse proxy to Myriad proxy — never rewrite to /api-only.
+// Federation paths that MUST reach proxy: /.well-known/webfinger, /.well-known/nodeinfo,
+// /nodeinfo/2.1, /inbox, /users/, /api/* (WS under /api/federation/*/ws).
 function buildNginxProxyLocation(httpPort, indent) {
   var childIndent = indent + '    ';
   return [
+    indent + '# Whole-site → Myriad proxy (SPA + /api + federation). Do NOT proxy only /api.',
+    indent + '# Must reach proxy: /.well-known/webfinger, /.well-known/nodeinfo, /nodeinfo/2.1,',
+    indent + '# /inbox, /users/, /api/* (incl. WS /api/federation/*/ws). Preserve Host for HTTP Signatures.',
     indent + 'location / {',
     childIndent + 'proxy_pass http://127.0.0.1:' + httpPort + ';',
     '',
@@ -831,6 +889,47 @@ function buildNginxProxyLocation(httpPort, indent) {
     childIndent + 'client_max_body_size 50M;',
     indent + '}'
   ].join('\n');
+}
+
+function extractNginxRoot(serverConfig, domain) {
+  var match = serverConfig.match(/(?:^|\n)[ \t]*root\s+([^;]+);/);
+  if (match) return match[1].trim();
+  if (domain) return '/www/sites/' + domain + '/index';
+  return '/www/sites/default/index';
+}
+
+function hasAcmeChallengeLocation(serverConfig) {
+  return /location\s+\^~\s+\/\.well-known\/acme-challenge\//.test(serverConfig);
+}
+
+function buildAcmeChallengeLocation(siteRoot, indent) {
+  var childIndent = indent + '    ';
+  return [
+    indent + '# ACME (1Panel/certbot): local root BEFORE catch-all. Other /.well-known/* via proxy.',
+    indent + 'location ^~ /.well-known/acme-challenge/ {',
+    childIndent + 'root ' + siteRoot + ';',
+    childIndent + 'allow all;',
+    indent + '}'
+  ].join('\n');
+}
+
+// Ensure ACME challenge is local; keep other /.well-known/* on the whole-site proxy.
+function ensureAcmeChallengeLocation(serverConfig, domain, serverIndent) {
+  if (hasAcmeChallengeLocation(serverConfig)) return serverConfig;
+
+  var childIndent = serverIndent + '    ';
+  var acmeBlock = buildAcmeChallengeLocation(extractNginxRoot(serverConfig, domain), childIndent);
+  var rootLocation = /(^|\n)([ \t]*)location\s+(?:(?:=|\^~)\s+)?\/\s*\{/;
+  var match = rootLocation.exec(serverConfig);
+  if (match) {
+    var insertAt = match.index + match[1].length;
+    return serverConfig.slice(0, insertAt) + acmeBlock + '\n\n' + serverConfig.slice(insertAt);
+  }
+
+  var closeBrace = serverConfig.lastIndexOf('}');
+  if (closeBrace === -1) return serverConfig;
+  return serverConfig.slice(0, closeBrace).replace(/[ \t]*$/, '') +
+    '\n\n' + acmeBlock + '\n' + serverConfig.slice(closeBrace);
 }
 
 function findClosingBrace(config, openBraceIndex) {
@@ -926,27 +1025,30 @@ function isRedirectOnlyServer(serverConfig) {
   return !servesTls && redirectsWholeServer && !hasUpstreamHandler;
 }
 
-function transformServerBlock(serverConfig, httpPort, serverIndent) {
+function transformServerBlock(serverConfig, httpPort, serverIndent, domain) {
   var childIndent = serverIndent + '    ';
   var proxyLocation = buildNginxProxyLocation(httpPort, childIndent);
   var proxyInclude = /^[ \t]*include\s+[^;\n]*\/proxy\/\*\.conf\s*;[ \t]*$/gm;
   var replacedRoot = replaceRootLocation(serverConfig, httpPort);
+  var next = serverConfig;
 
   if (replacedRoot !== null) {
-    // Myriad 独占根路径；移除 1Panel 外置代理入口，避免重复 location /。
-    return replacedRoot.replace(proxyInclude, '');
-  }
-  if (proxyInclude.test(serverConfig)) {
+    // Myriad 独占根路径（整站反代，非 /api-only）；移除 1Panel 外置代理入口，避免重复 location /。
+    next = replacedRoot.replace(proxyInclude, '');
+  } else if (proxyInclude.test(serverConfig)) {
     proxyInclude.lastIndex = 0;
-    return serverConfig.replace(proxyInclude, proxyLocation);
+    // Replace 1Panel proxy include with whole-site location / (keeps federation paths).
+    next = serverConfig.replace(proxyInclude, proxyLocation);
+  } else {
+    var closeBrace = serverConfig.lastIndexOf('}');
+    next = serverConfig.slice(0, closeBrace).replace(/[ \t]*$/, '') +
+      '\n\n' + proxyLocation + '\n' + serverConfig.slice(closeBrace);
   }
 
-  var closeBrace = serverConfig.lastIndexOf('}');
-  return serverConfig.slice(0, closeBrace).replace(/[ \t]*$/, '') +
-    '\n\n' + proxyLocation + '\n' + serverConfig.slice(closeBrace);
+  return ensureAcmeChallengeLocation(next, domain, serverIndent);
 }
 
-// 将上传的站点配置规范化为 Myriad proxy 单入口。
+// 将上传的站点配置规范化为 Myriad proxy 整站入口（非 /api-only）。
 // 支持同一站点常见的 HTTP 跳转块 + HTTPS 服务块，不修改其他域名。
 function replaceNginxUpstreamToProxy(config, httpPort, domain) {
   var blocks = findServerBlocks(config);
@@ -956,7 +1058,7 @@ function replaceNginxUpstreamToProxy(config, httpPort, domain) {
     return {
       start: block.start,
       end: block.end,
-      text: transformServerBlock(block.text, httpPort, block.indent)
+      text: transformServerBlock(block.text, httpPort, block.indent, domain)
     };
   });
 

--- a/apps/com.myriad.config-generator/manifest.json
+++ b/apps/com.myriad.config-generator/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "com.myriad.config-generator",
   "name": "Myriad 安装配置生成",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minSystemVersion": "0.2.1",
-  "description": "生成 Compose、.env 与 Nginx 部署配置",
+  "description": "生成 Compose、.env 与 Nginx 部署配置（整站反代 + 联邦）",
   "category": "developer",
   "main": "main.js",
   "author": {

--- a/apps/com.myriad.config-generator/manifest.json
+++ b/apps/com.myriad.config-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.config-generator",
   "name": "Myriad 安装配置生成",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "minSystemVersion": "0.2.1",
   "description": "生成 Compose、.env 与 Nginx 部署配置（整站反代 + 联邦）",
   "category": "developer",

--- a/apps/com.myriad.config-generator/page.html
+++ b/apps/com.myriad.config-generator/page.html
@@ -48,7 +48,7 @@
         <div class="form-group">
           <label for="main-domain">主域名</label>
           <input type="text" id="main-domain" class="form-input" placeholder="myriad.example.com" autocomplete="off">
-          <span class="form-hint">不要带 <code>https://</code></span>
+          <span class="form-hint">不要带 <code>https://</code>。会写入 <code>BASE_URL</code>/<code>FRONTEND_URL</code>（联邦 Actor URL）；外层 Nginx 须<strong>整站</strong>反代到 proxy，勿只反代 <code>/api</code>。</span>
         </div>
         <div class="form-group">
           <label for="extra-domain">额外域名（可选）</label>
@@ -175,6 +175,7 @@
           <div class="form-group form-group-third">
             <label for="proxy-tag">PROXY_TAG</label>
             <input type="text" id="proxy-tag" class="form-input" value="" placeholder="自动获取…" autocomplete="off">
+            <span class="form-hint">与 MYRIAD_TAG 独立；proxy 有 AP 路由/联邦变更时单独 bump</span>
           </div>
           <div class="form-group form-group-third">
             <label for="updater-tag">UPDATER_TAG</label>


### PR DESCRIPTION
## Summary

Align `com.myriad.config-generator` generated outer deploy configs with Myriad proxy federation routing (#97–#99), so production 1Panel/Nginx installs do not break ActivityPub/Aro federation.

### Operator-facing changes

- **Nginx (default + extra + uploaded rewrite)**: whole-site reverse proxy to Myriad proxy (not `/api`-only); keep Host / X-Real-IP / X-Forwarded-* / WebSocket Upgrade; document federation paths that must reach proxy (`/.well-known/webfinger`, `/.well-known/nodeinfo`, `/nodeinfo/2.1`, `/inbox`, `/users/`, `/api/*` incl. federation WS); ACME `location ^~ /.well-known/acme-challenge/` served locally before catch-all; dangerous `.well-known` extensions still blocked without blocking webfinger/nodeinfo.
- **`.env` comments**: `BASE_URL`/`FRONTEND_URL` = public HTTPS origin (federation Actor URLs); `PROXY_TAG` independent of `MYRIAD_TAG`; `PROXY_TRUSTED_UPSTREAMS` empty = private/loopback only — never `0.0.0.0/0`.
- **DEPLOY notes + README**: short 联邦/Federation section with path list and optional `curl` smoke (JSON not HTML).
- **docker-compose template**: proxy comments (public port only; SPA/API/health/federation; Host for HTTP Signatures); keep `HTTP_BIND_ADDRESS:HTTP_PORT` localhost-style bind for 1Panel.
- **page.html**: hints near domain / `PROXY_TAG`.
- **manifest**: `1.0.0` → `1.0.1`.

## Tests

- `node --check apps/com.myriad.config-generator/main.js`
- Local smoke of template contents + uploaded-nginx rewrite (whole-site `location /`, ACME inject, headers)

## Risks / follow-ups

- Operators with a pre-existing outer config that only proxies `/api` must re-generate or re-upload and apply the whole-site template for federation to work.
- ACME path uses site `root` (1Panel default); unusual root layouts may need a one-line edit.