### PR TITLE
feat(config-generator): external Postgres mode (MYRIAD_DB_MODE)

### DIFF
--- a/apps/com.myriad.config-generator/README.md
+++ b/apps/com.myriad.config-generator/README.md
@@ -6,22 +6,35 @@
 
 | 文件 | 内容 |
 |------|------|
-| `docker-compose.yml` | proxy / frontend / backend / backend-volume-init / postgres / docker-guard / updater / updater-gateway |
-| `.env` | 密钥与 tag（勿提交） |
+| `docker-compose.yml` | proxy / frontend / backend / backend-volume-init / [postgres] / docker-guard / updater / updater-gateway |
+| `.env` | 密钥、tag、`MYRIAD_DB_MODE`（勿提交） |
 | `<domain>.conf` | 外层整站反代到 proxy（含 ACME 本地挑战） |
 | `DEPLOY.md` | 启动、联邦与救援 |
+
+## 数据库模式 `MYRIAD_DB_MODE`
+
+| 模式 | 说明 |
+|------|------|
+| `bundled`（默认） | compose 含 `postgres` 服务、`./pgdata`、`depends_on: service_healthy`；`DATABASE_URL` 指向 `postgres:5432`；updater 可快照 pgdata |
+| `external` | **不**生成 `postgres` 服务；backend **不** `depends_on` postgres；`DATABASE_URL` 为用户外置库完整 URL；`DOCKER_GUARD_ALLOWED_IMAGES` 不含 `postgres`；不强制 `mkdir pgdata` / 不设 `UPDATER_PGDATA` |
+
+外置库（1Panel 外部 DB、托管 Postgres 等）选 **外置 Postgres**，避免 updater 重启后再起内置库冲突。
+
+外置数据备份与恢复由运维自行负责；Myriad updater 在 `external` 下**不会**快照数据库。
+
+容器访问宿主机上的库：主机可填 IP、`host.docker.internal`（Docker Desktop）或 docker bridge 网关（如 `172.17.0.1`）。
 
 ## 网络
 
 | 网络 | 成员 |
 |------|------|
-| `myriad-net` | proxy, frontend, backend, postgres |
+| `myriad-net` | proxy, frontend, backend（bundled 时含 postgres） |
 | `myriad-admin-net` | backend, updater, updater-gateway, proxy |
 | `myriad-docker-guard-net` (internal) | updater, docker-guard |
 
 - backend-volume-init 使用 `network_mode: none`
 - 仅 docker-guard 挂 sock；仅 proxy 映射宿主端口
-- `DOCKER_GUARD_ALLOWED_IMAGES` 须含 backend / frontend / **proxy** / updater / postgres（漏 proxy 会导致 pull 403）
+- `DOCKER_GUARD_ALLOWED_IMAGES` 须含 backend / frontend / **proxy** / updater；（bundled 时另含 postgres；漏 proxy 会导致 pull 403）
 - backend 只持 `UPDATER_GATEWAY_SECRET`，经 gateway 更新
 - backend-volume-init 会在 backend 启动前修复持久卷权限
 - 禁止 `:latest`
@@ -54,14 +67,24 @@ curl -sS "https://YOUR_DOMAIN/.well-known/nodeinfo" | head -c 200
 
 ## 用法
 
-1. 填域名 / 数据库，确认密钥  
+1. 填域名 / 数据库（内置或外置），确认密钥  
 2. 可选上传 Nginx 站点配置（会规范为整站反代 + ACME 本地挑战）  
 3. 生成并下载  
 
 1Panel：YAML → 编排，`.env` → 环境变量；站点反代到 `HTTP_BIND_ADDRESS:HTTP_PORT`。
 
+**内置：**
+
 ```bash
 mkdir -p pgdata state backups
+chmod 600 .env
+docker compose up -d
+```
+
+**外置：**（无需 `pgdata`）
+
+```bash
+mkdir -p state backups
 chmod 600 .env
 docker compose up -d
 ```
@@ -74,3 +97,4 @@ docker compose up -d
 - 仅 proxy 映射宿主端口（`HTTP_BIND_ADDRESS` 默认本机绑定，适配 1Panel）
 - cosign=`off` 时需双钥匙（见生成的 `.env`）
 - `PROXY_TRUSTED_UPSTREAMS` 空=信任私网/回环上游；切勿 `0.0.0.0/0`
+- 外置模式下数据库备份不由 Myriad updater 负责

--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -1,11 +1,7 @@
 // Myriad Config Generator — 生产 compose / .env / Nginx
 
