### PR TITLE
fix(doudizhu): texture CSS vars on documentElement (felt/scene paint)

### DIFF
--- a/apps/com.myriad.doudizhu/logic/structure.test.ts
+++ b/apps/com.myriad.doudizhu/logic/structure.test.ts
@@ -175,6 +175,9 @@ describe('com.myriad.doudizhu package layout', () => {
     assert.ok(main.includes('loadTextures') || main.includes('TEXTURE_MAP'))
     assert.ok(main.includes('assets/felt/table_felt.png'))
     assert.ok(main.includes('assets/cards/card_back.png'))
+    assert.ok(main.includes('document.documentElement'), 'texture vars on documentElement')
+    assert.ok(main.includes('textureApplyTargets'), 'multi-target texture apply')
+    assert.ok(main.includes('TEXTURE_CSS_VARS'), 'full key→CSS var map')
   })
 
   it('store index.json lists this app', () => {

--- a/apps/com.myriad.doudizhu/logic/texture-scope.test.ts
+++ b/apps/com.myriad.doudizhu/logic/texture-scope.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Texture CSS-var scope tests — proves #tapp-background ancestors receive felt/scene.
+ *
+ *   cd apps/com.myriad.doudizhu && npx --yes tsx --test logic/*.test.ts
+ */
+/* eslint-disable test/no-import-node-test */
+
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const appDir = join(__dirname, '..')
+const mainSrc = readFileSync(join(appDir, 'main.js'), 'utf8')
+const cssSrc = readFileSync(join(appDir, 'page.css'), 'utf8')
+const htmlSrc = readFileSync(join(appDir, 'page.html'), 'utf8')
+
+describe('texture CSS variable scope (shipped main.js)', () => {
+  it('textureApplyTargets includes document.documentElement (sibling bg inherits)', () => {
+    assert.ok(mainSrc.includes('function textureApplyTargets'), 'textureApplyTargets must exist')
+    const fnStart = mainSrc.indexOf('function textureApplyTargets')
+    const fnSlice = mainSrc.slice(fnStart, fnStart + 600)
+    assert.ok(
+      fnSlice.includes('document.documentElement'),
+      'targets must include document.documentElement so #tapp-background sees --ddz-tex-felt',
+    )
+    assert.ok(
+      fnSlice.includes('tapp-background') || fnSlice.includes("getElementById('tapp-background')"),
+      'targets should also include #tapp-background when present',
+    )
+  })
+
+  it('loadTextures applies textureApplyTargets, not only .ddz-root', () => {
+    const loadStart = mainSrc.indexOf('async function loadTextures')
+    assert.ok(loadStart >= 0)
+    const loadSlice = mainSrc.slice(loadStart, loadStart + 900)
+    assert.ok(loadSlice.includes('textureApplyTargets()'))
+    assert.ok(
+      !/applyTextureCssVars\(\s*document\.querySelector\('\.ddz-root'\)/.test(loadSlice),
+      'must not apply only on .ddz-root (breaks sibling #tapp-background)',
+    )
+  })
+
+  it('every TEXTURE_MAP key is bound to a CSS var in TEXTURE_CSS_VARS', () => {
+    const mapMatch = mainSrc.match(/var TEXTURE_MAP = \{([\s\S]*?)\n  \};/)
+    assert.ok(mapMatch, 'TEXTURE_MAP object')
+    const keys = [...mapMatch[1].matchAll(/^\s*([A-Za-z0-9_]+)\s*:/gm)].map((m) => m[1])
+    assert.ok(keys.length >= 30, `expected many texture keys, got ${keys.length}`)
+
+    const cssMapMatch = mainSrc.match(/var TEXTURE_CSS_VARS = \{([\s\S]*?)\n  \};/)
+    assert.ok(cssMapMatch, 'TEXTURE_CSS_VARS object')
+    const cssKeys = new Set(
+      [...cssMapMatch[1].matchAll(/^\s*([A-Za-z0-9_]+)\s*:/gm)].map((m) => m[1]),
+    )
+    const missing = keys.filter((k) => !cssKeys.has(k))
+    assert.deepEqual(missing, [], `TEXTURE_MAP keys missing from TEXTURE_CSS_VARS: ${missing.join(',')}`)
+  })
+
+  it('page.css consumes sm card faces, bubble-gold, coin, ornament, ready textures', () => {
+    assert.ok(cssSrc.includes('--ddz-tex-card-back-sm'))
+    assert.ok(cssSrc.includes('--ddz-tex-card-face-sm'))
+    assert.ok(cssSrc.includes('--ddz-tex-bubble-gold'))
+    assert.ok(cssSrc.includes('--ddz-tex-coin'))
+    assert.ok(cssSrc.includes('--ddz-tex-ornament'))
+    assert.ok(cssSrc.includes('--ddz-tex-ready'))
+    assert.ok(cssSrc.includes('.ddz-bg-felt'))
+    assert.ok(cssSrc.includes('var(--ddz-tex-felt)'))
+    assert.ok(cssSrc.includes('var(--ddz-tex-scene)'))
+  })
+
+  it('DOM cascade: documentElement receives --ddz-tex-felt and .ddz-bg-felt is under that tree', async () => {
+    assert.ok(existsSync(join(appDir, 'assets/felt/table_felt.png')))
+    assert.ok(cssSrc.includes('var(--ddz-tex-felt)'))
+    assert.ok(htmlSrc.includes('class="ddz-bg-felt"') || htmlSrc.includes('ddz-bg-felt'))
+
+    // Sibling layout: #tapp-background is NOT inside .ddz-root
+    const bgIdx = htmlSrc.indexOf('id="tapp-background"')
+    const contentIdx = htmlSrc.indexOf('id="tapp-content"')
+    assert.ok(bgIdx >= 0 && contentIdx > bgIdx, 'background before content')
+    assert.ok(
+      !htmlSrc.slice(contentIdx).includes('id="tapp-background"'),
+      '#tapp-background must not nest inside #tapp-content',
+    )
+
+    let JSDOM: typeof import('jsdom').JSDOM | null = null
+    try {
+      const require = createRequire(import.meta.url)
+      JSDOM = require('jsdom').JSDOM
+    } catch {
+      try {
+        JSDOM = (await import('jsdom')).JSDOM
+      } catch {
+        JSDOM = null
+      }
+    }
+
+    if (!JSDOM) {
+      // Source-level guarantee still required
+      assert.ok(mainSrc.includes('document.documentElement'))
+      assert.ok(mainSrc.includes("getElementById('tapp-background')"))
+      return
+    }
+
+    const fixture = `<!DOCTYPE html><html><head><style>${cssSrc}</style></head><body>
+${htmlSrc}
+</body></html>`
+    const dom = new JSDOM(fixture, { url: 'https://local.test/doudizhu/' })
+    const { document, getComputedStyle } = dom.window
+    const feltPath = 'assets/felt/table_felt.png'
+    const scenePath = 'assets/felt/scene_bg.png'
+
+    // Drive the same target set as shipped textureApplyTargets()
+    const targets = [
+      document.documentElement,
+      document.body,
+      document.getElementById('tapp-background'),
+      document.querySelector('.ddz-root'),
+    ].filter(Boolean) as HTMLElement[]
+
+    assert.ok(targets[0] === document.documentElement)
+    for (const el of targets) {
+      el.style.setProperty('--ddz-tex-felt', `url("${feltPath}")`)
+      el.style.setProperty('--ddz-tex-scene', `url("${scenePath}")`)
+      el.style.setProperty('--ddz-tex-felt-tile', `url("assets/felt/felt_tile.png")`)
+    }
+
+    // 1) documentElement must hold the var (inheritance root for #tapp-background in real browsers)
+    const rootFelt = document.documentElement.style.getPropertyValue('--ddz-tex-felt')
+    assert.ok(
+      rootFelt.includes('table_felt'),
+      `documentElement --ddz-tex-felt must include table_felt, got: ${rootFelt}`,
+    )
+    const bgFeltVar = (document.getElementById('tapp-background') as HTMLElement).style
+      .getPropertyValue('--ddz-tex-felt')
+    assert.ok(bgFeltVar.includes('table_felt'), `#tapp-background must also receive --ddz-tex-felt`)
+
+    // 2) Tree: .ddz-bg-felt under #tapp-background, NOT under .ddz-root (sibling bug class)
+    const feltEl = document.querySelector('.ddz-bg-felt') as HTMLElement
+    assert.ok(feltEl)
+    assert.ok(document.documentElement.contains(feltEl))
+    const bg = document.getElementById('tapp-background')
+    assert.ok(bg && bg.contains(feltEl), '.ddz-bg-felt must live under #tapp-background')
+    const ddzRoot = document.querySelector('.ddz-root')
+    assert.ok(ddzRoot && !ddzRoot.contains(feltEl), '.ddz-bg-felt must NOT be inside .ddz-root')
+
+    // 3) CSS rule for felt uses the custom property (browser will resolve from ancestors)
+    assert.match(cssSrc, /\.ddz-bg-felt[\s\S]*?var\(--ddz-tex-felt\)/)
+
+    // 4) Walk ancestor chain: every node from felt → html is either a target we painted
+    //    or a descendant of documentElement (so documentElement vars apply in real CSSOM).
+    let node: Element | null = feltEl
+    let sawDocumentElement = false
+    while (node) {
+      if (node === document.documentElement) sawDocumentElement = true
+      node = node.parentElement
+    }
+    assert.ok(sawDocumentElement, 'felt must be under documentElement for CSS var inheritance')
+
+    // 5) Regression: if we ONLY set vars on .ddz-root, #tapp-background itself has empty var
+    const dom2 = new JSDOM(fixture, { url: 'https://local.test/doudizhu/' })
+    const rootOnly = dom2.window.document.querySelector('.ddz-root') as HTMLElement
+    rootOnly.style.setProperty('--ddz-tex-felt', `url("${feltPath}")`)
+    const bg2 = dom2.window.document.getElementById('tapp-background') as HTMLElement
+    const bg2Val = bg2.style.getPropertyValue('--ddz-tex-felt').trim()
+    assert.equal(
+      bg2Val,
+      '',
+      'regression: applying only on .ddz-root leaves #tapp-background without the var',
+    )
+    // and documentElement also empty in that broken path
+    assert.equal(
+      dom2.window.document.documentElement.style.getPropertyValue('--ddz-tex-felt').trim(),
+      '',
+    )
+  })
+})

--- a/apps/com.myriad.doudizhu/main.js
+++ b/apps/com.myriad.doudizhu/main.js
@@ -451,49 +451,85 @@ console.log('[斗地主] core loaded');
     return 'url("' + String(pathOrUrl).replace(/"/g, '\\"') + '")';
   }
 
-  function applyTextureCssVars(root) {
-    if (!root) return;
-    var set = function (name, key) {
-      var u = textureUrls[key];
-      if (u) root.style.setProperty(name, cssUrl(u));
-    };
-    set('--ddz-tex-scene', 'scene');
-    set('--ddz-tex-felt', 'felt');
-    set('--ddz-tex-felt-dark', 'feltDark');
-    set('--ddz-tex-felt-tile', 'feltTile');
-    set('--ddz-tex-velvet', 'centerVelvet');
-    set('--ddz-tex-wood', 'woodPanel');
-    set('--ddz-tex-card-back', 'cardBack');
-    set('--ddz-tex-card-face', 'cardFace');
-    set('--ddz-tex-paper', 'paper');
-    set('--ddz-tex-suit-S', 'suitS');
-    set('--ddz-tex-suit-H', 'suitH');
-    set('--ddz-tex-suit-D', 'suitD');
-    set('--ddz-tex-suit-C', 'suitC');
-    set('--ddz-tex-joker-sj', 'jokerSj');
-    set('--ddz-tex-joker-bj', 'jokerBj');
-    set('--ddz-tex-seat-frame', 'seatFrame');
-    set('--ddz-tex-bottom-tray', 'bottomTray');
-    set('--ddz-tex-last-tray', 'lastTray');
-    set('--ddz-tex-avatar-ring', 'avatarRing');
-    set('--ddz-tex-logo', 'logoPlate');
-    set('--ddz-tex-btn-play', 'btnPlay');
-    set('--ddz-tex-btn-pass', 'btnPass');
-    set('--ddz-tex-btn-hint', 'btnHint');
-    set('--ddz-tex-btn-bid', 'btnBid');
-    set('--ddz-tex-btn-primary', 'btnPrimary');
-    set('--ddz-tex-btn-ghost', 'btnGhost');
-    set('--ddz-tex-badge-landlord', 'badgeLandlord');
-    set('--ddz-tex-badge-farmer', 'badgeFarmer');
-    set('--ddz-tex-badge-alarm', 'badgeAlarm');
-    set('--ddz-tex-end-ribbon', 'endRibbon');
-    set('--ddz-tex-ornament', 'ornament');
-    set('--ddz-tex-bubble', 'bubbleDark');
-    set('--ddz-tex-turn-ring', 'turnRing');
-    set('--ddz-tex-coin', 'coin');
-    set('--ddz-tex-crown', 'crown');
-    set('--ddz-tex-ready', 'readyCheck');
-    root.classList.add('ddz-textures-ready');
+  /**
+   * Map TEXTURE_MAP keys → CSS custom properties.
+   * MUST include every key in TEXTURE_MAP so no asset is load-only dead weight.
+   */
+  var TEXTURE_CSS_VARS = {
+    scene: '--ddz-tex-scene',
+    felt: '--ddz-tex-felt',
+    feltDark: '--ddz-tex-felt-dark',
+    feltTile: '--ddz-tex-felt-tile',
+    centerVelvet: '--ddz-tex-velvet',
+    woodPanel: '--ddz-tex-wood',
+    cardBack: '--ddz-tex-card-back',
+    cardBackSm: '--ddz-tex-card-back-sm',
+    cardFace: '--ddz-tex-card-face',
+    cardFaceSm: '--ddz-tex-card-face-sm',
+    paper: '--ddz-tex-paper',
+    suitS: '--ddz-tex-suit-S',
+    suitH: '--ddz-tex-suit-H',
+    suitD: '--ddz-tex-suit-D',
+    suitC: '--ddz-tex-suit-C',
+    jokerSj: '--ddz-tex-joker-sj',
+    jokerBj: '--ddz-tex-joker-bj',
+    btnPlay: '--ddz-tex-btn-play',
+    btnPass: '--ddz-tex-btn-pass',
+    btnHint: '--ddz-tex-btn-hint',
+    btnBid: '--ddz-tex-btn-bid',
+    btnPrimary: '--ddz-tex-btn-primary',
+    btnGhost: '--ddz-tex-btn-ghost',
+    bubbleDark: '--ddz-tex-bubble',
+    bubbleGold: '--ddz-tex-bubble-gold',
+    turnRing: '--ddz-tex-turn-ring',
+    badgeLandlord: '--ddz-tex-badge-landlord',
+    badgeFarmer: '--ddz-tex-badge-farmer',
+    badgeAlarm: '--ddz-tex-badge-alarm',
+    seatFrame: '--ddz-tex-seat-frame',
+    bottomTray: '--ddz-tex-bottom-tray',
+    lastTray: '--ddz-tex-last-tray',
+    avatarRing: '--ddz-tex-avatar-ring',
+    logoPlate: '--ddz-tex-logo',
+    ornament: '--ddz-tex-ornament',
+    coin: '--ddz-tex-coin',
+    endRibbon: '--ddz-tex-end-ribbon',
+    crown: '--ddz-tex-crown',
+    readyCheck: '--ddz-tex-ready'
+  };
+
+  /**
+   * Apply texture CSS vars to ancestors that cover BOTH #tapp-background (sibling)
+   * and #tapp-content/.ddz-root. documentElement is required so .ddz-bg-felt paints.
+   */
+  function textureApplyTargets() {
+    var list = [];
+    if (typeof document !== 'undefined') {
+      if (document.documentElement) list.push(document.documentElement);
+      if (document.body) list.push(document.body);
+      var bg = document.getElementById('tapp-background');
+      if (bg) list.push(bg);
+      var root = document.querySelector('.ddz-root');
+      if (root) list.push(root);
+    }
+    return list;
+  }
+
+  function applyTextureCssVars(targets) {
+    var nodes = targets;
+    if (!nodes) nodes = textureApplyTargets();
+    if (!nodes || !nodes.length) return;
+    if (nodes.nodeType) nodes = [nodes]; // single element
+    for (var n = 0; n < nodes.length; n++) {
+      var el = nodes[n];
+      if (!el || !el.style || !el.style.setProperty) continue;
+      var keys = Object.keys(TEXTURE_CSS_VARS);
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        var u = textureUrls[key];
+        if (u) el.style.setProperty(TEXTURE_CSS_VARS[key], cssUrl(u));
+      }
+      if (el.classList) el.classList.add('ddz-textures-ready');
+    }
     texturesReady = true;
   }
 
@@ -514,8 +550,8 @@ console.log('[斗地主] core loaded');
         textureUrls[k] = path;
       }
     }
-    var root = document.querySelector('.ddz-root') || document.documentElement;
-    applyTextureCssVars(root);
+    // documentElement first — #tapp-background is NOT inside .ddz-root
+    applyTextureCssVars(textureApplyTargets());
     return textureUrls;
   }
 
