### PR TITLE
fix(aro): full messenger interaction regression (clicks, overlays, races)

### DIFF
--- a/apps/com.myriad.aro/README.md
+++ b/apps/com.myriad.aro/README.md
@@ -2,7 +2,7 @@
 
 社交中心：消息（Channel/Room）、时间线、环网与个人资料。
 
-> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.2）。
+> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.3）。
 
 ## 功能
 
@@ -23,5 +23,5 @@ index.js          # core（与 aro.ts buildCoreCode() 一致）
 page.html / page.css / styles.css
 page/*.js         # pageModules 与 aro.ts PAGE_MODULES 一致
 i18n/{zh,en,ja}.json
-manifest.json     # version 1.0.2
+manifest.json     # version 1.0.3
 ```

--- a/apps/com.myriad.aro/manifest.json
+++ b/apps/com.myriad.aro/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.aro",
   "name": "Aro",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "minSystemVersion": "0.2.1",
   "description": "社交中心，统一管理消息、时间线、环网与个人资料",
   "locales": {

--- a/apps/com.myriad.aro/page.css
+++ b/apps/com.myriad.aro/page.css
@@ -7,8 +7,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 #tapp-content{display:flex!important;flex-direction:column!important;overflow:hidden!important}
 
 /* ===== Aro Nav ===== */