-var DOCKER_COMPOSE_TEMPLATE = `# Myriad
-# nets: myriad-net | myriad-admin-net | myriad-docker-guard-net(internal)
-# mkdir -p pgdata state backups && docker compose up -d
-
-services:
-  postgres:
+// Bundled Postgres service (MYRIAD_DB_MODE=bundled). Omitted entirely for external mode.
+var POSTGRES_SERVICE_TEMPLATE = `  postgres:
     image: postgres:{{DB_VERSION}}-alpine
     container_name: myriad-postgres
     deploy:
@@ -55,7 +51,15 @@ services:
       driver: "json-file"
       options: { max-size: "10m", max-file: "3" }
 
-  backend-volume-init:
+`;
+
+var DOCKER_COMPOSE_TEMPLATE = `# Myriad
+# nets: myriad-net | myriad-admin-net | myriad-docker-guard-net(internal)
+# MYRIAD_DB_MODE={{MYRIAD_DB_MODE}}
+# {{COMPOSE_START_HINT}}
+
+services:
+{{POSTGRES_SERVICE}}  backend-volume-init:
     image: \${BACKEND_IMAGE:-docker.io/somekawahitomi/myriad-backend}:\${MYRIAD_TAG}
     container_name: myriad-backend-volume-init
     user: "0:0"
@@ -100,8 +104,7 @@ services:
       MYRIAD_UPDATER_URL: http://updater-gateway:1104
       UPDATER_GATEWAY_SECRET: \${UPDATER_GATEWAY_SECRET}
     depends_on:
-      postgres: { condition: service_healthy }
-      backend-volume-init: { condition: service_completed_successfully }
+{{BACKEND_DEPENDS_ON}}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:1103/health"]
       interval: 30s
@@ -196,7 +199,7 @@ services:
       MYRIAD_DOCKER_GUARD_NETWORK: \${MYRIAD_DOCKER_GUARD_NETWORK:-myriad-docker-guard-net}
       DOCKER_GUARD_COMPOSE_DIR: /host/compose
       DOCKER_GUARD_ENV_FILE: /host/compose/.env
-      DOCKER_GUARD_ALLOWED_IMAGES: \${BACKEND_IMAGE:-docker.io/somekawahitomi/myriad-backend},\${FRONTEND_IMAGE:-docker.io/somekawahitomi/myriad-frontend},\${PROXY_IMAGE:-docker.io/somekawahitomi/myriad-proxy},\${UPDATER_IMAGE:-docker.io/somekawahitomi/myriad-updater},postgres
+      DOCKER_GUARD_ALLOWED_IMAGES: \${BACKEND_IMAGE:-docker.io/somekawahitomi/myriad-backend},\${FRONTEND_IMAGE:-docker.io/somekawahitomi/myriad-frontend},\${PROXY_IMAGE:-docker.io/somekawahitomi/myriad-proxy},\${UPDATER_IMAGE:-docker.io/somekawahitomi/myriad-updater}{{DOCKER_GUARD_EXTRA_IMAGES}}
       RUST_LOG: \${DOCKER_GUARD_LOG:-info}
       TZ: Asia/Shanghai
     volumes:
@@ -228,8 +231,7 @@ services:
       CHECK_INTERVAL_SECS: \${CHECK_INTERVAL_SECS:-3600}
       UPDATER_STATE_DIR: /host/compose/state
       UPDATER_ENV_FILE: /host/compose/.env
-      UPDATER_PGDATA: /host/compose/pgdata
-      UPDATER_COMPOSE_DIR: /host/compose
+{{UPDATER_PGDATA_LINE}}      UPDATER_COMPOSE_DIR: /host/compose
       DOCKER_HOST: tcp://docker-guard:2375
       DOCKER_GUARD_SELF_UPDATE_URL: http://docker-guard:2375/_myriad/self-update
       COSIGN_VERIFY: \${COSIGN_VERIFY:-strict}
@@ -327,10 +329,9 @@ PROXY_ALLOW_DIRECT_UPDATER=false
 COSIGN_VERIFY={{COSIGN_VERIFY}}
 {{COSIGN_INSECURE_HINT}}
 
-POSTGRES_DB={{POSTGRES_DB}}
-POSTGRES_USER={{POSTGRES_USER}}
-POSTGRES_PASSWORD={{POSTGRES_PASSWORD}}
-DATABASE_URL={{DATABASE_URL}}
+# MYRIAD_DB_MODE=bundled|external — external: no compose postgres; updater skips pgdata snapshots
+MYRIAD_DB_MODE={{MYRIAD_DB_MODE}}
+{{POSTGRES_ENV_BLOCK}}DATABASE_URL={{DATABASE_URL}}
 JWT_SECRET={{JWT_SECRET}}
 
 CORS_ORIGINS={{CORS_ORIGINS}}