@@ -751,9 +787,14 @@ console.log('[斗地主] core loaded');
   }
 
   function renderSeatAction(view, seat) {
+    var wrap = $('ddz-action-' + view);
     var labelEl = $('ddz-action-label-' + view);
     var cardsEl = view === 'me' ? $('ddz-local-me') : $('ddz-local-' + view);
     var action = seatActions[seat];
+    if (wrap) {
+      wrap.classList.remove('is-bid', 'is-bid-pass', 'is-play', 'is-pass');
+      if (action && action.kind) wrap.classList.add('is-' + action.kind);
+    }
     if (!labelEl) return;
     if (!action) {
       setText(labelEl, '');
@@ -1709,7 +1750,7 @@ console.log('[斗地主] core loaded');
       try {
         var keys = Object.keys(TEXTURE_MAP);
         for (var ti = 0; ti < keys.length; ti++) textureUrls[keys[ti]] = TEXTURE_MAP[keys[ti]];
-        applyTextureCssVars(document.querySelector('.ddz-root') || document.documentElement);
+        applyTextureCssVars(textureApplyTargets());
       } catch (e2) { /* ignore */ }
     }
     wireMessageHandler();

--- a/apps/com.myriad.doudizhu/page.css
+++ b/apps/com.myriad.doudizhu/page.css
@@ -35,7 +35,9 @@
   --ddz-tex-velvet: none;
   --ddz-tex-wood: none;
   --ddz-tex-card-back: none;
+  --ddz-tex-card-back-sm: none;
   --ddz-tex-card-face: none;
+  --ddz-tex-card-face-sm: none;
   --ddz-tex-paper: none;
   --ddz-tex-seat-frame: none;
   --ddz-tex-bottom-tray: none;
@@ -54,6 +56,7 @@
   --ddz-tex-end-ribbon: none;
   --ddz-tex-ornament: none;
   --ddz-tex-bubble: none;
+  --ddz-tex-bubble-gold: none;
   --ddz-tex-turn-ring: none;
   --ddz-tex-coin: none;
   --ddz-tex-crown: none;
@@ -146,9 +149,12 @@
   border: 1px solid var(--ddz-border);
   background:
     var(--ddz-tex-logo) right 8px center / 120px auto no-repeat,
+    var(--ddz-tex-ornament) left bottom / 100% 10px no-repeat,
+    var(--ddz-tex-coin) left 10px center / 22px 22px no-repeat,
     linear-gradient(180deg, rgba(90, 24, 20, 0.88), rgba(40, 12, 10, 0.82));
   box-shadow: var(--ddz-shadow);
   backdrop-filter: blur(10px);
+  padding-left: 36px;
 }
 
 .ddz-brand {
@@ -477,10 +483,12 @@
 }
 
 .ddz-pill-ready {
-  color: #0a3;
-  background: rgba(61, 206, 122, 0.2);
-  border: 1px solid rgba(61, 206, 122, 0.45);
   color: #7dffb0;
+  border: 1px solid rgba(61, 206, 122, 0.45);
+  background:
+    var(--ddz-tex-ready) 2px center / 12px 12px no-repeat,
+    rgba(61, 206, 122, 0.2);
+  padding-left: 16px;
 }
 
 .ddz-pill-wait {
@@ -769,6 +777,13 @@
   border: 1px dashed rgba(255, 255, 255, 0.12);
 }
 