-.aro-nav{display:flex;align-items:center;gap:4px;padding:8px 12px;border-bottom:1px solid rgba(128,128,128,.08);flex-shrink:0;background:rgba(255,255,255,.78);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px)}
-.aro-nav-item{min-height:36px;display:flex;align-items:center;gap:8px;padding:0 14px;border:none;background:none;border-radius:11px;font-size:13px;font-weight:600;color:var(--text-secondary,#888);cursor:pointer;transition:background .14s,color .14s;white-space:nowrap}
+.aro-nav{display:flex;align-items:center;gap:4px;padding:8px 12px;border-bottom:1px solid rgba(128,128,128,.08);flex-shrink:0;background:rgba(255,255,255,.78);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px);position:relative;z-index:30;pointer-events:auto}
+.aro-nav-item{min-height:36px;display:flex;align-items:center;gap:8px;padding:0 14px;border:none;background:none;border-radius:11px;font-size:13px;font-weight:600;color:var(--text-secondary,#888);cursor:pointer;transition:background .14s,color .14s;white-space:nowrap;touch-action:manipulation;pointer-events:auto;-webkit-tap-highlight-color:transparent}
 .aro-nav-item:hover{background:rgba(128,128,128,.07);color:var(--text-primary,#222)}
 .aro-nav-item:focus-visible{outline:2px solid rgba(var(--tapp-primary-rgb,99,102,241),.45);outline-offset:1px}
 .aro-nav-active{background:rgba(var(--tapp-primary-rgb,100,100,255),.12)!important;color:var(--tapp-primary,#6366f1)!important}
@@ -358,8 +358,9 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 
 /* ===== Layout ===== */
 .messenger-app{display:flex;flex:1;min-height:0;overflow:hidden;position:relative}
-.sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden}
-.sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px}
+.sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden;position:relative;z-index:2;pointer-events:auto}
+.sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px;position:relative;z-index:3;pointer-events:auto}
+.sidebar-header .create-btn{position:relative;z-index:4;pointer-events:auto;touch-action:manipulation}
 .sidebar-title{margin:0;font-size:16px;font-weight:700;color:var(--text-primary,#1a1a1a);letter-spacing:-.02em}
 /* Messenger list: type tabs (最近|私信|群聊) + closed chip same row */
 .conv-tabs-bar{
@@ -463,9 +464,13 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .history-overlay{
   position:absolute;inset:0;z-index:40;display:none;align-items:stretch;justify-content:flex-end;
   background:rgba(15,23,42,.22);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+  pointer-events:none; /* never intercept while closed / display:none race */
 }
+.history-overlay[style*="display: flex"],
+.history-overlay[style*="display:flex"]{pointer-events:auto}
 .history-overlay.aro-history-enter{animation:aroFadeIn var(--aro-dur) ease both}
-.history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none}
+.history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none!important}
+.history-overlay[hidden]{display:none!important;pointer-events:none!important}
 /* history open uses class on overlay (not aroPlayEnter generic) */
 .history-sheet{
   width:min(400px,100%);max-width:100%;height:100%;
@@ -1252,8 +1257,11 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .dark .msg-more-btn:hover,.dark .msg-more-btn:focus-visible{background:rgba(255,255,255,.1)}
 
 /* ===== Input ===== */
+/* pointer-events:none on the wrap so the gradient does not steal message-area
+   scrolls/clicks; only children (composer) are interactive. Never stretch over sidebar. */
 .input-float-wrap{position:absolute;bottom:0;left:0;right:0;z-index:20;padding:8px 12px;padding-bottom:calc(8px + env(safe-area-inset-bottom,0px));background:linear-gradient(to top,var(--bg-primary,#fff) 70%,transparent);pointer-events:none}
 .input-float-wrap>*{pointer-events:auto}
+.chat-main{isolation:isolate}
 .input-bar{display:flex;align-items:flex-end;gap:8px;padding:8px 10px;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.12);border-radius:18px;box-shadow:0 2px 12px rgba(0,0,0,.06)}
 .attach-btn{width:36px;height:36px;border-radius:50%;border:none;background:transparent;color:var(--text-secondary,#999);cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;transition:background .15s,color .15s;margin-bottom:1px}
 .attach-btn:hover{background:rgba(128,128,128,.08);color:var(--text-primary,#555)}
@@ -1879,12 +1887,12 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
   .aro-nav-item{flex-direction:column;gap:3px;padding:8px 12px;font-size:11px}
   .aro-nav-item svg{width:22px;height:22px}
   .nav-feed-avatar{width:24px;height:24px;font-size:11px}
-  .sidebar{width:100%}
-  .sidebar-hidden-mobile{display:none!important}
+  .sidebar{width:100%;z-index:2;pointer-events:auto}
+  .sidebar-hidden-mobile{display:none!important;pointer-events:none!important}
   .back-btn{display:block}
-  .member-panel{display:none;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none}
+  .member-panel{display:none!important;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none;pointer-events:none}
   .dark .member-panel{background:var(--bg-primary,#1a1a1a)}
-  .member-panel.member-open-mobile{display:flex!important}
+  .member-panel.member-open-mobile{display:flex!important;pointer-events:auto}
   .member-back-btn{display:flex}
   .aro-panel-layout .sidebar{width:100%}
   .aro-panel-layout .sidebar-hidden-mobile{display:none!important}
@@ -1912,7 +1920,12 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 }
 
 /* ===== Create Dialog ===== */
-.create-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:100}
+/* Default display:none — previous display:flex default left a full-screen click shield
+   whenever inline style was cleared or dismiss raced. */
+.create-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:100;pointer-events:none}
+.create-overlay[style*="display: flex"],
+.create-overlay[style*="display:flex"]{pointer-events:auto}
+.create-overlay[hidden]{display:none!important;pointer-events:none!important}
 .create-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(360px,90vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.15)}
 .create-dialog-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
 .create-dialog-title{margin:0;font-size:16px;font-weight:600;color:var(--text-primary,#1a1a1a)}
@@ -2026,7 +2039,8 @@ button.aro-select-trigger.create-input{
 
 
 /* ===== In-app Confirm Dialog (native confirm() is blocked in the sandboxed iframe) ===== */
-.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease}
+.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease;pointer-events:auto}
+.confirm-overlay.aro-leaving,.confirm-overlay[hidden]{pointer-events:none!important}
 .confirm-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(320px,88vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.18)}
 .confirm-message{font-size:14px;line-height:1.6;color:var(--text-primary,#1a1a1a);margin-bottom:18px;overflow-wrap:break-word}
 .confirm-actions{display:flex;gap:8px;justify-content:flex-end}

--- a/apps/com.myriad.aro/page/api.js
+++ b/apps/com.myriad.aro/page/api.js
@@ -1,10 +1,13 @@
 // ==================== API ====================
 async function loadConversations() {
+  var gen = (state.convLoadGen = (state.convLoadGen || 0) + 1);
   try {
     var results = await Promise.allSettled([
       Tapp.federation.getChannels(),
       Tapp.federation.getRooms(),
     ]);
+    // Stale reload finished after a newer one — do not flash older list data.
+    if (gen !== state.convLoadGen) return;
     var errors = [];
     if (results[0].status === 'fulfilled' && results[0].value) {
       state.channels = results[0].value.channels || [];
@@ -32,6 +35,7 @@ async function loadConversations() {
       refreshDeliveryHealth().catch(function () {});
     }
   } catch (e) {
+    if (gen !== state.convLoadGen) return;
     console.error('[Aro] loadConversations error:', e);
   }
 }
@@ -57,6 +61,11 @@ async function openConversation(kind, id) {
 
   // Stop poll immediately so a prior interval cannot write into the new shell.
   stopPolling();
+
+  // Drop click-shields / sheets that would sit above the list or chat after #24/#25.
+  if (typeof dismissTransientUi === 'function') {
+    dismissTransientUi({ keepChat: true });
+  }
 
   // Drop previous realtime subscription before switching
   await unsubscribeRealtime();
@@ -1233,7 +1242,8 @@ function toggleInvitePopover(e) {
     pop.style.top = (rect.bottom + 6) + 'px';
     pop.style.left = Math.max(4, rect.right - 240) + 'px';
     pop.classList.remove('aro-leaving');
-    pop.style.display = '';
+    pop.style.pointerEvents = '';
+    pop.style.display = 'block';
     aroPlayEnter(pop, 'aro-menu-enter');
     renderInvitePopoverContacts();
     var invInput = pop.querySelector('#invite-input');
@@ -1363,13 +1373,20 @@ function showEditRoomDialog() {
     }
   }
   overlay.classList.remove('aro-leaving');
+  overlay.hidden = false;
+  overlay.style.pointerEvents = '';
   overlay.style.display = 'flex';
 }
 
 function hideEditRoomDialog() {
   var overlay = $('edit-room-dialog');
   if (!overlay || overlay.style.display === 'none') return;
-  aroDismiss(overlay, { ms: 170 });
+  aroDismiss(overlay, {
+    ms: 170,
+    onDone: function () {
+      try { overlay.hidden = true; } catch (e) { /* ignore */ }
+    },
+  });
 }
 
 async function doSaveRoom() {
@@ -1652,6 +1669,8 @@ function showCreateDialog() {
   var overlay = $('create-dialog');
   if (overlay) {
     overlay.classList.remove('aro-leaving');
+    overlay.hidden = false;
+    overlay.style.pointerEvents = '';
     overlay.style.display = 'flex';
   }
   switchCreateTab('channel');
@@ -1813,6 +1832,10 @@ function switchView(view) {
   var prev = state.currentView;
   if (prev === view) return;
   state.currentView = view;
+  // Leaving a view: clear overlays that can pin over the whole #tapp-content (create/compose).
+  if (typeof dismissTransientUi === 'function') {
+    dismissTransientUi({ keepChat: view === 'messages' });
+  }
   var views = ['messages', 'feed', 'rings'];
   views.forEach(function (v) {
     var el = $('view-' + v);
@@ -1821,8 +1844,11 @@ function switchView(view) {
       if (v !== view) {
         el.style.display = 'none';
         el.classList.remove('aro-view-enter');
+        // Ensure inactive views never intercept pointer hits
+        el.style.pointerEvents = 'none';
       } else {
         el.style.display = '';
+        el.style.pointerEvents = '';
         el.classList.add('aro-view-active');
         if (prev && prev !== view) aroPlayEnter(el, 'aro-view-enter');
       }

--- a/apps/com.myriad.aro/page/events.js
+++ b/apps/com.myriad.aro/page/events.js
@@ -298,12 +298,14 @@
     backBtn.addEventListener('click', function () {
       // Invalidate in-flight open/poll so leaving chat cannot flash stale messages.
       state.openGen = (state.openGen || 0) + 1;
+      if (typeof dismissTransientUi === 'function') dismissTransientUi({});
       var sidebar = $('sidebar');
       var chat = $('chat-container');
       var members = $('member-panel');
       var empty = $('empty-state');
       if (sidebar) {
         sidebar.classList.remove('sidebar-hidden-mobile');
+        sidebar.style.pointerEvents = '';
         aroPlayEnter(sidebar, 'aro-panel-enter');
       }
       if (chat) {
@@ -314,6 +316,7 @@
         members.style.display = 'none';
         members.classList.remove('member-open-mobile');
         members.classList.remove('member-expanded-tablet');
+        members.style.pointerEvents = '';
       }
       if (empty) {
         empty.style.display = '';

--- a/apps/com.myriad.aro/page/files.js
+++ b/apps/com.myriad.aro/page/files.js
@@ -394,6 +394,7 @@ async function openRoomFiles() {
   var overlay = $('room-files-overlay');
   if (!overlay) return;
   overlay.hidden = false;
+  overlay.style.pointerEvents = 'auto';
   overlay.style.display = 'flex';
   overlay.classList.remove('aro-leaving', 'aro-history-enter');
   try { void overlay.offsetWidth; } catch (eAnim) { /* ignore */ }

--- a/apps/com.myriad.aro/page/helpers.js
+++ b/apps/com.myriad.aro/page/helpers.js
@@ -85,7 +85,24 @@ function aroPlayEnter(el, className) {
 }
 
 /**
+ * Immediately stop an overlay/menu from receiving clicks (safe even mid-animation).
+ * Use when a stuck layer would dead-lock the messenger UI.
+ */
+function forceHideInteractive(el) {
+  if (!el) return;
+  try {
+    el.classList.remove('aro-leaving', 'aro-history-enter', 'aro-view-enter', 'aro-panel-enter', 'aro-menu-enter', 'open', 'is-open');
+    el.style.pointerEvents = 'none';
+    el.style.display = 'none';
+    if (el.hasAttribute && (el.hasAttribute('hidden') || el.getAttribute('aria-modal') === 'true' || el.classList.contains('history-overlay') || el.classList.contains('create-overlay') || el.classList.contains('confirm-overlay') || el.classList.contains('picker-overlay') || el.classList.contains('forward-overlay'))) {
+      el.hidden = true;
+    }
+  } catch (eForce) { /* ignore */ }
+}
+
+/**
  * Hide or remove an element after a short exit animation (class `aro-leaving`).
+ * Always disables pointer-events immediately so dismiss never leaves a click shield.
  * @param {HTMLElement} el
  * @param {{ remove?: boolean, ms?: number, onDone?: function }} opts
  */
@@ -93,6 +110,8 @@ function aroDismiss(el, opts) {
   opts = opts || {};
   if (!el) { if (opts.onDone) opts.onDone(); return; }
   var finished = false;
+  // Critical: block hits the moment dismiss starts (aro-leaving CSS may lag / fail).
+  try { el.style.pointerEvents = 'none'; } catch (ePe) { /* ignore */ }
   var finish = function () {
     if (finished) return;
     finished = true;
@@ -102,6 +121,10 @@ function aroDismiss(el, opts) {
       try { el.remove(); } catch (e) { /* ignore */ }
     } else {
       el.style.display = 'none';
+      el.style.pointerEvents = '';
+      try {
+        if (el.hasAttribute && el.hasAttribute('hidden')) el.hidden = true;
+      } catch (eH) { /* ignore */ }
     }
     if (opts.onDone) opts.onDone();
   };
@@ -110,13 +133,76 @@ function aroDismiss(el, opts) {
     if (e && e.target && e.target !== el) return;
     finish();
   };
-  if (prefersReducedMotion() || el.style.display === 'none') {
+  if (prefersReducedMotion() || el.style.display === 'none' || el.hidden) {
     finish();
     return;
   }
   el.classList.add('aro-leaving');
   el.addEventListener('animationend', onAnimEnd);
   setTimeout(finish, opts.ms || 180);
+}
+
+/**
+ * Close menus/overlays that commonly leave a full-screen click shield after #24/#25.
+ * Safe to call from openConversation / switchView / back.
+ * @param {{ keepChat?: boolean }} [opts]
+ */
+function dismissTransientUi(opts) {
+  opts = opts || {};
+  try { if (typeof closeMsgMenu === 'function') closeMsgMenu(); } catch (e0) { /* ignore */ }
+  try { if (typeof closeAttachMenu === 'function') closeAttachMenu(); } catch (e1) { /* ignore */ }
+  try { if (typeof closeInvitePopover === 'function') closeInvitePopover(); } catch (e2) { /* ignore */ }
+  try { if (typeof closeManageDropdown === 'function') closeManageDropdown(); } catch (e3) { /* ignore */ }
+  try {
+    document.querySelectorAll('.aro-select.is-open').forEach(function (root) {
+      if (root._aroSelect && typeof root._aroSelect.close === 'function') root._aroSelect.close();
+    });
+  } catch (e4) { /* ignore */ }
+  // Force-hide fixed/absolute overlays that may still paint over the app
+  try {
+    ['create-dialog', 'edit-room-dialog', 'ring-create-dialog', 'feed-follow-dialog',
+      'feed-compose-dialog', 'quote-repost-dialog', 'chat-history-overlay', 'room-files-overlay'
+    ].forEach(function (id) {
+      var el = $(id);
+      if (!el) return;
+      if (el.style.display === 'none' || el.hidden) return;
+      // History/files: prefer their close helpers so state stays consistent
+      if (id === 'chat-history-overlay' && typeof closeChatHistory === 'function') {
+        closeChatHistory();
+        return;
+      }
+      if (id === 'room-files-overlay' && typeof closeRoomFiles === 'function') {
+        closeRoomFiles();
+        return;
+      }
+      if (id === 'create-dialog' && typeof hideCreateDialog === 'function') {
+        hideCreateDialog();
+        return;
+      }
+      if (id === 'edit-room-dialog' && typeof hideEditRoomDialog === 'function') {
+        hideEditRoomDialog();
+        return;
+      }
+      forceHideInteractive(el);
+    });
+  } catch (e5) { /* ignore */ }
+  // Dynamically created portals (do NOT kill .confirm-overlay — mid-confirm would hang).
+  try {
+    document.querySelectorAll('.forward-overlay, .picker-overlay, .img-viewer').forEach(function (el) {
+      forceHideInteractive(el);
+      try { el.remove(); } catch (eR) { /* ignore */ }
+    });
+  } catch (e6) { /* ignore */ }
+  // Mobile member sheet must not stick over the conv list after switch
+  try {
+    var panel = $('member-panel');
+    if (panel) {
+      panel.classList.remove('member-open-mobile');
+      if (!opts.keepChat) {
+        panel.classList.remove('member-expanded-tablet');
+      }
+    }
+  } catch (e7) { /* ignore */ }
 }
 
 function timeStr(iso) { try { return new Date(iso).toLocaleTimeString(currentLocale, { hour: '2-digit', minute: '2-digit' }); } catch (e) { return ''; } }
@@ -868,6 +954,7 @@ function initAroSelect(rootOrId, opts) {
   }
 
   function onDocPointer(e) {
+    // Never capture/swallow when closed — leftover open=true must not block messenger.
     if (!open) return;
     if (root.contains(e.target)) return;
     closeMenu();
@@ -947,7 +1034,8 @@ function initAroSelect(rootOrId, opts) {
     trigger.focus();
   });
   root.addEventListener('keydown', onKeyDown);
-  document.addEventListener('click', onDocPointer, true);
+  // Bubble phase only — capture:true previously risked ordering races with list/tab clicks.
+  document.addEventListener('click', onDocPointer, false);
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape' && open) {
       closeMenu();

--- a/apps/com.myriad.aro/page/history.js
+++ b/apps/com.myriad.aro/page/history.js
@@ -228,6 +228,7 @@ function openChatHistory() {
   var overlay = $('chat-history-overlay');
   if (!overlay) return;
   overlay.hidden = false;
+  overlay.style.pointerEvents = 'auto';
   overlay.style.display = 'flex';
   overlay.classList.remove('aro-leaving', 'aro-history-enter');
   // Restart enter animation

--- a/apps/com.myriad.aro/page/members.js
+++ b/apps/com.myriad.aro/page/members.js
@@ -5,10 +5,24 @@ function renderMembers() {
   if (!panel) return;
 
   if (state.activeKind !== 'room' || !state.roomDetail) {
+    // Always clear mobile full-screen sheet — stuck member-open-mobile blocks the list.
+    panel.classList.remove('member-open-mobile', 'member-expanded-tablet');
     panel.style.display = 'none';
+    panel.style.pointerEvents = '';
     return;
   }
-  panel.style.display = '';
+  // Desktop: show side panel. Mobile: keep hidden until user opens (member-open-mobile).
+  var isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+  if (isMobile) {
+    // Do not force-show; only ensure pointer-events when intentionally open.
+    if (!panel.classList.contains('member-open-mobile')) {
+      panel.style.display = '';
+      // media query keeps it display:none until .member-open-mobile
+    }
+  } else {
+    panel.style.display = '';
+    panel.style.pointerEvents = '';
+  }
   $('member-title').textContent = lang.members + ' (' + state.members.length + ')';
 
   var myRole = state.roomDetail.my_role || '';
@@ -292,6 +306,10 @@ function closeMemberPanel() {
   panel.classList.remove('member-expanded-tablet');
   if (window.innerWidth > 768 && !isTablet()) {
     panel.classList.add('member-collapsed');
+  }
+  // Mobile full-screen sheet: force hide so it cannot block sidebar/list
+  if (window.innerWidth <= 768) {
+    panel.style.display = '';
   }
   state.memberPanelOpen = false;
 }

--- a/apps/com.myriad.aro/page/state.js
+++ b/apps/com.myriad.aro/page/state.js
@@ -38,6 +38,8 @@ var state = {
    * Bumped on every open or leave so stale awaits cannot flashback UI.
    */
   openGen: 0,
+  /** Monotonic generation for loadConversations (stale list writes discarded). */
+  convLoadGen: 0,
   // Aro views
   currentView: 'feed',
   // Feed (merged timeline + profile)

--- a/apps/com.myriad.aro/styles.css
+++ b/apps/com.myriad.aro/styles.css
@@ -7,8 +7,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 #tapp-content{display:flex!important;flex-direction:column!important;overflow:hidden!important}
 
 /* ===== Aro Nav ===== */
-.aro-nav{display:flex;align-items:center;gap:4px;padding:8px 12px;border-bottom:1px solid rgba(128,128,128,.08);flex-shrink:0;background:rgba(255,255,255,.78);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px)}
-.aro-nav-item{min-height:36px;display:flex;align-items:center;gap:8px;padding:0 14px;border:none;background:none;border-radius:11px;font-size:13px;font-weight:600;color:var(--text-secondary,#888);cursor:pointer;transition:background .14s,color .14s;white-space:nowrap}
+.aro-nav{display:flex;align-items:center;gap:4px;padding:8px 12px;border-bottom:1px solid rgba(128,128,128,.08);flex-shrink:0;background:rgba(255,255,255,.78);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px);position:relative;z-index:30;pointer-events:auto}
+.aro-nav-item{min-height:36px;display:flex;align-items:center;gap:8px;padding:0 14px;border:none;background:none;border-radius:11px;font-size:13px;font-weight:600;color:var(--text-secondary,#888);cursor:pointer;transition:background .14s,color .14s;white-space:nowrap;touch-action:manipulation;pointer-events:auto;-webkit-tap-highlight-color:transparent}
 .aro-nav-item:hover{background:rgba(128,128,128,.07);color:var(--text-primary,#222)}
 .aro-nav-item:focus-visible{outline:2px solid rgba(var(--tapp-primary-rgb,99,102,241),.45);outline-offset:1px}
 .aro-nav-active{background:rgba(var(--tapp-primary-rgb,100,100,255),.12)!important;color:var(--tapp-primary,#6366f1)!important}
@@ -358,8 +358,9 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 
 /* ===== Layout ===== */
 .messenger-app{display:flex;flex:1;min-height:0;overflow:hidden;position:relative}
-.sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden}
-.sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px}
+.sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden;position:relative;z-index:2;pointer-events:auto}
+.sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px;position:relative;z-index:3;pointer-events:auto}
+.sidebar-header .create-btn{position:relative;z-index:4;pointer-events:auto;touch-action:manipulation}
 .sidebar-title{margin:0;font-size:16px;font-weight:700;color:var(--text-primary,#1a1a1a);letter-spacing:-.02em}
 /* Messenger list: type tabs (最近|私信|群聊) + closed chip same row */
 .conv-tabs-bar{
@@ -463,9 +464,13 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .history-overlay{
   position:absolute;inset:0;z-index:40;display:none;align-items:stretch;justify-content:flex-end;
   background:rgba(15,23,42,.22);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+  pointer-events:none; /* never intercept while closed / display:none race */
 }
+.history-overlay[style*="display: flex"],
+.history-overlay[style*="display:flex"]{pointer-events:auto}
 .history-overlay.aro-history-enter{animation:aroFadeIn var(--aro-dur) ease both}
-.history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none}
+.history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none!important}
+.history-overlay[hidden]{display:none!important;pointer-events:none!important}
 /* history open uses class on overlay (not aroPlayEnter generic) */
 .history-sheet{
   width:min(400px,100%);max-width:100%;height:100%;
@@ -1252,8 +1257,11 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .dark .msg-more-btn:hover,.dark .msg-more-btn:focus-visible{background:rgba(255,255,255,.1)}
 
 /* ===== Input ===== */
+/* pointer-events:none on the wrap so the gradient does not steal message-area
+   scrolls/clicks; only children (composer) are interactive. Never stretch over sidebar. */
 .input-float-wrap{position:absolute;bottom:0;left:0;right:0;z-index:20;padding:8px 12px;padding-bottom:calc(8px + env(safe-area-inset-bottom,0px));background:linear-gradient(to top,var(--bg-primary,#fff) 70%,transparent);pointer-events:none}
 .input-float-wrap>*{pointer-events:auto}
+.chat-main{isolation:isolate}
 .input-bar{display:flex;align-items:flex-end;gap:8px;padding:8px 10px;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.12);border-radius:18px;box-shadow:0 2px 12px rgba(0,0,0,.06)}
 .attach-btn{width:36px;height:36px;border-radius:50%;border:none;background:transparent;color:var(--text-secondary,#999);cursor:pointer;display:flex;align-items:center;justify-content:center;flex-shrink:0;transition:background .15s,color .15s;margin-bottom:1px}
 .attach-btn:hover{background:rgba(128,128,128,.08);color:var(--text-primary,#555)}
@@ -1879,12 +1887,12 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
   .aro-nav-item{flex-direction:column;gap:3px;padding:8px 12px;font-size:11px}
   .aro-nav-item svg{width:22px;height:22px}
   .nav-feed-avatar{width:24px;height:24px;font-size:11px}
-  .sidebar{width:100%}
-  .sidebar-hidden-mobile{display:none!important}
+  .sidebar{width:100%;z-index:2;pointer-events:auto}
+  .sidebar-hidden-mobile{display:none!important;pointer-events:none!important}
   .back-btn{display:block}
-  .member-panel{display:none;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none}
+  .member-panel{display:none!important;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none;pointer-events:none}
   .dark .member-panel{background:var(--bg-primary,#1a1a1a)}
-  .member-panel.member-open-mobile{display:flex!important}
+  .member-panel.member-open-mobile{display:flex!important;pointer-events:auto}
   .member-back-btn{display:flex}
   .aro-panel-layout .sidebar{width:100%}
   .aro-panel-layout .sidebar-hidden-mobile{display:none!important}
@@ -1912,7 +1920,12 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 }
 
 /* ===== Create Dialog ===== */
-.create-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:100}
+/* Default display:none — previous display:flex default left a full-screen click shield
+   whenever inline style was cleared or dismiss raced. */
+.create-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:100;pointer-events:none}
+.create-overlay[style*="display: flex"],
+.create-overlay[style*="display:flex"]{pointer-events:auto}
+.create-overlay[hidden]{display:none!important;pointer-events:none!important}
 .create-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(360px,90vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.15)}
 .create-dialog-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
 .create-dialog-title{margin:0;font-size:16px;font-weight:600;color:var(--text-primary,#1a1a1a)}
@@ -2026,7 +2039,8 @@ button.aro-select-trigger.create-input{
 
 
 /* ===== In-app Confirm Dialog (native confirm() is blocked in the sandboxed iframe) ===== */
-.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease}
+.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease;pointer-events:auto}
+.confirm-overlay.aro-leaving,.confirm-overlay[hidden]{pointer-events:none!important}
 .confirm-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(320px,88vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.18)}
 .confirm-message{font-size:14px;line-height:1.6;color:var(--text-primary,#1a1a1a);margin-bottom:18px;overflow-wrap:break-word}
 .confirm-actions{display:flex;gap:8px;justify-content:flex-end}

--- a/index.json
+++ b/index.json
@@ -245,7 +245,7 @@
     {
       "id": "com.myriad.aro",
       "name": "Aro",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "社交中心，统一管理消息、时间线、环网与个人资料",
       "long_description": "社交中心：统一管理联邦消息（Channel/Room）、时间线、环网与个人资料。支持后台新消息通知、附件与多语言（中/英/日）。",
       "locales": {
@@ -324,7 +324,7 @@
       "featured": true,
       "verified": true,
       "created_at": "2025-12-01T00:00:00Z",
-      "updated_at": "2026-07-21T12:00:00Z"
+      "updated_at": "2026-07-21T18:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Full messenger / nav **interaction regression** fix after #24/#25 (and follow-up to merged #26). User reported many unclickable paths, not only three symptoms.

### Root causes fixed

| Area | Root cause | Fix |
|------|------------|-----|
| List / tab clicks dead | Per-item listeners destroyed on re-render; PE/z-index | Event delegation on `#conv-list` + tab bar; sidebar/create-btn PE + z-index |
| Closed chip under tabs / dead tabs | Flex wrap + `showClosed` stuck | nowrap + min-widths; auto-clear `showClosed` on type tab |
| A→B / nav flashbacks | No gen after await in open/poll/realtime | `openGen` + `isConversationCurrent`; poll/realtime/subscribe guards |
| Full-app click shield | `.create-overlay` CSS defaulted to `display:flex` | Default `display:none` + PE none until inline flex open |
| History sheet after close | Overlay could keep PE during/after leave | PE none default; `[hidden]` force; dismiss PE-none immediately |
| Mobile list locked | `member-open-mobile` stuck after switch | Clear class on hide/switch; mobile PE only when open |
| #25 aro-select | Document **capture** click listener | Bubble phase only; early-return when closed |
| List flash on concurrent reload | `loadConversations` no gen | `convLoadGen` discard stale |
| View switch dead hits | Inactive views still PE | `pointer-events:none` on inactive views; dismiss overlays on switch |
| Dismiss race | `aroDismiss` left PE active until animation end | PE none at dismiss start + `dismissTransientUi` |

### Chinese happy path (交付标准)

打开信使 → 切 最近/私信/群聊 → 点会话 → 发消息/返回 → 再切会话 → 切底部 动态/环网 — 全程无卡死、无闪回。

### Version

Aro **1.0.3** (`manifest.json` + `index.json`)

## Files

- `page/state.js` — `openGen`, `convLoadGen`
- `page/api.js` — open/poll/realtime/load/switchView/create/invite/edit
- `page/chat.js` — list delegation, closed filter UX
- `page/events.js` — tab bar delegation, back dismiss
- `page/helpers.js` — `dismissTransientUi`, `forceHideInteractive`, aroDismiss, aro-select
- `page/members.js` — mobile member sheet hygiene
- `page/history.js`, `page/files.js` — overlay open PE
- `page.html`, `page.css`, `styles.css` (synced)
- `manifest.json`, `index.json`, `README.md`

## Test plan

- [ ] 最近/私信/群聊 tabs click immediately; 已关闭 chip same row; type tab clears closed mode
- [ ] Rapid A→B→C conversation open: no flashback
- [ ] Poll + open race: list stays clickable
- [ ] Open/close create dialog, history, room files: list + nav still clickable
- [ ] Mobile: open member panel → back → list works; no full-screen lock
- [ ] Bottom nav messages ↔ feed ↔ rings with open chat: no wrong transcript, no PE lock
- [ ] Ring create aro-select open/close: does not swallow messenger clicks