### PR TITLE
fix(config-generator): allowlist proxy in docker-guard images

### DIFF
--- a/apps/com.myriad.config-generator/README.md
+++ b/apps/com.myriad.config-generator/README.md
@@ -21,6 +21,7 @@
 
 - backend-volume-init 使用 `network_mode: none`
 - 仅 docker-guard 挂 sock；仅 proxy 映射宿主端口
+- `DOCKER_GUARD_ALLOWED_IMAGES` 须含 backend / frontend / **proxy** / updater / postgres（漏 proxy 会导致 pull 403）
 - backend 只持 `UPDATER_GATEWAY_SECRET`，经 gateway 更新
 - backend-volume-init 会在 backend 启动前修复持久卷权限
 - 禁止 `:latest`

--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -196,7 +196,7 @@ services:
       MYRIAD_DOCKER_GUARD_NETWORK: \${MYRIAD_DOCKER_GUARD_NETWORK:-myriad-docker-guard-net}
       DOCKER_GUARD_COMPOSE_DIR: /host/compose
       DOCKER_GUARD_ENV_FILE: /host/compose/.env
-      DOCKER_GUARD_ALLOWED_IMAGES: \${BACKEND_IMAGE:-docker.io/somekawahitomi/myriad-backend},\${FRONTEND_IMAGE:-docker.io/somekawahitomi/myriad-frontend},\${UPDATER_IMAGE:-docker.io/somekawahitomi/myriad-updater},postgres
+      DOCKER_GUARD_ALLOWED_IMAGES: \${BACKEND_IMAGE:-docker.io/somekawahitomi/myriad-backend},\${FRONTEND_IMAGE:-docker.io/somekawahitomi/myriad-frontend},\${PROXY_IMAGE:-docker.io/somekawahitomi/myriad-proxy},\${UPDATER_IMAGE:-docker.io/somekawahitomi/myriad-updater},postgres
       RUST_LOG: \${DOCKER_GUARD_LOG:-info}
       TZ: Asia/Shanghai
     volumes:
@@ -300,6 +300,8 @@ PROXY_TAG={{PROXY_TAG}}
 UPDATER_TAG={{UPDATER_TAG}}
 BACKEND_IMAGE=docker.io/somekawahitomi/myriad-backend
 FRONTEND_IMAGE=docker.io/somekawahitomi/myriad-frontend
+# PROXY_IMAGE=docker.io/somekawahitomi/myriad-proxy
+# UPDATER_IMAGE=docker.io/somekawahitomi/myriad-updater
 COMPOSE_PROJECT_NAME=myriad
 # MYRIAD_DOCKER_NETWORK=myriad-net
 # MYRIAD_ADMIN_NETWORK=myriad-admin-net
@@ -498,6 +500,8 @@ https://{{MAIN_DOMAIN}} → \`{{HTTP_BIND_ADDRESS}}:{{HTTP_PORT}}\`（整站反�
 设置 → 关于 → 更新管理 · \`{{CHANNEL}}\` · cosign \`{{COSIGN_VERIFY}}\`
 
 proxy 有 AP 路由变更时需单独 bump \`PROXY_TAG\`（与 \`MYRIAD_TAG\` 独立）。
+
+\`DOCKER_GUARD_ALLOWED_IMAGES\` 必须包含 proxy（默认 \`myriad-proxy\`）；否则 product/proxy 更新会 403。已部署栈若曾漏掉 proxy：编辑 compose 补上后执行 \`docker compose up -d --force-recreate docker-guard\`，再重试更新。
 
 ## 数据
 

--- a/apps/com.myriad.config-generator/manifest.json
+++ b/apps/com.myriad.config-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.config-generator",
   "name": "Myriad 安装配置生成",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minSystemVersion": "0.2.1",
   "description": "生成 Compose、.env 与 Nginx 部署配置（整站反代 + 联邦）",
   "locales": {

--- a/index.json
+++ b/index.json
@@ -132,7 +132,7 @@
     {
       "id": "com.myriad.config-generator",
       "name": "Myriad 安装配置生成",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "生成 Compose、.env 与 Nginx 部署配置",
       "long_description": "填写域名与数据库参数，生成官方生产拓扑的 docker-compose、.env、Nginx 与部署说明（含 1Panel）。",
       "locales": {
@@ -185,7 +185,7 @@
       "featured": true,
       "verified": true,
       "created_at": "2025-12-14T00:00:00Z",
-      "updated_at": "2026-07-19T11:28:19Z"
+      "updated_at": "2026-07-21T00:00:00Z"
     },
     {
       "id": "com.myriad.doudizhu",


### PR DESCRIPTION
## Summary

- Add `${PROXY_IMAGE:-docker.io/somekawahitomi/myriad-proxy}` to `DOCKER_GUARD_ALLOWED_IMAGES` in the generated compose template (matches Myriad root `docker-compose.yml`).
- Document optional commented `PROXY_IMAGE` / `UPDATER_IMAGE` in `ENV_TEMPLATE`.
- DEPLOY notes: existing installs must recreate `docker-guard` after fixing the allowlist.
- README: note that the allowlist must include proxy.
- Bump `com.myriad.config-generator` to **1.0.1** (`manifest.json` + `index.json`).

### Root cause

Generated stacks denied `docker pull` of `myriad-proxy` with:

```text
precondition failed: pull proxy docker.io/somekawahitomi/myriad-proxy:v…:
docker: pull stream: Docker responded with status code 403: image pull repository is not allowlisted
```

Hub tags were fine; guard allowlist was incomplete.

### Light-diff vs Myriad compose

Compared docker-guard / updater / updater-gateway against Myriad `docker-compose.yml`. Only material bug found was missing proxy on the allowlist. Intentional 1Panel differences (e.g. `HTTP_BIND_ADDRESS`) left as-is.

## Operator note (already-deployed stacks)

Stacks generated by older config-generator need a one-time fix:

1. Edit compose: add proxy to `DOCKER_GUARD_ALLOWED_IMAGES` (or re-generate with 1.0.1+).
2. `docker compose up -d --force-recreate docker-guard`
3. Retry proxy / product update

## Test plan

- [ ] Generate compose from config-generator 1.0.1 and confirm `DOCKER_GUARD_ALLOWED_IMAGES` includes `PROXY_IMAGE` / `myriad-proxy`.
- [ ] Fresh deploy can pull/update proxy without 403.
- [ ] On a pre-1.0.1 stack, manual allowlist + `--force-recreate docker-guard` unblocks updates.
- [ ] Store catalog shows version 1.0.1 for `com.myriad.config-generator`.