### PR TITLE
feat(aro): custom selects + deep dark-mode polish

### DIFF
--- a/apps/com.myriad.aro/README.md
+++ b/apps/com.myriad.aro/README.md
@@ -2,7 +2,7 @@
 
 社交中心：消息（Channel/Room）、时间线、环网与个人资料。
 
-> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.0）。
+> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.1）。
 
 ## 功能
 
@@ -23,5 +23,5 @@ index.js          # core（与 aro.ts buildCoreCode() 一致）
 page.html / page.css / styles.css
 page/*.js         # pageModules 与 aro.ts PAGE_MODULES 一致
 i18n/{zh,en,ja}.json
-manifest.json     # version 1.0.0
+manifest.json     # version 1.0.1
 ```

--- a/apps/com.myriad.aro/index.js
+++ b/apps/com.myriad.aro/index.js
@@ -2364,6 +2364,327 @@
     return map[type] || type || '';
   }
 
+  // ==================== Custom select (aro-select) ====================
+  // Lightweight listbox replacing native <select> for dark/iframe-friendly UI.
+  // Reuses manage-dropdown / manage-item visual language.
+
+  /**
+   * Resolve a root element for aro-select by id or node.
+   * @param {string|HTMLElement} rootOrId
+   * @returns {HTMLElement|null}
+   */
+  function resolveAroSelectRoot(rootOrId) {
+    if (!rootOrId) return null;
+    if (typeof rootOrId === 'string') return $(rootOrId);
+    return rootOrId.nodeType ? rootOrId : null;
+  }
+
+  /**
+   * Read value from custom select or native control.
+   * @param {string|HTMLElement} rootOrId
+   * @returns {string}
+   */
+  function getAroSelectValue(rootOrId) {
+    var root = resolveAroSelectRoot(rootOrId);
+    if (!root) return '';
+    if (root._aroSelect && typeof root._aroSelect.getValue === 'function') {
+      return root._aroSelect.getValue();
+    }
+    if (typeof root.value === 'string') return root.value;
+    return root.getAttribute('data-value') || '';
+  }
+
+  /**
+   * Set value on custom select (or native). silent skips change event.
+   * @param {string|HTMLElement} rootOrId
+   * @param {string} value
+   * @param {boolean} [silent]
+   */
+  function setAroSelectValue(rootOrId, value, silent) {
+    var root = resolveAroSelectRoot(rootOrId);
+    if (!root) return;
+    if (root._aroSelect && typeof root._aroSelect.setValue === 'function') {
+      root._aroSelect.setValue(value, !!silent);
+      return;
+    }
+    root.value = value == null ? '' : String(value);
+  }
+
+  /**
+   * Replace options: [{ value, label, id? }]. Keeps selection when possible.
+   * @param {string|HTMLElement} rootOrId
+   * @param {Array<{value:string,label:string,id?:string}>} options
+   * @param {string} [selectedValue]
+   */
+  function setAroSelectOptions(rootOrId, options, selectedValue) {
+    var root = resolveAroSelectRoot(rootOrId);
+    if (!root) return;
+    if (!root._aroSelect) initAroSelect(root);
+    if (root._aroSelect && typeof root._aroSelect.setOptions === 'function') {
+      root._aroSelect.setOptions(options || [], selectedValue);
+    }
+  }
+
+  /** Refresh trigger label after i18n updates option textContent. */
+  function refreshAroSelectLabel(rootOrId) {
+    var root = resolveAroSelectRoot(rootOrId);
+    if (root && root._aroSelect && typeof root._aroSelect.refreshLabel === 'function') {
+      root._aroSelect.refreshLabel();
+    }
+  }
+
+  /**
+   * Initialize a custom select root. Safe to call multiple times.
+   * Defines root.value get/set and dispatches bubbling 'change' events.
+   * @param {string|HTMLElement} rootOrId
+   * @param {{ onChange?: function(string):void }} [opts]
+   * @returns {{ getValue:function, setValue:function, setOptions:function, open:function, close:function, refreshLabel:function }|null}
+   */
+  function initAroSelect(rootOrId, opts) {
+    var root = resolveAroSelectRoot(rootOrId);
+    if (!root) return null;
+    if (root._aroSelect) {
+      if (opts && typeof opts.onChange === 'function') root._aroSelect._onChange = opts.onChange;
+      return root._aroSelect;
+    }
+
+    var trigger = root.querySelector('.aro-select-trigger');
+    var labelEl = root.querySelector('[data-aro-select-label]') || root.querySelector('.aro-select-value');
+    var menu = root.querySelector('.aro-select-menu');
+    if (!trigger || !menu) return null;
+
+    var open = false;
+    var onChangeCb = opts && typeof opts.onChange === 'function' ? opts.onChange : null;
+
+    function optionNodes() {
+      return Array.prototype.slice.call(menu.querySelectorAll('.aro-select-option[data-value], .aro-select-option[data-value=""]'));
+    }
+
+    function getValue() {
+      var v = root.getAttribute('data-value');
+      return v == null ? '' : v;
+    }
+
+    function findOption(value) {
+      var optsList = optionNodes();
+      var want = value == null ? '' : String(value);
+      for (var i = 0; i < optsList.length; i++) {
+        if ((optsList[i].getAttribute('data-value') || '') === want) return optsList[i];
+      }
+      return null;
+    }
+
+    function syncSelectedUi() {
+      var cur = getValue();
+      var optsList = optionNodes();
+      var matched = null;
+      for (var i = 0; i < optsList.length; i++) {
+        var ov = optsList[i].getAttribute('data-value') || '';
+        var sel = ov === cur;
+        optsList[i].classList.toggle('is-selected', sel);
+        optsList[i].setAttribute('aria-selected', sel ? 'true' : 'false');
+        if (sel) matched = optsList[i];
+      }
+      if (labelEl) {
+        labelEl.textContent = matched
+          ? (matched.textContent || '').trim()
+          : (optsList[0] ? (optsList[0].textContent || '').trim() : '');
+      }
+    }
+
+    function setValue(value, silent) {
+      var next = value == null ? '' : String(value);
+      var prev = getValue();
+      root.setAttribute('data-value', next);
+      syncSelectedUi();
+      if (!silent && next !== prev) {
+        try {
+          root.dispatchEvent(new Event('change', { bubbles: true }));
+        } catch (eEvt) {
+          var ev = document.createEvent('Event');
+          ev.initEvent('change', true, true);
+          root.dispatchEvent(ev);
+        }
+        if (onChangeCb) onChangeCb(next);
+      }
+    }
+
+    function setOptions(options, selectedValue) {
+      var keep = selectedValue != null ? String(selectedValue) : getValue();
+      menu.innerHTML = '';
+      (options || []).forEach(function (opt) {
+        if (!opt) return;
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'aro-select-option manage-item';
+        btn.setAttribute('role', 'option');
+        btn.setAttribute('data-value', opt.value == null ? '' : String(opt.value));
+        if (opt.id) btn.id = opt.id;
+        btn.textContent = opt.label == null ? String(opt.value || '') : String(opt.label);
+        menu.appendChild(btn);
+      });
+      var has = findOption(keep);
+      if (!has) {
+        var first = optionNodes()[0];
+        keep = first ? (first.getAttribute('data-value') || '') : '';
+      }
+      root.setAttribute('data-value', keep);
+      syncSelectedUi();
+    }
+
+    function closeMenu() {
+      if (!open) return;
+      open = false;
+      root.classList.remove('is-open');
+      menu.classList.remove('open');
+      menu.hidden = true;
+      root.setAttribute('aria-expanded', 'false');
+      trigger.setAttribute('aria-expanded', 'false');
+    }
+
+    function openMenu() {
+      if (open || root.getAttribute('aria-disabled') === 'true') return;
+      // Close other aro-selects
+      document.querySelectorAll('.aro-select.is-open').forEach(function (el) {
+        if (el !== root && el._aroSelect) el._aroSelect.close();
+      });
+      open = true;
+      root.classList.add('is-open');
+      menu.hidden = false;
+      menu.classList.add('open');
+      root.setAttribute('aria-expanded', 'true');
+      trigger.setAttribute('aria-expanded', 'true');
+      var cur = findOption(getValue());
+      if (cur && typeof cur.focus === 'function') {
+        try { cur.focus(); } catch (eF) { /* ignore */ }
+      }
+    }
+
+    function toggleMenu() {
+      if (open) closeMenu();
+      else openMenu();
+    }
+
+    function onDocPointer(e) {
+      if (!open) return;
+      if (root.contains(e.target)) return;
+      closeMenu();
+    }
+
+    function onKeyDown(e) {
+      var key = e.key;
+      if (key === 'Escape') {
+        if (open) {
+          e.preventDefault();
+          e.stopPropagation();
+          closeMenu();
+          trigger.focus();
+        }
+        return;
+      }
+      if (key === 'Enter' || key === ' ') {
+        if (e.target === trigger || e.target === root) {
+          e.preventDefault();
+          toggleMenu();
+        }
+        return;
+      }
+      if (key === 'ArrowDown' || key === 'ArrowUp') {
+        e.preventDefault();
+        var optsList = optionNodes();
+        if (!optsList.length) return;
+        if (!open) {
+          openMenu();
+          return;
+        }
+        var active = document.activeElement;
+        var idx = optsList.indexOf(active);
+        if (idx < 0) {
+          var sel = findOption(getValue());
+          idx = sel ? optsList.indexOf(sel) : 0;
+        }
+        var nextIdx = key === 'ArrowDown'
+          ? Math.min(optsList.length - 1, (idx < 0 ? 0 : idx + 1))
+          : Math.max(0, (idx < 0 ? 0 : idx - 1));
+        if (idx < 0) nextIdx = key === 'ArrowDown' ? 0 : optsList.length - 1;
+        else if (key === 'ArrowDown') nextIdx = (idx + 1) % optsList.length;
+        else nextIdx = (idx - 1 + optsList.length) % optsList.length;
+        optsList[nextIdx].focus();
+      }
+    }
+
+    trigger.setAttribute('aria-haspopup', 'listbox');
+    trigger.setAttribute('aria-expanded', 'false');
+    if (!trigger.getAttribute('type')) trigger.type = 'button';
+    root.setAttribute('aria-haspopup', 'listbox');
+    root.setAttribute('aria-expanded', 'false');
+    if (!root.getAttribute('role')) root.setAttribute('role', 'combobox');
+    menu.setAttribute('role', 'listbox');
+    menu.hidden = true;
+    menu.classList.remove('open');
+
+    // Seed data-value from attribute or first option
+    if (!root.hasAttribute('data-value')) {
+      var firstOpt = optionNodes()[0];
+      root.setAttribute('data-value', firstOpt ? (firstOpt.getAttribute('data-value') || '') : '');
+    }
+    syncSelectedUi();
+
+    trigger.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleMenu();
+    });
+    menu.addEventListener('click', function (e) {
+      var opt = e.target && e.target.closest ? e.target.closest('.aro-select-option') : null;
+      if (!opt || !menu.contains(opt)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setValue(opt.getAttribute('data-value') || '', false);
+      closeMenu();
+      trigger.focus();
+    });
+    root.addEventListener('keydown', onKeyDown);
+    document.addEventListener('click', onDocPointer, true);
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && open) {
+        closeMenu();
+      }
+    });
+
+    var api = {
+      getValue: getValue,
+      setValue: setValue,
+      setOptions: setOptions,
+      open: openMenu,
+      close: closeMenu,
+      refreshLabel: syncSelectedUi,
+    };
+    Object.defineProperty(api, '_onChange', {
+      get: function () { return onChangeCb; },
+      set: function (fn) { onChangeCb = typeof fn === 'function' ? fn : null; },
+      configurable: true,
+    });
+
+    try {
+      Object.defineProperty(root, 'value', {
+        get: function () { return getValue(); },
+        set: function (v) { setValue(v, true); },
+        configurable: true,
+      });
+    } catch (eProp) { /* ignore */ }
+
+    root._aroSelect = api;
+    root.classList.add('aro-select-ready');
+    return api;
+  }
+
+  /** Init ring-create selects if present in DOM. */
+  function initRingCreateSelects() {
+    initAroSelect('ring-type-select');
+    initAroSelect('ring-brew-category-select');
+  }
+
   /** 本地化成员角色标签 */
   function roleLabel(role) {
     var map = { owner: lang.roleOwner, admin: lang.roleAdmin, member: lang.roleMember };
@@ -3319,8 +3640,10 @@
     el = $('ring-type-opt-tapp'); if (el) el.textContent = lang.ringTypeTappStore;
     el = $('ring-type-opt-library'); if (el) el.textContent = lang.ringTypeLibraryExchange;
     el = $('ring-type-opt-instance'); if (el) el.textContent = lang.ringTypeInstanceDirectory;
+    if (typeof refreshAroSelectLabel === 'function') refreshAroSelectLabel('ring-type-select');
     el = $('ring-brew-category-label'); if (el) el.textContent = lang.ringBrewCategoryLabel || 'Brew category (optional)';
     el = $('ring-brew-category-all'); if (el) el.textContent = lang.ringBrewCategoryAll || 'All my categories';
+    if (typeof refreshAroSelectLabel === 'function') refreshAroSelectLabel('ring-brew-category-select');
     el = $('ring-brew-category-input'); if (el) el.placeholder = lang.ringBrewCategoryPlaceholder || 'Or type a category name';
     document.querySelectorAll('[data-i18n-empty-peers]').forEach(function (node) {
       node.textContent = lang.emptyPeers;
@@ -13017,7 +13340,9 @@
   }
 
   function updateRingCreateCategoryVisibility() {
-    var type = ($('ring-type-select') || {}).value || 'brew-recommend';
+    var type = (typeof getAroSelectValue === 'function'
+      ? getAroSelectValue('ring-type-select')
+      : (($('ring-type-select') || {}).value)) || 'brew-recommend';
     var wrap = $('ring-brew-category-wrap');
     if (!wrap) return;
     if (type === 'brew-recommend') {
@@ -13032,9 +13357,13 @@
     var select = $('ring-brew-category-select');
     var freeText = $('ring-brew-category-input');
     if (!select) return;
-    // Keep the "all" option; rebuild the rest
+    if (typeof initAroSelect === 'function') initAroSelect(select);
+    // Keep the "all" option; rebuild the rest via custom select API
     var allLabel = (lang.ringBrewCategoryAll || 'All my categories');
-    select.innerHTML = '<option id="ring-brew-category-all" value="">' + esc(allLabel) + '</option>';
+    var baseOpts = [{ value: '', label: allLabel, id: 'ring-brew-category-all' }];
+    if (typeof setAroSelectOptions === 'function') {
+      setAroSelectOptions(select, baseOpts, '');
+    }
     if (freeText) {
       freeText.value = '';
       freeText.style.display = 'none';
@@ -13048,14 +13377,15 @@
     select.style.display = '';
     Tapp.brewList.categories().then(function (cats) {
       var list = Array.isArray(cats) ? cats : (cats && cats.categories) || [];
+      var opts = [{ value: '', label: allLabel, id: 'ring-brew-category-all' }];
       list.forEach(function (c) {
         var name = (c && (c.name || c)) || '';
         if (!name) return;
-        var opt = document.createElement('option');
-        opt.value = name;
-        opt.textContent = name;
-        select.appendChild(opt);
+        opts.push({ value: name, label: name });
       });
+      if (typeof setAroSelectOptions === 'function') {
+        setAroSelectOptions(select, opts, '');
+      }
       // If no categories from API, allow free-text
       if (list.length === 0 && freeText) {
         freeText.style.display = '';
@@ -13073,14 +13403,18 @@
     if (!input) return;
     var name = input.value.trim();
     if (!name) return;
-    var type = ($('ring-type-select') || {}).value || 'brew-recommend';
+    var type = (typeof getAroSelectValue === 'function'
+      ? getAroSelectValue('ring-type-select')
+      : (($('ring-type-select') || {}).value)) || 'brew-recommend';
     var req = { name: name, ring_type: type };
     if (type === 'brew-recommend') {
       var catSelect = $('ring-brew-category-select');
       var catInput = $('ring-brew-category-input');
       var cat = '';
       if (catSelect && catSelect.style.display !== 'none') {
-        cat = (catSelect.value || '').trim();
+        cat = ((typeof getAroSelectValue === 'function'
+          ? getAroSelectValue(catSelect)
+          : catSelect.value) || '').trim();
       }
       if (!cat && catInput && catInput.style.display !== 'none') {
         cat = (catInput.value || '').trim();
@@ -13092,7 +13426,8 @@
       await Tapp.federation.createRing(req);
       input.value = '';
       var catSel = $('ring-brew-category-select');
-      if (catSel) catSel.value = '';
+      if (catSel && typeof setAroSelectValue === 'function') setAroSelectValue(catSel, '', true);
+      else if (catSel) catSel.value = '';
       var catIn = $('ring-brew-category-input');
       if (catIn) catIn.value = '';
       var d = $('ring-create-dialog');
@@ -13375,6 +13710,11 @@
       }
       if (typeof updateRingCreateCategoryVisibility === 'function') updateRingCreateCategoryVisibility();
     });
+    if (typeof initRingCreateSelects === 'function') initRingCreateSelects();
+    else if (typeof initAroSelect === 'function') {
+      initAroSelect('ring-type-select');
+      initAroSelect('ring-brew-category-select');
+    }
     var ringTypeSelect = $('ring-type-select');
     if (ringTypeSelect) ringTypeSelect.addEventListener('change', function () {
       if (typeof updateRingCreateCategoryVisibility === 'function') updateRingCreateCategoryVisibility();

--- a/apps/com.myriad.aro/manifest.json
+++ b/apps/com.myriad.aro/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.aro",
   "name": "Aro",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minSystemVersion": "0.2.1",
   "description": "社交中心，统一管理消息、时间线、环网与个人资料",
   "locales": {

--- a/apps/com.myriad.aro/page.css
+++ b/apps/com.myriad.aro/page.css
@@ -777,8 +777,24 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   transition:background .12s,border-color .12s;
 }
 .backup-check:hover{background:rgba(128,128,128,.06)}
-.backup-check input{
-  width:16px;height:16px;margin:0;flex-shrink:0;accent-color:var(--tapp-primary,#6366f1);cursor:pointer;
+.backup-check input[type="checkbox"]{
+  appearance:none;-webkit-appearance:none;
+  width:16px;height:16px;margin:0;flex-shrink:0;cursor:pointer;
+  border-radius:4px;border:1.5px solid rgba(128,128,128,.35);background:transparent;
+  display:inline-grid;place-content:center;transition:border-color .12s,background .12s;
+}
+.backup-check input[type="checkbox"]::before{
+  content:"";width:9px;height:5px;border:solid #fff;border-width:0 0 2px 2px;
+  transform:rotate(-45deg) scale(0);transform-origin:center;transition:transform .12s ease;
+  margin-top:-1px;
+}
+.backup-check input[type="checkbox"]:checked{
+  border-color:var(--tapp-primary,#6366f1);background:var(--tapp-primary,#6366f1);
+}
+.backup-check input[type="checkbox"]:checked::before{transform:rotate(-45deg) scale(1)}
+.dark .backup-check input[type="checkbox"]{border-color:rgba(255,255,255,.28)}
+.dark .backup-check input[type="checkbox"]:checked{
+  border-color:var(--tapp-primary,#818cf8);background:var(--tapp-primary,#6366f1);
 }
 .backup-status{
   min-height:0;font-size:12px;font-weight:600;line-height:1.4;
@@ -845,7 +861,7 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .dark .backup-btn{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.1);color:rgba(255,255,255,.88)}
 .dark .backup-btn-primary{background:var(--tapp-primary,#6366f1);border-color:transparent;color:#fff}
 .dark .backup-btn-ghost:hover{background:rgba(255,255,255,.08);color:rgba(255,255,255,.9)}
-.dark .backup-check{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.06);color:rgba(255,255,255,.55)}
+.dark .backup-check{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.06);color:rgba(255,255,255,.72)}
 .dark .backup-archive-item,.dark .backup-archive-link{background:rgba(255,255,255,.035);border-color:rgba(255,255,255,.06)}
 .dark .backup-archive-link:hover{background:rgba(var(--tapp-primary-rgb,99,102,241),.14)}
 .dark .backup-toolbar{background:linear-gradient(180deg,rgba(10,10,10,.92) 55%,rgba(10,10,10,0))}
@@ -895,7 +911,23 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   border-color:rgba(var(--tapp-primary-rgb,99,102,241),.45);
   background:rgba(var(--tapp-primary-rgb,99,102,241),.08);
 }
-.settings-radio input{margin-top:2px;accent-color:var(--tapp-primary,#6366f1)}
+.settings-radio input[type="radio"]{
+  appearance:none;-webkit-appearance:none;margin-top:2px;flex-shrink:0;
+  width:16px;height:16px;border-radius:50%;cursor:pointer;
+  border:1.5px solid rgba(128,128,128,.35);background:transparent;
+  box-shadow:none;transition:border-color .12s,background .12s,box-shadow .12s;
+}
+.settings-radio input[type="radio"]:checked{
+  border-color:var(--tapp-primary,#6366f1);
+  background:var(--tapp-primary,#6366f1);
+  box-shadow:inset 0 0 0 3px var(--bg-primary,#fff);
+}
+.dark .settings-radio input[type="radio"]{border-color:rgba(255,255,255,.28)}
+.dark .settings-radio input[type="radio"]:checked{
+  border-color:var(--tapp-primary,#818cf8);
+  background:var(--tapp-primary,#6366f1);
+  box-shadow:inset 0 0 0 3px #121212;
+}
 .settings-radio-body{min-width:0;flex:1}
 .settings-radio-title{font-size:13px;font-weight:650;color:var(--text-primary,#0f1419)}
 .settings-radio-desc{margin-top:2px;font-size:11.5px;line-height:1.4;color:var(--text-secondary,#8b98a5)}
@@ -1838,15 +1870,80 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 .create-tab{flex:1;padding:6px 12px;border:none;background:none;border-radius:8px;font-size:12px;font-weight:500;color:var(--text-secondary,#999);cursor:pointer;transition:all .15s}
 .create-tab-active{background:var(--bg-primary,#fff);color:var(--text-primary,#1a1a1a);box-shadow:0 1px 3px rgba(0,0,0,.08)}
 .create-form{display:flex;flex-direction:column;gap:10px}
-.create-input{height:40px;padding:0 14px;border-radius:12px;border:1px solid rgba(128,128,128,.15);background:rgba(128,128,128,.03);color:var(--text-primary,#1a1a1a);font-size:13px;outline:none;transition:border-color .2s}
+.create-input{height:40px;padding:0 14px;border-radius:12px;border:1px solid rgba(128,128,128,.15);background:rgba(128,128,128,.03);color:var(--text-primary,#1a1a1a);font-size:13px;outline:none;transition:border-color .2s;box-sizing:border-box;font-family:inherit}
 .create-input:focus{border-color:rgba(var(--tapp-primary-rgb,128,128,128),.4)}
 .create-input::placeholder{color:var(--text-secondary,#bbb)}
 .create-submit{height:40px;border-radius:12px;border:none;background:var(--tapp-primary,#888);color:#fff;font-size:13px;font-weight:500;cursor:pointer;transition:opacity .15s}
 .create-submit:hover{opacity:.85}
 .create-submit:disabled{opacity:.4;cursor:not-allowed}
-.dark .create-dialog{background:var(--bg-primary,#1a1a1a)}
+.dark .create-dialog{background:var(--bg-primary,#1a1a1a);box-shadow:0 16px 48px rgba(0,0,0,.45)}
+.dark .create-overlay{background:rgba(0,0,0,.55)}
 .dark .create-tab-active{background:rgba(255,255,255,.08);color:rgba(255,255,255,.92)}
 .dark .create-input{background:rgba(255,255,255,.03);border-color:rgba(255,255,255,.1);color:rgba(255,255,255,.9)}
+.dark .create-dialog-close{color:rgba(255,255,255,.5)}
+.dark .create-dialog-close:hover{background:rgba(255,255,255,.08);color:rgba(255,255,255,.9)}
+.dark .create-divider{background:rgba(255,255,255,.08)}
+.dark .create-submit-secondary{background:rgba(255,255,255,.1)!important;color:rgba(255,255,255,.9)!important}
+
+/* ===== Custom select (replaces native <select>) ===== */
+.aro-select{position:relative;display:block;width:100%;min-width:0}
+.aro-select-trigger.create-input,
+button.aro-select-trigger.create-input{
+  display:flex;align-items:center;justify-content:space-between;gap:10px;
+  width:100%;height:40px;padding:0 12px 0 14px;margin:0;cursor:pointer;
+  text-align:left;font:inherit;line-height:1.2;appearance:none;-webkit-appearance:none;
+}
+.aro-select-trigger:focus,
+.aro-select-trigger:focus-visible{
+  border-color:rgba(var(--tapp-primary-rgb,99,102,241),.45);
+  outline:none;
+  box-shadow:0 0 0 3px rgba(var(--tapp-primary-rgb,99,102,241),.16);
+}
+.aro-select.is-open .aro-select-trigger{
+  border-color:rgba(var(--tapp-primary-rgb,99,102,241),.45);
+}
+.aro-select-value{
+  flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  color:var(--text-primary,#1a1a1a);font-size:13px;font-weight:500;
+}
+.aro-select-chevron{
+  flex-shrink:0;font-size:11px;line-height:1;opacity:.55;
+  color:var(--text-secondary,#888);transition:transform .15s var(--aro-ease,ease);
+}
+.aro-select.is-open .aro-select-chevron{transform:rotate(180deg);opacity:.8}
+.aro-select-menu.manage-dropdown{
+  display:none;left:0;right:0;top:calc(100% + 4px);min-width:100%;width:100%;
+  max-height:min(240px,42vh);overflow-x:hidden;overflow-y:auto;z-index:120;
+  padding:4px;scrollbar-width:thin;scrollbar-color:rgba(128,128,128,.35) transparent;
+}
+.aro-select-menu.manage-dropdown.open,
+.aro-select.is-open .aro-select-menu.manage-dropdown{display:block}
+.aro-select-option.manage-item{
+  width:100%;min-height:36px;padding:8px 12px;border-radius:8px;
+  font-size:13px;font-weight:500;justify-content:flex-start;
+}
+.aro-select-option.manage-item.is-selected{
+  background:rgba(var(--tapp-primary-rgb,99,102,241),.12);
+  color:var(--tapp-primary,#6366f1);
+  font-weight:600;
+}
+.aro-select-option.manage-item:focus-visible{
+  outline:2px solid rgba(var(--tapp-primary-rgb,99,102,241),.45);
+  outline-offset:-2px;
+}
+.dark .aro-select-value{color:rgba(255,255,255,.9)}
+.dark .aro-select-chevron{color:rgba(255,255,255,.5)}
+.dark .aro-select-option.manage-item.is-selected{
+  background:rgba(var(--tapp-primary-rgb,99,102,241),.2);
+  color:var(--tapp-primary,#818cf8);
+}
+.dark .aro-select-menu.manage-dropdown{
+  background:var(--bg-primary,#1a1a1a);
+  border-color:rgba(255,255,255,.1);
+  box-shadow:0 8px 28px rgba(0,0,0,.45);
+  scrollbar-color:rgba(255,255,255,.22) transparent;
+}
+
 .edit-label{font-size:11px;font-weight:600;color:var(--text-secondary,#888);text-transform:uppercase;letter-spacing:.04em}
 .member-kick{margin-left:auto;width:36px;height:36px;min-width:36px;min-height:36px;border:none;background:none;color:var(--text-secondary,#999);cursor:pointer;border-radius:8px;display:flex;align-items:center;justify-content:center;opacity:0;transition:opacity .15s,background .15s;flex-shrink:0}
 .member-item:hover .member-kick,.member-kick:focus-visible{opacity:1}
@@ -1930,13 +2027,36 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 .create-overlay{animation:aroFadeIn var(--aro-dur) ease both}
 .create-dialog{animation:aroScaleIn var(--aro-dur) var(--aro-ease) both}
 .edit-check-row{display:flex;align-items:flex-start;gap:8px;font-size:12.5px;line-height:1.4;color:var(--text-primary,#1a1a1a);cursor:pointer;user-select:none}
-.edit-check-row input{margin-top:2px;flex-shrink:0}
+.edit-check-row input[type="checkbox"]{
+  appearance:none;-webkit-appearance:none;margin-top:2px;flex-shrink:0;cursor:pointer;
+  width:16px;height:16px;border-radius:4px;border:1.5px solid rgba(128,128,128,.35);
+  background:transparent;display:inline-grid;place-content:center;
+  transition:border-color .12s,background .12s;
+}
+.edit-check-row input[type="checkbox"]::before{
+  content:"";width:9px;height:5px;border:solid #fff;border-width:0 0 2px 2px;
+  transform:rotate(-45deg) scale(0);transform-origin:center;transition:transform .12s ease;
+  margin-top:-1px;
+}
+.edit-check-row input[type="checkbox"]:checked{
+  border-color:var(--tapp-primary,#6366f1);background:var(--tapp-primary,#6366f1);
+}
+.edit-check-row input[type="checkbox"]:checked::before{transform:rotate(-45deg) scale(1)}
+.edit-check-row input[type="checkbox"]:disabled{opacity:.45;cursor:not-allowed}
+.dark .edit-check-row{color:rgba(255,255,255,.88)}
+.dark .edit-check-row input[type="checkbox"]{border-color:rgba(255,255,255,.28)}
+.dark .edit-check-row input[type="checkbox"]:checked{
+  border-color:var(--tapp-primary,#818cf8);background:var(--tapp-primary,#6366f1);
+}
 .edit-hint{margin:0;font-size:11.5px;line-height:1.4;color:var(--text-secondary,#999)}
+.dark .edit-hint{color:rgba(255,255,255,.45)}
 .edit-room-id-box{display:flex;flex-direction:column;gap:6px}
 .edit-room-id-row{display:flex;align-items:center;gap:8px}
-.edit-room-id-value{flex:1;min-width:0;padding:8px 10px;border-radius:8px;background:rgba(128,128,128,.08);font-size:11.5px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.edit-room-id-value{flex:1;min-width:0;padding:8px 10px;border-radius:8px;background:rgba(128,128,128,.08);font-size:11.5px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-primary,#1a1a1a)}
+.dark .edit-room-id-value{background:rgba(255,255,255,.06);color:rgba(255,255,255,.82)}
 .edit-room-id-copy{flex-shrink:0;padding:6px 10px;border:none;border-radius:8px;background:rgba(var(--tapp-primary-rgb,100,100,255),.12);color:var(--tapp-primary,#6366f1);font-size:12px;font-weight:500;cursor:pointer}
 .edit-room-id-copy:hover{filter:brightness(1.05)}
+.dark .edit-room-id-copy{background:rgba(var(--tapp-primary-rgb,99,102,241),.2);color:var(--tapp-primary,#818cf8)}
 .create-divider{height:1px;background:rgba(128,128,128,.12);margin:4px 0}
 .create-submit-secondary{background:rgba(128,128,128,.1)!important;color:var(--text-primary,#1a1a1a)!important;box-shadow:none!important}
 .meta-badge.badge-public{background:rgba(34,197,94,.12);color:#16a34a}

--- a/apps/com.myriad.aro/page.html
+++ b/apps/com.myriad.aro/page.html
@@ -425,17 +425,29 @@
       </div>
       <div class="create-form">
         <input id="ring-name-input" class="create-input" type="text" placeholder="环网名称" />
-        <select id="ring-type-select" class="create-input" style="height:40px;cursor:pointer">
-          <option id="ring-type-opt-brew" value="brew-recommend">Brew 推荐</option>
-          <option id="ring-type-opt-tapp" value="tapp-store">Tapp 商店</option>
-          <option id="ring-type-opt-library" value="library-exchange">资料交换</option>
-          <option id="ring-type-opt-instance" value="instance-directory">实例目录</option>
-        </select>
+        <div id="ring-type-select" class="aro-select" data-value="brew-recommend" role="combobox" aria-haspopup="listbox" aria-expanded="false">
+          <button type="button" class="aro-select-trigger create-input" id="ring-type-select-trigger" aria-haspopup="listbox" aria-expanded="false">
+            <span class="aro-select-value" data-aro-select-label>Brew 推荐</span>
+            <span class="aro-select-chevron" aria-hidden="true">▾</span>
+          </button>
+          <div class="aro-select-menu manage-dropdown" role="listbox" hidden>
+            <button type="button" class="aro-select-option manage-item" role="option" id="ring-type-opt-brew" data-value="brew-recommend" aria-selected="true">Brew 推荐</button>
+            <button type="button" class="aro-select-option manage-item" role="option" id="ring-type-opt-tapp" data-value="tapp-store" aria-selected="false">Tapp 商店</button>
+            <button type="button" class="aro-select-option manage-item" role="option" id="ring-type-opt-library" data-value="library-exchange" aria-selected="false">资料交换</button>
+            <button type="button" class="aro-select-option manage-item" role="option" id="ring-type-opt-instance" data-value="instance-directory" aria-selected="false">实例目录</button>
+          </div>
+        </div>
         <div id="ring-brew-category-wrap" style="display:none;flex-direction:column;gap:6px">
-          <label id="ring-brew-category-label" for="ring-brew-category-select" style="font-size:12px;opacity:.8">Brew category (optional)</label>
-          <select id="ring-brew-category-select" class="create-input" style="height:40px;cursor:pointer">
-            <option id="ring-brew-category-all" value="">All my categories</option>
-          </select>
+          <label id="ring-brew-category-label" for="ring-brew-category-select-trigger" style="font-size:12px;opacity:.8">Brew category (optional)</label>
+          <div id="ring-brew-category-select" class="aro-select" data-value="" role="combobox" aria-haspopup="listbox" aria-expanded="false">
+            <button type="button" class="aro-select-trigger create-input" id="ring-brew-category-select-trigger" aria-haspopup="listbox" aria-expanded="false">
+              <span class="aro-select-value" data-aro-select-label>All my categories</span>
+              <span class="aro-select-chevron" aria-hidden="true">▾</span>
+            </button>
+            <div class="aro-select-menu manage-dropdown" role="listbox" hidden>
+              <button type="button" class="aro-select-option manage-item" role="option" id="ring-brew-category-all" data-value="" aria-selected="true">All my categories</button>
+            </div>
+          </div>
           <input id="ring-brew-category-input" class="create-input" type="text" placeholder="Or type a category name" style="display:none" />
         </div>
         <button id="create-ring-btn" class="create-submit">创建</button>

--- a/apps/com.myriad.aro/page/events.js
+++ b/apps/com.myriad.aro/page/events.js
@@ -5,6 +5,11 @@
     }
     if (typeof updateRingCreateCategoryVisibility === 'function') updateRingCreateCategoryVisibility();
   });
+  if (typeof initRingCreateSelects === 'function') initRingCreateSelects();
+  else if (typeof initAroSelect === 'function') {
+    initAroSelect('ring-type-select');
+    initAroSelect('ring-brew-category-select');
+  }
   var ringTypeSelect = $('ring-type-select');
   if (ringTypeSelect) ringTypeSelect.addEventListener('change', function () {
     if (typeof updateRingCreateCategoryVisibility === 'function') updateRingCreateCategoryVisibility();

--- a/apps/com.myriad.aro/page/helpers.js
+++ b/apps/com.myriad.aro/page/helpers.js
@@ -666,6 +666,327 @@ function ringTypeLabel(type) {
   return map[type] || type || '';
 }
 
+// ==================== Custom select (aro-select) ====================
+// Lightweight listbox replacing native <select> for dark/iframe-friendly UI.
+// Reuses manage-dropdown / manage-item visual language.
+
+/**
+ * Resolve a root element for aro-select by id or node.
+ * @param {string|HTMLElement} rootOrId
+ * @returns {HTMLElement|null}
+ */
+function resolveAroSelectRoot(rootOrId) {
+  if (!rootOrId) return null;
+  if (typeof rootOrId === 'string') return $(rootOrId);
+  return rootOrId.nodeType ? rootOrId : null;
+}
+
+/**
+ * Read value from custom select or native control.
+ * @param {string|HTMLElement} rootOrId
+ * @returns {string}
+ */
+function getAroSelectValue(rootOrId) {
+  var root = resolveAroSelectRoot(rootOrId);
+  if (!root) return '';
+  if (root._aroSelect && typeof root._aroSelect.getValue === 'function') {
+    return root._aroSelect.getValue();
+  }
+  if (typeof root.value === 'string') return root.value;
+  return root.getAttribute('data-value') || '';
+}
+
+/**
+ * Set value on custom select (or native). silent skips change event.
+ * @param {string|HTMLElement} rootOrId
+ * @param {string} value
+ * @param {boolean} [silent]
+ */
+function setAroSelectValue(rootOrId, value, silent) {
+  var root = resolveAroSelectRoot(rootOrId);
+  if (!root) return;
+  if (root._aroSelect && typeof root._aroSelect.setValue === 'function') {
+    root._aroSelect.setValue(value, !!silent);
+    return;
+  }
+  root.value = value == null ? '' : String(value);
+}
+
+/**
+ * Replace options: [{ value, label, id? }]. Keeps selection when possible.
+ * @param {string|HTMLElement} rootOrId
+ * @param {Array<{value:string,label:string,id?:string}>} options
+ * @param {string} [selectedValue]
+ */
+function setAroSelectOptions(rootOrId, options, selectedValue) {
+  var root = resolveAroSelectRoot(rootOrId);
+  if (!root) return;
+  if (!root._aroSelect) initAroSelect(root);
+  if (root._aroSelect && typeof root._aroSelect.setOptions === 'function') {
+    root._aroSelect.setOptions(options || [], selectedValue);
+  }
+}
+
+/** Refresh trigger label after i18n updates option textContent. */
+function refreshAroSelectLabel(rootOrId) {
+  var root = resolveAroSelectRoot(rootOrId);
+  if (root && root._aroSelect && typeof root._aroSelect.refreshLabel === 'function') {
+    root._aroSelect.refreshLabel();
+  }
+}
+
+/**
+ * Initialize a custom select root. Safe to call multiple times.
+ * Defines root.value get/set and dispatches bubbling 'change' events.
+ * @param {string|HTMLElement} rootOrId
+ * @param {{ onChange?: function(string):void }} [opts]
+ * @returns {{ getValue:function, setValue:function, setOptions:function, open:function, close:function, refreshLabel:function }|null}
+ */
+function initAroSelect(rootOrId, opts) {
+  var root = resolveAroSelectRoot(rootOrId);
+  if (!root) return null;
+  if (root._aroSelect) {
+    if (opts && typeof opts.onChange === 'function') root._aroSelect._onChange = opts.onChange;
+    return root._aroSelect;
+  }
+
+  var trigger = root.querySelector('.aro-select-trigger');
+  var labelEl = root.querySelector('[data-aro-select-label]') || root.querySelector('.aro-select-value');
+  var menu = root.querySelector('.aro-select-menu');
+  if (!trigger || !menu) return null;
+
+  var open = false;
+  var onChangeCb = opts && typeof opts.onChange === 'function' ? opts.onChange : null;
+
+  function optionNodes() {
+    return Array.prototype.slice.call(menu.querySelectorAll('.aro-select-option[data-value], .aro-select-option[data-value=""]'));
+  }
+
+  function getValue() {
+    var v = root.getAttribute('data-value');
+    return v == null ? '' : v;
+  }
+
+  function findOption(value) {
+    var optsList = optionNodes();
+    var want = value == null ? '' : String(value);
+    for (var i = 0; i < optsList.length; i++) {
+      if ((optsList[i].getAttribute('data-value') || '') === want) return optsList[i];
+    }
+    return null;
+  }
+
+  function syncSelectedUi() {
+    var cur = getValue();
+    var optsList = optionNodes();
+    var matched = null;
+    for (var i = 0; i < optsList.length; i++) {
+      var ov = optsList[i].getAttribute('data-value') || '';
+      var sel = ov === cur;
+      optsList[i].classList.toggle('is-selected', sel);
+      optsList[i].setAttribute('aria-selected', sel ? 'true' : 'false');
+      if (sel) matched = optsList[i];
+    }
+    if (labelEl) {
+      labelEl.textContent = matched
+        ? (matched.textContent || '').trim()
+        : (optsList[0] ? (optsList[0].textContent || '').trim() : '');
+    }
+  }
+
+  function setValue(value, silent) {
+    var next = value == null ? '' : String(value);
+    var prev = getValue();
+    root.setAttribute('data-value', next);
+    syncSelectedUi();
+    if (!silent && next !== prev) {
+      try {
+        root.dispatchEvent(new Event('change', { bubbles: true }));
+      } catch (eEvt) {
+        var ev = document.createEvent('Event');
+        ev.initEvent('change', true, true);
+        root.dispatchEvent(ev);
+      }
+      if (onChangeCb) onChangeCb(next);
+    }
+  }
+
+  function setOptions(options, selectedValue) {
+    var keep = selectedValue != null ? String(selectedValue) : getValue();
+    menu.innerHTML = '';
+    (options || []).forEach(function (opt) {
+      if (!opt) return;
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'aro-select-option manage-item';
+      btn.setAttribute('role', 'option');
+      btn.setAttribute('data-value', opt.value == null ? '' : String(opt.value));
+      if (opt.id) btn.id = opt.id;
+      btn.textContent = opt.label == null ? String(opt.value || '') : String(opt.label);
+      menu.appendChild(btn);
+    });
+    var has = findOption(keep);
+    if (!has) {
+      var first = optionNodes()[0];
+      keep = first ? (first.getAttribute('data-value') || '') : '';
+    }
+    root.setAttribute('data-value', keep);
+    syncSelectedUi();
+  }
+
+  function closeMenu() {
+    if (!open) return;
+    open = false;
+    root.classList.remove('is-open');
+    menu.classList.remove('open');
+    menu.hidden = true;
+    root.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-expanded', 'false');
+  }
+
+  function openMenu() {
+    if (open || root.getAttribute('aria-disabled') === 'true') return;
+    // Close other aro-selects
+    document.querySelectorAll('.aro-select.is-open').forEach(function (el) {
+      if (el !== root && el._aroSelect) el._aroSelect.close();
+    });
+    open = true;
+    root.classList.add('is-open');
+    menu.hidden = false;
+    menu.classList.add('open');
+    root.setAttribute('aria-expanded', 'true');
+    trigger.setAttribute('aria-expanded', 'true');
+    var cur = findOption(getValue());
+    if (cur && typeof cur.focus === 'function') {
+      try { cur.focus(); } catch (eF) { /* ignore */ }
+    }
+  }
+
+  function toggleMenu() {
+    if (open) closeMenu();
+    else openMenu();
+  }
+
+  function onDocPointer(e) {
+    if (!open) return;
+    if (root.contains(e.target)) return;
+    closeMenu();
+  }
+
+  function onKeyDown(e) {
+    var key = e.key;
+    if (key === 'Escape') {
+      if (open) {
+        e.preventDefault();
+        e.stopPropagation();
+        closeMenu();
+        trigger.focus();
+      }
+      return;
+    }
+    if (key === 'Enter' || key === ' ') {
+      if (e.target === trigger || e.target === root) {
+        e.preventDefault();
+        toggleMenu();
+      }
+      return;
+    }
+    if (key === 'ArrowDown' || key === 'ArrowUp') {
+      e.preventDefault();
+      var optsList = optionNodes();
+      if (!optsList.length) return;
+      if (!open) {
+        openMenu();
+        return;
+      }
+      var active = document.activeElement;
+      var idx = optsList.indexOf(active);
+      if (idx < 0) {
+        var sel = findOption(getValue());
+        idx = sel ? optsList.indexOf(sel) : 0;
+      }
+      var nextIdx = key === 'ArrowDown'
+        ? Math.min(optsList.length - 1, (idx < 0 ? 0 : idx + 1))
+        : Math.max(0, (idx < 0 ? 0 : idx - 1));
+      if (idx < 0) nextIdx = key === 'ArrowDown' ? 0 : optsList.length - 1;
+      else if (key === 'ArrowDown') nextIdx = (idx + 1) % optsList.length;
+      else nextIdx = (idx - 1 + optsList.length) % optsList.length;
+      optsList[nextIdx].focus();
+    }
+  }
+
+  trigger.setAttribute('aria-haspopup', 'listbox');
+  trigger.setAttribute('aria-expanded', 'false');
+  if (!trigger.getAttribute('type')) trigger.type = 'button';
+  root.setAttribute('aria-haspopup', 'listbox');
+  root.setAttribute('aria-expanded', 'false');
+  if (!root.getAttribute('role')) root.setAttribute('role', 'combobox');
+  menu.setAttribute('role', 'listbox');
+  menu.hidden = true;
+  menu.classList.remove('open');
+
+  // Seed data-value from attribute or first option
+  if (!root.hasAttribute('data-value')) {
+    var firstOpt = optionNodes()[0];
+    root.setAttribute('data-value', firstOpt ? (firstOpt.getAttribute('data-value') || '') : '');
+  }
+  syncSelectedUi();
+
+  trigger.addEventListener('click', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleMenu();
+  });
+  menu.addEventListener('click', function (e) {
+    var opt = e.target && e.target.closest ? e.target.closest('.aro-select-option') : null;
+    if (!opt || !menu.contains(opt)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setValue(opt.getAttribute('data-value') || '', false);
+    closeMenu();
+    trigger.focus();
+  });
+  root.addEventListener('keydown', onKeyDown);
+  document.addEventListener('click', onDocPointer, true);
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && open) {
+      closeMenu();
+    }
+  });
+
+  var api = {
+    getValue: getValue,
+    setValue: setValue,
+    setOptions: setOptions,
+    open: openMenu,
+    close: closeMenu,
+    refreshLabel: syncSelectedUi,
+  };
+  Object.defineProperty(api, '_onChange', {
+    get: function () { return onChangeCb; },
+    set: function (fn) { onChangeCb = typeof fn === 'function' ? fn : null; },
+    configurable: true,
+  });
+
+  try {
+    Object.defineProperty(root, 'value', {
+      get: function () { return getValue(); },
+      set: function (v) { setValue(v, true); },
+      configurable: true,
+    });
+  } catch (eProp) { /* ignore */ }
+
+  root._aroSelect = api;
+  root.classList.add('aro-select-ready');
+  return api;
+}
+
+/** Init ring-create selects if present in DOM. */
+function initRingCreateSelects() {
+  initAroSelect('ring-type-select');
+  initAroSelect('ring-brew-category-select');
+}
+
 /** 本地化成员角色标签 */
 function roleLabel(role) {
   var map = { owner: lang.roleOwner, admin: lang.roleAdmin, member: lang.roleMember };
@@ -1624,8 +1945,10 @@ function applyLabels() {
   el = $('ring-type-opt-tapp'); if (el) el.textContent = lang.ringTypeTappStore;
   el = $('ring-type-opt-library'); if (el) el.textContent = lang.ringTypeLibraryExchange;
   el = $('ring-type-opt-instance'); if (el) el.textContent = lang.ringTypeInstanceDirectory;
+  if (typeof refreshAroSelectLabel === 'function') refreshAroSelectLabel('ring-type-select');
   el = $('ring-brew-category-label'); if (el) el.textContent = lang.ringBrewCategoryLabel || 'Brew category (optional)';
   el = $('ring-brew-category-all'); if (el) el.textContent = lang.ringBrewCategoryAll || 'All my categories';
+  if (typeof refreshAroSelectLabel === 'function') refreshAroSelectLabel('ring-brew-category-select');
   el = $('ring-brew-category-input'); if (el) el.placeholder = lang.ringBrewCategoryPlaceholder || 'Or type a category name';
   document.querySelectorAll('[data-i18n-empty-peers]').forEach(function (node) {
     node.textContent = lang.emptyPeers;

--- a/apps/com.myriad.aro/page/views.js
+++ b/apps/com.myriad.aro/page/views.js
@@ -2348,7 +2348,9 @@ function renderRingsSidebar() {
 }
 
 function updateRingCreateCategoryVisibility() {
-  var type = ($('ring-type-select') || {}).value || 'brew-recommend';
+  var type = (typeof getAroSelectValue === 'function'
+    ? getAroSelectValue('ring-type-select')
+    : (($('ring-type-select') || {}).value)) || 'brew-recommend';
   var wrap = $('ring-brew-category-wrap');
   if (!wrap) return;
   if (type === 'brew-recommend') {
@@ -2363,9 +2365,13 @@ function loadBrewCategoriesForRingCreate() {
   var select = $('ring-brew-category-select');
   var freeText = $('ring-brew-category-input');
   if (!select) return;
-  // Keep the "all" option; rebuild the rest
+  if (typeof initAroSelect === 'function') initAroSelect(select);
+  // Keep the "all" option; rebuild the rest via custom select API
   var allLabel = (lang.ringBrewCategoryAll || 'All my categories');
-  select.innerHTML = '<option id="ring-brew-category-all" value="">' + esc(allLabel) + '</option>';
+  var baseOpts = [{ value: '', label: allLabel, id: 'ring-brew-category-all' }];
+  if (typeof setAroSelectOptions === 'function') {
+    setAroSelectOptions(select, baseOpts, '');
+  }
   if (freeText) {
     freeText.value = '';
     freeText.style.display = 'none';
@@ -2379,14 +2385,15 @@ function loadBrewCategoriesForRingCreate() {
   select.style.display = '';
   Tapp.brewList.categories().then(function (cats) {
     var list = Array.isArray(cats) ? cats : (cats && cats.categories) || [];
+    var opts = [{ value: '', label: allLabel, id: 'ring-brew-category-all' }];
     list.forEach(function (c) {
       var name = (c && (c.name || c)) || '';
       if (!name) return;
-      var opt = document.createElement('option');
-      opt.value = name;
-      opt.textContent = name;
-      select.appendChild(opt);
+      opts.push({ value: name, label: name });
     });
+    if (typeof setAroSelectOptions === 'function') {
+      setAroSelectOptions(select, opts, '');
+    }
     // If no categories from API, allow free-text
     if (list.length === 0 && freeText) {
       freeText.style.display = '';
@@ -2404,14 +2411,18 @@ async function doCreateRing() {
   if (!input) return;
   var name = input.value.trim();
   if (!name) return;
-  var type = ($('ring-type-select') || {}).value || 'brew-recommend';
+  var type = (typeof getAroSelectValue === 'function'
+    ? getAroSelectValue('ring-type-select')
+    : (($('ring-type-select') || {}).value)) || 'brew-recommend';
   var req = { name: name, ring_type: type };
   if (type === 'brew-recommend') {
     var catSelect = $('ring-brew-category-select');
     var catInput = $('ring-brew-category-input');
     var cat = '';
     if (catSelect && catSelect.style.display !== 'none') {
-      cat = (catSelect.value || '').trim();
+      cat = ((typeof getAroSelectValue === 'function'
+        ? getAroSelectValue(catSelect)
+        : catSelect.value) || '').trim();
     }
     if (!cat && catInput && catInput.style.display !== 'none') {
       cat = (catInput.value || '').trim();
@@ -2423,7 +2434,8 @@ async function doCreateRing() {
     await Tapp.federation.createRing(req);
     input.value = '';
     var catSel = $('ring-brew-category-select');
-    if (catSel) catSel.value = '';
+    if (catSel && typeof setAroSelectValue === 'function') setAroSelectValue(catSel, '', true);
+    else if (catSel) catSel.value = '';
     var catIn = $('ring-brew-category-input');
     if (catIn) catIn.value = '';
     var d = $('ring-create-dialog');

--- a/apps/com.myriad.aro/styles.css
+++ b/apps/com.myriad.aro/styles.css
@@ -181,6 +181,7 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   scroll-snap-type:x proximity;
   scrollbar-width:none;
   overscroll-behavior-x:contain;
+  /* Soft edge fade so overflow is obvious without chrome */
   mask-image:linear-gradient(90deg,transparent 0,#000 10px,#000 calc(100% - 10px),transparent 100%);
   -webkit-mask-image:linear-gradient(90deg,transparent 0,#000 10px,#000 calc(100% - 10px),transparent 100%);
 }
@@ -776,8 +777,24 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   transition:background .12s,border-color .12s;
 }
 .backup-check:hover{background:rgba(128,128,128,.06)}
-.backup-check input{
-  width:16px;height:16px;margin:0;flex-shrink:0;accent-color:var(--tapp-primary,#6366f1);cursor:pointer;
+.backup-check input[type="checkbox"]{
+  appearance:none;-webkit-appearance:none;
+  width:16px;height:16px;margin:0;flex-shrink:0;cursor:pointer;
+  border-radius:4px;border:1.5px solid rgba(128,128,128,.35);background:transparent;
+  display:inline-grid;place-content:center;transition:border-color .12s,background .12s;
+}
+.backup-check input[type="checkbox"]::before{
+  content:"";width:9px;height:5px;border:solid #fff;border-width:0 0 2px 2px;
+  transform:rotate(-45deg) scale(0);transform-origin:center;transition:transform .12s ease;
+  margin-top:-1px;
+}
+.backup-check input[type="checkbox"]:checked{
+  border-color:var(--tapp-primary,#6366f1);background:var(--tapp-primary,#6366f1);
+}
+.backup-check input[type="checkbox"]:checked::before{transform:rotate(-45deg) scale(1)}
+.dark .backup-check input[type="checkbox"]{border-color:rgba(255,255,255,.28)}
+.dark .backup-check input[type="checkbox"]:checked{
+  border-color:var(--tapp-primary,#818cf8);background:var(--tapp-primary,#6366f1);
 }
 .backup-status{
   min-height:0;font-size:12px;font-weight:600;line-height:1.4;
@@ -844,7 +861,7 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .dark .backup-btn{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.1);color:rgba(255,255,255,.88)}
 .dark .backup-btn-primary{background:var(--tapp-primary,#6366f1);border-color:transparent;color:#fff}
 .dark .backup-btn-ghost:hover{background:rgba(255,255,255,.08);color:rgba(255,255,255,.9)}
-.dark .backup-check{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.06);color:rgba(255,255,255,.55)}
+.dark .backup-check{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.06);color:rgba(255,255,255,.72)}
 .dark .backup-archive-item,.dark .backup-archive-link{background:rgba(255,255,255,.035);border-color:rgba(255,255,255,.06)}
 .dark .backup-archive-link:hover{background:rgba(var(--tapp-primary-rgb,99,102,241),.14)}
 .dark .backup-toolbar{background:linear-gradient(180deg,rgba(10,10,10,.92) 55%,rgba(10,10,10,0))}
@@ -894,7 +911,23 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   border-color:rgba(var(--tapp-primary-rgb,99,102,241),.45);
   background:rgba(var(--tapp-primary-rgb,99,102,241),.08);
 }
-.settings-radio input{margin-top:2px;accent-color:var(--tapp-primary,#6366f1)}
+.settings-radio input[type="radio"]{
+  appearance:none;-webkit-appearance:none;margin-top:2px;flex-shrink:0;
+  width:16px;height:16px;border-radius:50%;cursor:pointer;
+  border:1.5px solid rgba(128,128,128,.35);background:transparent;
+  box-shadow:none;transition:border-color .12s,background .12s,box-shadow .12s;
+}
+.settings-radio input[type="radio"]:checked{
+  border-color:var(--tapp-primary,#6366f1);
+  background:var(--tapp-primary,#6366f1);
+  box-shadow:inset 0 0 0 3px var(--bg-primary,#fff);
+}
+.dark .settings-radio input[type="radio"]{border-color:rgba(255,255,255,.28)}
+.dark .settings-radio input[type="radio"]:checked{
+  border-color:var(--tapp-primary,#818cf8);
+  background:var(--tapp-primary,#6366f1);
+  box-shadow:inset 0 0 0 3px #121212;
+}
 .settings-radio-body{min-width:0;flex:1}
 .settings-radio-title{font-size:13px;font-weight:650;color:var(--text-primary,#0f1419)}
 .settings-radio-desc{margin-top:2px;font-size:11.5px;line-height:1.4;color:var(--text-secondary,#8b98a5)}
@@ -1837,15 +1870,80 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 .create-tab{flex:1;padding:6px 12px;border:none;background:none;border-radius:8px;font-size:12px;font-weight:500;color:var(--text-secondary,#999);cursor:pointer;transition:all .15s}
 .create-tab-active{background:var(--bg-primary,#fff);color:var(--text-primary,#1a1a1a);box-shadow:0 1px 3px rgba(0,0,0,.08)}
 .create-form{display:flex;flex-direction:column;gap:10px}
-.create-input{height:40px;padding:0 14px;border-radius:12px;border:1px solid rgba(128,128,128,.15);background:rgba(128,128,128,.03);color:var(--text-primary,#1a1a1a);font-size:13px;outline:none;transition:border-color .2s}
+.create-input{height:40px;padding:0 14px;border-radius:12px;border:1px solid rgba(128,128,128,.15);background:rgba(128,128,128,.03);color:var(--text-primary,#1a1a1a);font-size:13px;outline:none;transition:border-color .2s;box-sizing:border-box;font-family:inherit}
 .create-input:focus{border-color:rgba(var(--tapp-primary-rgb,128,128,128),.4)}
 .create-input::placeholder{color:var(--text-secondary,#bbb)}
 .create-submit{height:40px;border-radius:12px;border:none;background:var(--tapp-primary,#888);color:#fff;font-size:13px;font-weight:500;cursor:pointer;transition:opacity .15s}
 .create-submit:hover{opacity:.85}
 .create-submit:disabled{opacity:.4;cursor:not-allowed}
-.dark .create-dialog{background:var(--bg-primary,#1a1a1a)}
+.dark .create-dialog{background:var(--bg-primary,#1a1a1a);box-shadow:0 16px 48px rgba(0,0,0,.45)}
+.dark .create-overlay{background:rgba(0,0,0,.55)}
 .dark .create-tab-active{background:rgba(255,255,255,.08);color:rgba(255,255,255,.92)}
 .dark .create-input{background:rgba(255,255,255,.03);border-color:rgba(255,255,255,.1);color:rgba(255,255,255,.9)}
+.dark .create-dialog-close{color:rgba(255,255,255,.5)}
+.dark .create-dialog-close:hover{background:rgba(255,255,255,.08);color:rgba(255,255,255,.9)}
+.dark .create-divider{background:rgba(255,255,255,.08)}
+.dark .create-submit-secondary{background:rgba(255,255,255,.1)!important;color:rgba(255,255,255,.9)!important}
+
+/* ===== Custom select (replaces native <select>) ===== */
+.aro-select{position:relative;display:block;width:100%;min-width:0}
+.aro-select-trigger.create-input,
+button.aro-select-trigger.create-input{
+  display:flex;align-items:center;justify-content:space-between;gap:10px;
+  width:100%;height:40px;padding:0 12px 0 14px;margin:0;cursor:pointer;
+  text-align:left;font:inherit;line-height:1.2;appearance:none;-webkit-appearance:none;
+}
+.aro-select-trigger:focus,
+.aro-select-trigger:focus-visible{
+  border-color:rgba(var(--tapp-primary-rgb,99,102,241),.45);
+  outline:none;
+  box-shadow:0 0 0 3px rgba(var(--tapp-primary-rgb,99,102,241),.16);
+}
+.aro-select.is-open .aro-select-trigger{
+  border-color:rgba(var(--tapp-primary-rgb,99,102,241),.45);
+}
+.aro-select-value{
+  flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  color:var(--text-primary,#1a1a1a);font-size:13px;font-weight:500;
+}
+.aro-select-chevron{
+  flex-shrink:0;font-size:11px;line-height:1;opacity:.55;
+  color:var(--text-secondary,#888);transition:transform .15s var(--aro-ease,ease);
+}
+.aro-select.is-open .aro-select-chevron{transform:rotate(180deg);opacity:.8}
+.aro-select-menu.manage-dropdown{
+  display:none;left:0;right:0;top:calc(100% + 4px);min-width:100%;width:100%;
+  max-height:min(240px,42vh);overflow-x:hidden;overflow-y:auto;z-index:120;
+  padding:4px;scrollbar-width:thin;scrollbar-color:rgba(128,128,128,.35) transparent;
+}
+.aro-select-menu.manage-dropdown.open,
+.aro-select.is-open .aro-select-menu.manage-dropdown{display:block}
+.aro-select-option.manage-item{
+  width:100%;min-height:36px;padding:8px 12px;border-radius:8px;
+  font-size:13px;font-weight:500;justify-content:flex-start;
+}
+.aro-select-option.manage-item.is-selected{
+  background:rgba(var(--tapp-primary-rgb,99,102,241),.12);
+  color:var(--tapp-primary,#6366f1);
+  font-weight:600;
+}
+.aro-select-option.manage-item:focus-visible{
+  outline:2px solid rgba(var(--tapp-primary-rgb,99,102,241),.45);
+  outline-offset:-2px;
+}
+.dark .aro-select-value{color:rgba(255,255,255,.9)}
+.dark .aro-select-chevron{color:rgba(255,255,255,.5)}
+.dark .aro-select-option.manage-item.is-selected{
+  background:rgba(var(--tapp-primary-rgb,99,102,241),.2);
+  color:var(--tapp-primary,#818cf8);
+}
+.dark .aro-select-menu.manage-dropdown{
+  background:var(--bg-primary,#1a1a1a);
+  border-color:rgba(255,255,255,.1);
+  box-shadow:0 8px 28px rgba(0,0,0,.45);
+  scrollbar-color:rgba(255,255,255,.22) transparent;
+}
+
 .edit-label{font-size:11px;font-weight:600;color:var(--text-secondary,#888);text-transform:uppercase;letter-spacing:.04em}
 .member-kick{margin-left:auto;width:36px;height:36px;min-width:36px;min-height:36px;border:none;background:none;color:var(--text-secondary,#999);cursor:pointer;border-radius:8px;display:flex;align-items:center;justify-content:center;opacity:0;transition:opacity .15s,background .15s;flex-shrink:0}
 .member-item:hover .member-kick,.member-kick:focus-visible{opacity:1}
@@ -1929,13 +2027,36 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 .create-overlay{animation:aroFadeIn var(--aro-dur) ease both}
 .create-dialog{animation:aroScaleIn var(--aro-dur) var(--aro-ease) both}
 .edit-check-row{display:flex;align-items:flex-start;gap:8px;font-size:12.5px;line-height:1.4;color:var(--text-primary,#1a1a1a);cursor:pointer;user-select:none}
-.edit-check-row input{margin-top:2px;flex-shrink:0}
+.edit-check-row input[type="checkbox"]{
+  appearance:none;-webkit-appearance:none;margin-top:2px;flex-shrink:0;cursor:pointer;
+  width:16px;height:16px;border-radius:4px;border:1.5px solid rgba(128,128,128,.35);
+  background:transparent;display:inline-grid;place-content:center;
+  transition:border-color .12s,background .12s;
+}
+.edit-check-row input[type="checkbox"]::before{
+  content:"";width:9px;height:5px;border:solid #fff;border-width:0 0 2px 2px;
+  transform:rotate(-45deg) scale(0);transform-origin:center;transition:transform .12s ease;
+  margin-top:-1px;
+}
+.edit-check-row input[type="checkbox"]:checked{
+  border-color:var(--tapp-primary,#6366f1);background:var(--tapp-primary,#6366f1);
+}
+.edit-check-row input[type="checkbox"]:checked::before{transform:rotate(-45deg) scale(1)}
+.edit-check-row input[type="checkbox"]:disabled{opacity:.45;cursor:not-allowed}
+.dark .edit-check-row{color:rgba(255,255,255,.88)}
+.dark .edit-check-row input[type="checkbox"]{border-color:rgba(255,255,255,.28)}
+.dark .edit-check-row input[type="checkbox"]:checked{
+  border-color:var(--tapp-primary,#818cf8);background:var(--tapp-primary,#6366f1);
+}
 .edit-hint{margin:0;font-size:11.5px;line-height:1.4;color:var(--text-secondary,#999)}
+.dark .edit-hint{color:rgba(255,255,255,.45)}
 .edit-room-id-box{display:flex;flex-direction:column;gap:6px}
 .edit-room-id-row{display:flex;align-items:center;gap:8px}
-.edit-room-id-value{flex:1;min-width:0;padding:8px 10px;border-radius:8px;background:rgba(128,128,128,.08);font-size:11.5px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.edit-room-id-value{flex:1;min-width:0;padding:8px 10px;border-radius:8px;background:rgba(128,128,128,.08);font-size:11.5px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-primary,#1a1a1a)}
+.dark .edit-room-id-value{background:rgba(255,255,255,.06);color:rgba(255,255,255,.82)}
 .edit-room-id-copy{flex-shrink:0;padding:6px 10px;border:none;border-radius:8px;background:rgba(var(--tapp-primary-rgb,100,100,255),.12);color:var(--tapp-primary,#6366f1);font-size:12px;font-weight:500;cursor:pointer}
 .edit-room-id-copy:hover{filter:brightness(1.05)}
+.dark .edit-room-id-copy{background:rgba(var(--tapp-primary-rgb,99,102,241),.2);color:var(--tapp-primary,#818cf8)}
 .create-divider{height:1px;background:rgba(128,128,128,.12);margin:4px 0}
 .create-submit-secondary{background:rgba(128,128,128,.1)!important;color:var(--text-primary,#1a1a1a)!important;box-shadow:none!important}
 .meta-badge.badge-public{background:rgba(34,197,94,.12);color:#16a34a}

--- a/index.json
+++ b/index.json
@@ -245,7 +245,7 @@
     {
       "id": "com.myriad.aro",
       "name": "Aro",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "社交中心，统一管理消息、时间线、环网与个人资料",
       "long_description": "社交中心：统一管理联邦消息（Channel/Room）、时间线、环网与个人资料。支持后台新消息通知、附件与多语言（中/英/日）。",
       "locales": {
@@ -324,7 +324,7 @@
       "featured": true,
       "verified": true,
       "created_at": "2025-12-01T00:00:00Z",
-      "updated_at": "2026-07-20T12:35:43Z"
+      "updated_at": "2026-07-21T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Deep dark-mode polish for **Aro** (`apps/com.myriad.aro`) and replace native form controls that look broken in dark / iframe sandboxes.

### Before → After

| Area | Before | After |
|------|--------|--------|
| Ring type (`#ring-type-select`) | Native `<select>` — OS chrome, light popup in dark iframe | Custom `aro-select` trigger (`.create-input`) + `manage-dropdown` option list |
| Brew category (`#ring-brew-category-select`) | Native `<select>` with dynamic options | Same custom select; `setOptions()` rebuilds list from `Tapp.brewList.categories()` |
| Settings radios | Native radio dots | Custom circular indicator, dark-aware |
| Room / backup checkboxes | OS-native checkboxes | Custom checkmark squares, dark-aware |
| Create dialog surfaces | Mixed light edges in dark | Overlay, dialog, secondary submit, dividers, close button dark tokens |

### Custom select API (`page/helpers.js`, mirrored in `index.js`)

- `initAroSelect` / `initRingCreateSelects`
- `getAroSelectValue` / `setAroSelectValue` / `setAroSelectOptions` / `refreshAroSelectLabel`
- Root keeps `id` + `data-value`; defines `.value` getter/setter; dispatches `change`
- Keyboard: Escape close, Enter/Space toggle, ArrowUp/Down navigate options
- a11y: `role="combobox"` / `listbox` / `option`, `aria-expanded`, `aria-selected`

### Dark polish (page.css + styles.css kept in sync)

- Create overlay/dialog/input/close/divider/secondary button
- Edit-check rows, edit room id, chat room id (existing + reinforced)
- Settings radios + backup checks fully themed
- Select menu shadows/scrollbars under `.dark`

### Version

- Aro **1.0.0 → 1.0.1** (`manifest.json`, `index.json`, README)

### Out of scope (as requested)

- Backend Myriad / federation API
- config-generator
- Full Aro layout redesign
- `window.prompt` attach flows (optional; not changed)

## Test plan

- [ ] Open Aro page in **dark** host theme
- [ ] Rings → Create ring: type dropdown opens in-app menu (no OS select)
- [ ] Choose each type (brew / tapp / library / instance); brew shows category row, others hide it
- [ ] Brew categories load from API when available; free-text fallback when empty/unavailable
- [ ] Create ring still submits correct `ring_type` (+ optional `category`)
- [ ] Locale switch updates option labels and trigger text
- [ ] Settings radios + backup “include media” checkbox look custom in dark
- [ ] Create/edit room public checkbox custom in dark
- [ ] Messenger / feed / rings navigation still works (no regressions)