+.ddz-seat-action.is-bid,
+.ddz-seat-action.is-bid-pass {
+  background:
+    var(--ddz-tex-bubble-gold) center top / 100% auto no-repeat,
+    rgba(80, 40, 10, 0.35);
+}
+
 .ddz-action-label {
   font-size: 11px;
   font-weight: 800;
@@ -895,11 +910,24 @@
   --card-h: 42px;
   border-radius: 6px;
   padding: 2px;
+  background:
+    var(--ddz-tex-card-face-sm) center / cover no-repeat,
+    var(--ddz-tex-card-face) center / cover no-repeat,
+    var(--ddz-tex-paper) center / cover no-repeat,
+    #f8f5ef;
 }
 
 .ddz-card.mini .ddz-card-rank { font-size: 11px; }
 .ddz-card.mini .ddz-card-suit { width: 12px; height: 12px; }
 .ddz-card.mini.joker { width: 32px; }
+
+.ddz-card.mini.back,
+.ddz-played .ddz-card.back {
+  background:
+    var(--ddz-tex-card-back-sm) center / cover no-repeat,
+    var(--ddz-tex-card-back) center / cover no-repeat,
+    linear-gradient(145deg, #1e4a80, #0f2a50);
+}
 
 .ddz-played .ddz-card {
   --card-w: 22px;


### PR DESCRIPTION
## Summary
- Apply `--ddz-tex-*` on `document.documentElement` (+ body, `#tapp-background`, `.ddz-root`) so sibling `#tapp-background` felt/scene textures actually paint
- Map every `TEXTURE_MAP` key to a CSS var; wire sm card faces, bubble-gold, coin, ornament, ready in CSS
- Add `logic/texture-scope.test.ts` cascade/target tests

## Test plan
- [x] `npx --yes tsx --test logic/*.test.ts`