@@ -446,11 +447,13 @@ var DEPLOY_NOTES_TEMPLATE = `# Myriad 部署
 
 同目录：\`docker-compose.yml\` + \`.env\`（\`chmod 600\`，勿提交）。
 
+数据库模式：\`MYRIAD_DB_MODE={{MYRIAD_DB_MODE}}\`（bundled=内置 Postgres；external=外置，不启动 compose 内 postgres）。
+
 ## 网络
 
 | 网络 | 成员 |
 |------|------|
-| myriad-net | proxy, frontend, backend, postgres |
+| myriad-net | {{DEPLOY_NET_MEMBERS}} |
 | myriad-admin-net | backend, updater, updater-gateway, proxy |
 | myriad-docker-guard-net (internal) | updater, docker-guard |
 
@@ -482,7 +485,7 @@ curl -sS "https://{{MAIN_DOMAIN}}/.well-known/nodeinfo" | head -c 200
 ## 启动
 
 \`\`\`bash
-mkdir -p pgdata state backups
+{{DEPLOY_MKDIR}}
 chmod 600 .env
 docker compose pull && docker compose up -d
 \`\`\`
@@ -503,9 +506,7 @@ proxy 有 AP 路由变更时需单独 bump \`PROXY_TAG\`（与 \`MYRIAD_TAG\` �
 
 \`DOCKER_GUARD_ALLOWED_IMAGES\` 必须包含 proxy（默认 \`myriad-proxy\`）；否则 product/proxy 更新会 403。已部署栈若曾漏掉 proxy：编辑 compose 补上后执行 \`docker compose up -d --force-recreate docker-guard\`，再重试更新。
 
-## 数据
-
-\`./pgdata\` bind mount。换 PG 大版本前先 dump/restore。
+{{DEPLOY_DATA_SECTION}}
 
 ## 救援
 
@@ -1111,6 +1112,54 @@ function buildCorsOrigins(mainDomain, extraDomain) {
   return origins.join(',');
 }
 
+// Host reachable from backend container (IP / hostname / host.docker.internal)
+function isValidDbHost(host) {
+  if (!host || typeof host !== 'string') return false;
+  var h = host.trim();
+  if (!h || h.length > 253) return false;
+  if (h === 'localhost' || h === 'host.docker.internal') return true;
+  // IPv4
+  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(h)) {
+    var parts = h.split('.');
+    for (var i = 0; i < parts.length; i++) {
+      var n = Number(parts[i]);
+      if (n < 0 || n > 255) return false;
+    }
+    return true;
+  }
+  // hostname (incl. docker DNS names)
+  return /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i.test(h);
+}
+
+var SSLMODE_ALLOWED = {
+  '': true,
+  disable: true,
+  allow: true,
+  prefer: true,
+  require: true,
+  'verify-ca': true,
+  'verify-full': true
+};
+
+// Build postgres:// URL with encoded user/password; optional sslmode query.
+function buildDatabaseUrl(opts) {
+  var user = opts.user;
+  var password = opts.password;
+  var host = opts.host;
+  var port = opts.port;
+  var database = opts.database;
+  var sslmode = (opts.sslmode || '').trim();
+  var url = 'postgres://' +
+    encodeURIComponent(user) + ':' +
+    encodeURIComponent(password) +
+    '@' + host + ':' + port + '/' +
+    encodeURIComponent(database);
+  if (sslmode) {
+    url += '?sslmode=' + encodeURIComponent(sslmode);
+  }
+  return url;
+}
+
 // ========================================
 // 状态
 // ========================================
@@ -1128,9 +1177,14 @@ var state = {
   extraNginxFileName: '',
   httpBindAddress: '127.0.0.1',
   httpPort: 8080,
+  // bundled = compose postgres; external = user-managed PG (1Panel / managed)
+  dbMode: 'bundled',
   dbVersion: '18',
   dbName: 'myriad',
   dbUser: 'myriad',
+  dbHost: '',
+  dbPort: 5432,
+  dbSslmode: '',
   dbCpuLimit: '2.0',
   dbMemLimit: '2G',
   // 运行时由 Docker Hub 解析填充，不在源码中写死版本
@@ -1159,6 +1213,13 @@ function initPage() {
   var gatewaySecretInput = document.getElementById('updater-gateway-secret');
   var dbNameInput = document.getElementById('db-name');
   var dbUserInput = document.getElementById('db-user');
+  var dbHostInput = document.getElementById('db-host');
+  var dbPortInput = document.getElementById('db-port');
+  var dbSslmodeSelect = document.getElementById('db-sslmode');
+  var dbModeBundledFields = document.getElementById('db-mode-bundled-fields');
+  var dbModeExternalFields = document.getElementById('db-mode-external-fields');
+  var dbResourceGroup = document.getElementById('db-resource-group');
+  var dbModeRadios = document.querySelectorAll('input[name="db-mode"]');
 
   var genDbPasswordBtn = document.getElementById('gen-db-password');
   var genJwtSecretBtn = document.getElementById('gen-jwt-secret');
@@ -1193,6 +1254,33 @@ function initPage() {
     proxy: proxyTagInput,
     updater: updaterTagInput
   };
+
+  function getSelectedDbMode() {
+    var selected = document.querySelector('input[name="db-mode"]:checked');
+    return (selected && selected.value === 'external') ? 'external' : 'bundled';
+  }
+
+  function syncDbModeUi() {
+    var mode = getSelectedDbMode();
+    state.dbMode = mode;
+    var isExternal = mode === 'external';
+    if (dbModeBundledFields) dbModeBundledFields.hidden = isExternal;
+    if (dbModeExternalFields) dbModeExternalFields.hidden = !isExternal;
+    if (dbResourceGroup) dbResourceGroup.hidden = isExternal;
+    // Segmented control active styles
+    document.querySelectorAll('.db-mode-option').forEach(function(label) {
+      var input = label.querySelector('input[name="db-mode"]');
+      if (!input) return;
+      label.classList.toggle('is-active', input.checked);
+    });
+  }
+
+  if (dbModeRadios && dbModeRadios.length) {
+    dbModeRadios.forEach(function(radio) {
+      radio.addEventListener('change', syncDbModeUi);
+    });
+    syncDbModeUi();
+  }
 
   function markTagManual(input) {
     if (!input) return;
@@ -1274,6 +1362,8 @@ function initPage() {
       var gatewaySecret = gatewaySecretInput ? gatewaySecretInput.value.trim() : '';
       var dbName = dbNameInput.value.trim();
       var dbUser = dbUserInput.value.trim();
+      var dbMode = getSelectedDbMode();
+      var isExternal = dbMode === 'external';
 
       if (!mainDomain) {
         showNotification('请输入主域名', 'error');
@@ -1305,16 +1395,47 @@ function initPage() {
         return;
       }
 
-      // 密钥不足时当场补齐并继续，避免「生成后还要再点一次」
-      if (!dbPassword || dbPassword.length < 32) {
-        dbPassword = generatePassword();
-        dbPasswordInput.value = dbPassword;
+      var dbHost = '';
+      var dbPort = 5432;
+      var dbSslmode = '';
+      if (isExternal) {
+        dbHost = dbHostInput ? dbHostInput.value.trim() : '';
+        if (!isValidDbHost(dbHost)) {
+          showNotification('请填写有效的数据库主机（IP / 主机名 / host.docker.internal）', 'error');
+          if (dbHostInput) dbHostInput.focus();
+          return;
+        }
+        dbPort = parseInt(dbPortInput && dbPortInput.value, 10);
+        if (!dbPort || dbPort < 1 || dbPort > 65535) {
+          showNotification('数据库端口无效', 'error');
+          if (dbPortInput) dbPortInput.focus();
+          return;
+        }
+        dbSslmode = dbSslmodeSelect ? (dbSslmodeSelect.value || '').trim() : '';
+        if (!SSLMODE_ALLOWED[dbSslmode]) {
+          showNotification('sslmode 无效', 'error');
+          if (dbSslmodeSelect) dbSslmodeSelect.focus();
+          return;
+        }
+        // External: keep user password as-is (URL-encoded when building DATABASE_URL)
+        if (!dbPassword) {
+          showNotification('请填写外置数据库密码', 'error');
+          dbPasswordInput.focus();
+          return;
+        }
+      } else {
+        // Bundled: 密钥不足时当场补齐；限制 URL-safe 字符避免 compose 特殊字符问题
+        if (!dbPassword || dbPassword.length < 32) {
+          dbPassword = generatePassword();
+          dbPasswordInput.value = dbPassword;
+        }
+        if (!/^[A-Za-z0-9_-]{32,}$/.test(dbPassword)) {
+          showNotification('数据库密码至少 32 位，只能使用字母、数字、下划线和连字符', 'error');
+          dbPasswordInput.focus();
+          return;
+        }
       }
-      if (!/^[A-Za-z0-9_-]{32,}$/.test(dbPassword)) {
-        showNotification('数据库密码至少 32 位，只能使用字母、数字、下划线和连字符', 'error');
-        dbPasswordInput.focus();
-        return;
-      }
+
       if (!jwtSecret || jwtSecret.length < 32) {
         jwtSecret = generateJwtSecret();
         jwtSecretInput.value = jwtSecret;
@@ -1336,6 +1457,10 @@ function initPage() {
       state.updaterGatewaySecret = gatewaySecret;
       state.dbName = dbName;
       state.dbUser = dbUser;
+      state.dbMode = dbMode;
+      state.dbHost = dbHost;
+      state.dbPort = dbPort;
+      state.dbSslmode = dbSslmode;
 
       state.httpBindAddress = httpBindAddressSelect.value || '127.0.0.1';
       if (state.httpBindAddress !== '127.0.0.1' && state.httpBindAddress !== '0.0.0.0') {
@@ -1351,11 +1476,13 @@ function initPage() {
         return;
       }
 
-      state.dbVersion = (dbVersionSelect.value || '18').trim();
-      if (!/^\d+$/.test(state.dbVersion) || Number(state.dbVersion) < 18) {
-        showNotification('PostgreSQL 版本必须是 18 或更高的正式主版本', 'error');
-        dbVersionSelect.focus();
-        return;
+      state.dbVersion = (dbVersionSelect && dbVersionSelect.value) ? dbVersionSelect.value.trim() : '18';
+      if (!isExternal) {
+        if (!/^\d+$/.test(state.dbVersion) || Number(state.dbVersion) < 18) {
+          showNotification('PostgreSQL 版本必须是 18 或更高的正式主版本', 'error');
+          if (dbVersionSelect) dbVersionSelect.focus();
+          return;
+        }
       }
 
       // 若 tag 为空：等待进行中的拉取，或发起新拉取（不强制覆盖手改字段）
@@ -1380,19 +1507,23 @@ function initPage() {
       state.channel = channelSelect.value || 'stable';
       state.cosignVerify = cosignSelect.value || 'strict';
 
-      state.dbCpuLimit = dbCpuLimitInput.value.trim() || '2.0';
-      state.dbMemLimit = dbMemLimitInput.value.trim() || '2G';
+      state.dbCpuLimit = (dbCpuLimitInput && dbCpuLimitInput.value.trim()) || '2.0';
+      state.dbMemLimit = (dbMemLimitInput && dbMemLimitInput.value.trim()) || '2G';
       state.backendCpuLimit = backendCpuLimitInput.value.trim() || '2.0';
       state.backendMemLimit = backendMemLimitInput.value.trim() || '4G';
       state.frontendCpuLimit = frontendCpuLimitInput.value.trim() || '2.0';
       state.frontendMemLimit = frontendMemLimitInput.value.trim() || '2G';
 
-      var cpuValues = [state.dbCpuLimit, state.backendCpuLimit, state.frontendCpuLimit];
+      var cpuValues = isExternal
+        ? [state.backendCpuLimit, state.frontendCpuLimit]
+        : [state.dbCpuLimit, state.backendCpuLimit, state.frontendCpuLimit];
       if (cpuValues.some(function(value) { return !/^\d+(?:\.\d+)?$/.test(value) || Number(value) <= 0; })) {
         showNotification('CPU 数量必须是大于 0 的数字', 'error');
         return;
       }
-      var memoryValues = [state.dbMemLimit, state.backendMemLimit, state.frontendMemLimit];
+      var memoryValues = isExternal
+        ? [state.backendMemLimit, state.frontendMemLimit]
+        : [state.dbMemLimit, state.backendMemLimit, state.frontendMemLimit];
       if (memoryValues.some(function(value) { return !/^\d+(?:\.\d+)?[KMGTP]i?B?$/i.test(value); })) {
         showNotification('内存格式无效，请使用 512M、2G 等格式', 'error');
         return;
@@ -1542,23 +1673,96 @@ function applyPlaceholders(template, map) {
   var out = template;
   Object.keys(map).forEach(function(key) {
     var re = new RegExp('\\{\\{' + key + '\\}\\}', 'g');
-    out = out.replace(re, map[key]);
+    // Function replacer: avoid $ special sequences in passwords / URLs
+    var value = map[key] == null ? '' : String(map[key]);
+    out = out.replace(re, function() { return value; });
   });
   return out;
 }
 
 function generateConfigs() {
   var corsOrigins = buildCorsOrigins(state.mainDomain, state.extraDomain);
-  var databaseUrl = 'postgres://' +
-    encodeURIComponent(state.dbUser) + ':' +
-    encodeURIComponent(state.dbPassword) +
-    '@postgres:5432/' + encodeURIComponent(state.dbName);
+  var isExternal = state.dbMode === 'external';
+
+  var databaseUrl;
+  if (isExternal) {
+    databaseUrl = buildDatabaseUrl({
+      user: state.dbUser,
+      password: state.dbPassword,
+      host: state.dbHost,
+      port: state.dbPort,
+      database: state.dbName,
+      sslmode: state.dbSslmode
+    });
+  } else {
+    databaseUrl = buildDatabaseUrl({
+      user: state.dbUser,
+      password: state.dbPassword,
+      host: 'postgres',
+      port: 5432,
+      database: state.dbName,
+      sslmode: ''
+    });
+  }
 
   var cosignInsecureHint = state.cosignVerify === 'off'
     ? 'UPDATER_ALLOW_INSECURE_COSIGN=true'
     : '# UPDATER_ALLOW_INSECURE_COSIGN=true\n# COSIGN_INSECURE_OK=true';
 
+  var postgresService = '';
+  var backendDependsOn = '      backend-volume-init: { condition: service_completed_successfully }\n';
+  var dockerGuardExtra = '';
+  var updaterPgdataLine = '';
+  var composeStartHint = 'mkdir -p state backups && docker compose up -d';
+  var postgresEnvBlock = '';
+  var deployNetMembers = 'proxy, frontend, backend';
+  var deployMkdir = 'mkdir -p state backups';
+  var deployDataSection =
+    '## 数据\n\n' +
+    '`MYRIAD_DB_MODE=external`：不使用 `./pgdata`，Myriad updater **不会** 快照外置数据库。\n' +
+    '备份与恢复由你自行负责（1Panel 备份、托管 PG 快照、`pg_dump` 等）。\n' +
+    '容器访问宿主机/外置库时，主机可能需填 IP、`host.docker.internal` 或 docker bridge 网关。\n';
+
+  if (!isExternal) {
+    postgresService = applyPlaceholders(POSTGRES_SERVICE_TEMPLATE, {
+      DB_VERSION: state.dbVersion,
+      DB_CPU_LIMIT: state.dbCpuLimit,
+      DB_MEM_LIMIT: state.dbMemLimit
+    });
+    backendDependsOn =
+      '      postgres: { condition: service_healthy }\n' +
+      '      backend-volume-init: { condition: service_completed_successfully }\n';
+    dockerGuardExtra = ',postgres';
+    updaterPgdataLine = '      UPDATER_PGDATA: /host/compose/pgdata\n';
+    composeStartHint = 'mkdir -p pgdata state backups && docker compose up -d';
+    postgresEnvBlock =
+      'POSTGRES_DB=' + state.dbName + '\n' +
+      'POSTGRES_USER=' + state.dbUser + '\n' +
+      'POSTGRES_PASSWORD=' + state.dbPassword + '\n';
+    deployNetMembers = 'proxy, frontend, backend, postgres';
+    deployMkdir = 'mkdir -p pgdata state backups';
+    deployDataSection =
+      '## 数据\n\n' +
+      '`./pgdata` bind mount（`MYRIAD_DB_MODE=bundled`）。换 PG 大版本前先 dump/restore。\n';
+  } else {
+    // Still document credentials used to build DATABASE_URL (optional for operators)
+    postgresEnvBlock =
+      '# Credentials used to build DATABASE_URL (external DB; no compose postgres service)\n' +
+      '# POSTGRES_DB=' + state.dbName + '\n' +
+      '# POSTGRES_USER=' + state.dbUser + '\n';
+  }
+
   var map = {
+    MYRIAD_DB_MODE: isExternal ? 'external' : 'bundled',
+    COMPOSE_START_HINT: composeStartHint,
+    POSTGRES_SERVICE: postgresService,
+    BACKEND_DEPENDS_ON: backendDependsOn,
+    DOCKER_GUARD_EXTRA_IMAGES: dockerGuardExtra,
+    UPDATER_PGDATA_LINE: updaterPgdataLine,
+    POSTGRES_ENV_BLOCK: postgresEnvBlock,
+    DEPLOY_NET_MEMBERS: deployNetMembers,
+    DEPLOY_MKDIR: deployMkdir,
+    DEPLOY_DATA_SECTION: deployDataSection,
     DB_VERSION: state.dbVersion,
     POSTGRES_DB: state.dbName,
     POSTGRES_USER: state.dbUser,

--- a/apps/com.myriad.config-generator/page.css
+++ b/apps/com.myriad.config-generator/page.css
@@ -636,6 +636,79 @@
   color: var(--config-text);
 }
 
+/* 数据库模式切换：内置 / 外置 */
+.form-label-text {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--config-text);
+  margin-bottom: 8px;
+}
+
+.db-mode-toggle {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.db-mode-option {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: var(--config-radius-sm);
+  border: 1px solid var(--config-border);
+  background: var(--config-input-bg);
+  cursor: pointer;
+  transition: var(--config-transition);
+  user-select: none;
+}
+
+.db-mode-option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.db-mode-option:hover {
+  border-color: rgba(var(--config-primary-rgb), 0.35);
+  background: rgba(var(--config-primary-rgb), 0.06);
+}
+
+.db-mode-option.is-active {
+  border-color: rgba(var(--config-primary-rgb), 0.55);
+  background: rgba(var(--config-primary-rgb), 0.12);
+  box-shadow: 0 0 0 1px rgba(var(--config-primary-rgb), 0.2);
+}
+
+.db-mode-option-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--config-text);
+}
+
+.db-mode-option.is-active .db-mode-option-title {
+  color: var(--config-primary);
+}
+
+.db-mode-option-desc {
+  font-size: 11px;
+  color: var(--config-text-muted);
+  line-height: 1.4;
+}
+
+.form-hint-block {
+  display: block;
+  margin: -4px 0 14px;
+}
+
+@media (max-width: 520px) {
+  .db-mode-toggle {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Select 下拉框 */
 .form-select {
   appearance: none;

--- a/apps/com.myriad.config-generator/page.html
+++ b/apps/com.myriad.config-generator/page.html
@@ -67,33 +67,80 @@
           </span>
           数据库
         </h2>
-        <div class="form-row">
-          <div class="form-group form-group-half">
+
+        <div class="form-group">
+          <span class="form-label-text" id="db-mode-label">部署方式</span>
+          <div class="db-mode-toggle" role="radiogroup" aria-labelledby="db-mode-label">
+            <label class="db-mode-option is-active">
+              <input type="radio" name="db-mode" value="bundled" checked>
+              <span class="db-mode-option-title">内置 Postgres</span>
+              <span class="db-mode-option-desc">compose 内 postgres · 默认</span>
+            </label>
+            <label class="db-mode-option">
+              <input type="radio" name="db-mode" value="external">
+              <span class="db-mode-option-title">外置 Postgres</span>
+              <span class="db-mode-option-desc">1Panel / 托管库 · 无 postgres 服务</span>
+            </label>
+          </div>
+          <span class="form-hint">写入 <code>MYRIAD_DB_MODE=bundled|external</code>。外置时 updater 不快照数据库，备份自负。</span>
+        </div>
+
+        <div id="db-mode-bundled-fields">
+          <div class="form-group">
             <label for="db-version">PostgreSQL 版本</label>
             <input type="number" id="db-version" class="form-input" value="18" min="18" step="1">
+            <span class="form-hint">内置镜像 <code>postgres:VERSION-alpine</code>，主版本 ≥18</span>
           </div>
+        </div>
+
+        <div id="db-mode-external-fields" hidden>
+          <div class="form-row">
+            <div class="form-group form-group-half">
+              <label for="db-host">主机</label>
+              <input type="text" id="db-host" class="form-input" placeholder="host.docker.internal 或 IP" autocomplete="off">
+            </div>
+            <div class="form-group form-group-half">
+              <label for="db-port">端口</label>
+              <input type="number" id="db-port" class="form-input" value="5432" min="1" max="65535">
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="db-sslmode">sslmode（可选）</label>
+            <select id="db-sslmode" class="form-input form-select">
+              <option value="" selected>不设置</option>
+              <option value="disable">disable</option>
+              <option value="allow">allow</option>
+              <option value="prefer">prefer</option>
+              <option value="require">require</option>
+              <option value="verify-ca">verify-ca</option>
+              <option value="verify-full">verify-full</option>
+            </select>
+          </div>
+          <span class="form-hint form-hint-block">容器访问宿主机上的库：常用 <code>host.docker.internal</code>（Docker Desktop）、宿主 IP，或 docker bridge 网关（如 <code>172.17.0.1</code>）。托管库填公网/VPC 主机名即可。</span>
+        </div>
+
+        <div class="form-row">
           <div class="form-group form-group-half">
             <label for="db-name">数据库名</label>
             <input type="text" id="db-name" class="form-input" value="myriad" autocomplete="off">
             <span class="form-hint">小写字母/数字/_，字母开头</span>
           </div>
-        </div>
-        <div class="form-row">
           <div class="form-group form-group-half">
             <label for="db-user">用户名</label>
             <input type="text" id="db-user" class="form-input" value="myriad" autocomplete="off">
           </div>
-          <div class="form-group form-group-half">
-            <label for="db-password">密码</label>
-            <div class="input-with-action">
-              <input type="text" id="db-password" class="form-input" placeholder="≥32，可自动生成" autocomplete="off">
-              <button type="button" id="gen-db-password" class="btn-generate" title="生成随机密码">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
-                </svg>
-              </button>
-            </div>
+        </div>
+        <div class="form-group">
+          <label for="db-password">密码</label>
+          <div class="input-with-action">
+            <input type="text" id="db-password" class="form-input" placeholder="内置 ≥32 可生成；外置填真实密码" autocomplete="off">
+            <button type="button" id="gen-db-password" class="btn-generate" title="生成随机密码">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
+              </svg>
+            </button>
           </div>
+          <span class="form-hint">写入 <code>DATABASE_URL</code> 时会对密码做 URL 编码</span>
         </div>
       </section>
 
@@ -253,8 +300,8 @@
           </div>
 
           <h3 class="advanced-subtitle">资源上限</h3>
-          <div class="resource-group">
-            <div class="resource-label"><span>PostgreSQL</span></div>
+          <div class="resource-group" id="db-resource-group">
+            <div class="resource-label"><span>PostgreSQL（仅内置）</span></div>
             <div class="form-row">
               <div class="form-group form-group-half">
                 <label for="db-cpu-limit">CPU</label>


### PR DESCRIPTION
## Summary

Users who deploy Postgres **outside** Myriad compose (1Panel external DB, managed PG, etc.) previously still got a full embedded `postgres` service, `depends_on: service_healthy`, `./pgdata`, and `DATABASE_URL=...@postgres:5432/...`. After updater restarts this conflicts with real external DB usage.

This PR adds **`MYRIAD_DB_MODE=bundled|external`** to the config-generator (aligned with Myriad workers):

| Mode | Behavior |
|------|----------|
| **bundled** (default) | Unchanged: postgres service, pgdata, depends_on, DATABASE_URL → `postgres:5432`, docker-guard allowlist includes `postgres`, `UPDATER_PGDATA` set |
| **external** | No `postgres` service; backend does not depend_on postgres; `DATABASE_URL` from host/port/db/user/password (+ optional sslmode); `MYRIAD_DB_MODE=external` in `.env`; no `UPDATER_PGDATA`; docker-guard allowlist **without** postgres (still backend/frontend/**proxy**/updater); no `mkdir pgdata` in deploy steps |

### UI
- Toggle: 内置 Postgres / 外置 Postgres
- External fields: host, port (default 5432), database, user, password, optional sslmode
- Identifier validation; password special chars URL-encoded in `DATABASE_URL`
- Short note on `host.docker.internal` / host IP / docker bridge gateway

### Docs
- README + generated DEPLOY.md: external backups are the operator’s responsibility; updater does not snapshot external data

## Files
- `apps/com.myriad.config-generator/main.js`
- `apps/com.myriad.config-generator/page.html`
- `apps/com.myriad.config-generator/page.css`
- `apps/com.myriad.config-generator/README.md`

## Tests
- Node smoke checks for bundled vs external compose/env generation:
  - bundled: postgres service, depends_on, allowlist `,postgres`, `UPDATER_PGDATA`, `MYRIAD_DB_MODE=bundled`
  - external: no postgres service/depends_on/allowlist/UPDATER_PGDATA; `MYRIAD_DB_MODE=external`; URL encodes password specials + sslmode
- `node --check` on `main.js`

## Risks / follow-ups
- Operators already on a mixed external-DB + embedded-postgres stack should re-generate and remove the postgres service manually if needed
- Myriad updater must honor `MYRIAD_DB_MODE=external` (skip pgdata snapshots) — contract match; verify against current updater release if deploying before that lands