### PR TITLE
fix(aro): full messenger cleanup — delete closed chip; fix opens & click shields

### DIFF
--- a/apps/com.myriad.aro/README.md
+++ b/apps/com.myriad.aro/README.md
@@ -2,7 +2,7 @@
 
 社交中心：消息（Channel/Room）、时间线、环网与个人资料。
 
-> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.2）。
+> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.3）。
 
 ## 功能
 
@@ -23,5 +23,5 @@ index.js          # core（与 aro.ts buildCoreCode() 一致）
 page.html / page.css / styles.css
 page/*.js         # pageModules 与 aro.ts PAGE_MODULES 一致
 i18n/{zh,en,ja}.json
-manifest.json     # version 1.0.2
+manifest.json     # version 1.0.3
 ```

--- a/apps/com.myriad.aro/manifest.json
+++ b/apps/com.myriad.aro/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.aro",
   "name": "Aro",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "minSystemVersion": "0.2.1",
   "description": "社交中心，统一管理消息、时间线、环网与个人资料",
   "locales": {

--- a/apps/com.myriad.aro/page.css
+++ b/apps/com.myriad.aro/page.css
@@ -361,7 +361,7 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden}
 .sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px}
 .sidebar-title{margin:0;font-size:16px;font-weight:700;color:var(--text-primary,#1a1a1a);letter-spacing:-.02em}
-/* Messenger list: type tabs (最近|私信|群聊) + closed chip same row */
+/* Messenger list type tabs: 最近 | 私信 | 群聊 (no closed chip) */
 .conv-tabs-bar{
   display:flex;flex-wrap:nowrap;align-items:stretch;gap:6px;flex-shrink:0;
   padding:6px 8px 0 6px;border-bottom:1px solid rgba(128,128,128,.06);
@@ -392,52 +392,10 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   font-weight:750;
   border-bottom-color:var(--tapp-primary,#6366f1)!important;
 }
-/* Type tabs stay selected under closed mode but are dimmed (list is closed-only) */
-.conv-tabs-dimmed .conv-tab{opacity:.45}
-.conv-tabs-dimmed .conv-tab-active{opacity:.7}
-/* Keep closed chip on the same row as type tabs (never wraps under) */
-.conv-closed-chip{
-  flex:0 0 auto;flex-shrink:0;align-self:center;
-  margin:0 0 6px 0;padding:5px 10px;
-  border:1px solid rgba(128,128,128,.18);
-  border-radius:999px;background:transparent;cursor:pointer;
-  font-size:11px;font-weight:600;font-family:inherit;
-  color:var(--text-secondary,#8b98a5);
-  white-space:nowrap;line-height:1.2;
-  transition:color .12s,background .12s,border-color .12s,box-shadow .12s;
-  -webkit-tap-highlight-color:transparent;
-  position:relative;z-index:1;
-  max-width:40%;overflow:hidden;text-overflow:ellipsis;
-}
-.conv-closed-chip:hover{
-  color:var(--text-primary,#1a1a1a);
-  background:rgba(128,128,128,.06);
-  border-color:rgba(128,128,128,.28);
-}
-.conv-closed-chip-active{
-  color:var(--tapp-primary,#6366f1)!important;
-  border-color:rgba(var(--tapp-primary-rgb,99,102,241),.45)!important;
-  background:rgba(var(--tapp-primary-rgb,99,102,241),.1)!important;
-  box-shadow:0 0 0 1px rgba(var(--tapp-primary-rgb,99,102,241),.12);
-}
 .dark .conv-tabs-bar{background:rgba(0,0,0,.18);border-color:rgba(255,255,255,.06)}
 .dark .conv-tab{color:rgba(255,255,255,.5)}
 .dark .conv-tab:hover{color:rgba(255,255,255,.9);background:rgba(255,255,255,.04)}
 .dark .conv-tab-active{color:rgba(255,255,255,.95)!important}
-.dark .conv-closed-chip{
-  color:rgba(255,255,255,.5);
-  border-color:rgba(255,255,255,.14);
-}
-.dark .conv-closed-chip:hover{
-  color:rgba(255,255,255,.9);
-  background:rgba(255,255,255,.06);
-  border-color:rgba(255,255,255,.22);
-}
-.dark .conv-closed-chip-active{
-  color:rgba(165,180,252)!important;
-  border-color:rgba(var(--tapp-primary-rgb,99,102,241),.5)!important;
-  background:rgba(var(--tapp-primary-rgb,99,102,241),.16)!important;
-}
 .create-btn{width:36px;height:36px;min-width:36px;min-height:36px;border-radius:10px;border:none;background:var(--tapp-primary,#6366f1);color:#fff;font-size:22px;font-weight:400;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:opacity .15s,transform .12s;flex-shrink:0;line-height:1}
 .create-btn:hover{opacity:.9}
 .create-btn:active{transform:scale(.96)}
@@ -459,13 +417,15 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .forward-search{padding:8px 12px 4px;flex-shrink:0}
 .forward-search .aro-search-input{width:100%;flex:none}
 
-/* ===== Chat history panel ===== */
+/* ===== Chat history / room-files panel (scoped under #chat-main; never covers sidebar) ===== */
 .history-overlay{
   position:absolute;inset:0;z-index:40;display:none;align-items:stretch;justify-content:flex-end;
   background:rgba(15,23,42,.22);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+  /* Closed default: never intercept clicks (JS also sets display:none + hidden) */
+  pointer-events:none;
 }
 .history-overlay.aro-history-enter{animation:aroFadeIn var(--aro-dur) ease both}
-.history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none}
+.history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none!important}
 /* history open uses class on overlay (not aroPlayEnter generic) */
 .history-sheet{
   width:min(400px,100%);max-width:100%;height:100%;

--- a/apps/com.myriad.aro/page.css
+++ b/apps/com.myriad.aro/page.css
@@ -7,8 +7,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 #tapp-content{display:flex!important;flex-direction:column!important;overflow:hidden!important}
 
 /* ===== Aro Nav ===== */
-.aro-nav{display:flex;align-items:center;gap:4px;padding:8px 12px;border-bottom:1px solid rgba(128,128,128,.08);flex-shrink:0;background:rgba(255,255,255,.78);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px)}
-.aro-nav-item{min-height:36px;display:flex;align-items:center;gap:8px;padding:0 14px;border:none;background:none;border-radius:11px;font-size:13px;font-weight:600;color:var(--text-secondary,#888);cursor:pointer;transition:background .14s,color .14s;white-space:nowrap}
+.aro-nav{display:flex;align-items:center;gap:4px;padding:8px 12px;border-bottom:1px solid rgba(128,128,128,.08);flex-shrink:0;background:rgba(255,255,255,.78);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px);position:relative;z-index:30;pointer-events:auto}
+.aro-nav-item{min-height:36px;display:flex;align-items:center;gap:8px;padding:0 14px;border:none;background:none;border-radius:11px;font-size:13px;font-weight:600;color:var(--text-secondary,#888);cursor:pointer;transition:background .14s,color .14s;white-space:nowrap;touch-action:manipulation;pointer-events:auto;-webkit-tap-highlight-color:transparent}
 .aro-nav-item:hover{background:rgba(128,128,128,.07);color:var(--text-primary,#222)}
 .aro-nav-item:focus-visible{outline:2px solid rgba(var(--tapp-primary-rgb,99,102,241),.45);outline-offset:1px}
 .aro-nav-active{background:rgba(var(--tapp-primary-rgb,100,100,255),.12)!important;color:var(--tapp-primary,#6366f1)!important}
@@ -20,8 +20,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .nav-feed-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:96px}
 
 /* ===== Aro Views ===== */
-.aro-view{display:none;flex:1;min-height:0;min-width:0;width:100%;overflow:hidden}
-.aro-view-active{display:flex;flex-direction:column;width:100%;max-width:none}
+.aro-view{display:none;flex:1;min-height:0;min-width:0;width:100%;overflow:hidden;pointer-events:none}
+.aro-view-active{display:flex;flex-direction:column;width:100%;max-width:none;pointer-events:auto}
 
 /* ===== Panel Layout (sidebar+content, for rings) ===== */
 .aro-panel-layout{display:flex;flex:1;min-height:0;overflow:hidden}
@@ -358,8 +358,9 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 
 /* ===== Layout ===== */
 .messenger-app{display:flex;flex:1;min-height:0;overflow:hidden;position:relative}
-.sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden}
-.sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px}
+.sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden;position:relative;z-index:2;pointer-events:auto}
+.sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px;position:relative;z-index:3;pointer-events:auto}
+.sidebar-header .create-btn{position:relative;z-index:4;pointer-events:auto;touch-action:manipulation}
 .sidebar-title{margin:0;font-size:16px;font-weight:700;color:var(--text-primary,#1a1a1a);letter-spacing:-.02em}
 /* Messenger list type tabs: 最近 | 私信 | 群聊 (no closed chip) */
 .conv-tabs-bar{
@@ -424,8 +425,11 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   /* Closed default: never intercept clicks (JS also sets display:none + hidden) */
   pointer-events:none;
 }
+.history-overlay[style*="display: flex"],
+.history-overlay[style*="display:flex"]{pointer-events:auto}
 .history-overlay.aro-history-enter{animation:aroFadeIn var(--aro-dur) ease both}
 .history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none!important}
+.history-overlay[hidden]{display:none!important;pointer-events:none!important}
 /* history open uses class on overlay (not aroPlayEnter generic) */
 .history-sheet{
   width:min(400px,100%);max-width:100%;height:100%;
@@ -1000,7 +1004,7 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 
 .conv-list{flex:1;min-height:0;overflow-y:auto;padding:6px 8px;display:flex;flex-direction:column;gap:2px;position:relative;z-index:1;pointer-events:auto;-webkit-overflow-scrolling:touch}
 .conv-list .conv-item{pointer-events:auto;touch-action:manipulation}
-.chat-main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;overflow:hidden}
+.chat-main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;overflow:hidden;isolation:isolate}
 .member-panel{display:flex;flex-direction:column;width:220px;border-left:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden;transition:width .2s}
 .member-panel.member-collapsed{width:0;border-left:none;overflow:hidden}
 .member-back-btn{display:none;background:none;border:none;font-size:16px;color:var(--text-primary,#1a1a1a);cursor:pointer;padding:2px 4px;margin-right:6px;border-radius:6px;flex-shrink:0}
@@ -1212,6 +1216,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .dark .msg-more-btn:hover,.dark .msg-more-btn:focus-visible{background:rgba(255,255,255,.1)}
 
 /* ===== Input ===== */
+/* pointer-events:none on the wrap so the gradient does not steal message-area
+   scrolls/clicks; only children (composer) are interactive. Never stretch over sidebar. */
 .input-float-wrap{position:absolute;bottom:0;left:0;right:0;z-index:20;padding:8px 12px;padding-bottom:calc(8px + env(safe-area-inset-bottom,0px));background:linear-gradient(to top,var(--bg-primary,#fff) 70%,transparent);pointer-events:none}
 .input-float-wrap>*{pointer-events:auto}
 .input-bar{display:flex;align-items:flex-end;gap:8px;padding:8px 10px;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.12);border-radius:18px;box-shadow:0 2px 12px rgba(0,0,0,.06)}
@@ -1839,12 +1845,12 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
   .aro-nav-item{flex-direction:column;gap:3px;padding:8px 12px;font-size:11px}
   .aro-nav-item svg{width:22px;height:22px}
   .nav-feed-avatar{width:24px;height:24px;font-size:11px}
-  .sidebar{width:100%}
-  .sidebar-hidden-mobile{display:none!important}
+  .sidebar{width:100%;z-index:2;pointer-events:auto}
+  .sidebar-hidden-mobile{display:none!important;pointer-events:none!important}
   .back-btn{display:block}
-  .member-panel{display:none;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none}
+  .member-panel{display:none!important;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none;pointer-events:none}
   .dark .member-panel{background:var(--bg-primary,#1a1a1a)}
-  .member-panel.member-open-mobile{display:flex!important}
+  .member-panel.member-open-mobile{display:flex!important;pointer-events:auto}
   .member-back-btn{display:flex}
   .aro-panel-layout .sidebar{width:100%}
   .aro-panel-layout .sidebar-hidden-mobile{display:none!important}
@@ -1872,7 +1878,12 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 }
 
 /* ===== Create Dialog ===== */
-.create-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:100}
+/* Default display:none — previous display:flex default left a full-screen click shield
+   whenever inline style was cleared or dismiss raced. */
+.create-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:100;pointer-events:none}
+.create-overlay[style*="display: flex"],
+.create-overlay[style*="display:flex"]{pointer-events:auto}
+.create-overlay[hidden]{display:none!important;pointer-events:none!important}
 .create-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(360px,90vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.15)}
 .create-dialog-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
 .create-dialog-title{margin:0;font-size:16px;font-weight:600;color:var(--text-primary,#1a1a1a)}
@@ -1986,7 +1997,8 @@ button.aro-select-trigger.create-input{
 
 
 /* ===== In-app Confirm Dialog (native confirm() is blocked in the sandboxed iframe) ===== */
-.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease}
+.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease;pointer-events:auto}
+.confirm-overlay.aro-leaving,.confirm-overlay[hidden]{pointer-events:none!important}
 .confirm-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(320px,88vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.18)}
 .confirm-message{font-size:14px;line-height:1.6;color:var(--text-primary,#1a1a1a);margin-bottom:18px;overflow-wrap:break-word}
 .confirm-actions{display:flex;gap:8px;justify-content:flex-end}

--- a/apps/com.myriad.aro/page.html
+++ b/apps/com.myriad.aro/page.html
@@ -38,7 +38,6 @@
             <button type="button" class="conv-tab" data-conv-tab="dm" role="tab" aria-selected="false" id="conv-tab-dm">私信</button>
             <button type="button" class="conv-tab" data-conv-tab="room" role="tab" aria-selected="false" id="conv-tab-room">群聊</button>
           </div>
-          <button type="button" class="conv-closed-chip" id="conv-closed-toggle" aria-pressed="false" title="已关闭" aria-label="已关闭">已关闭</button>
         </div>
         <div class="aro-search-bar">
           <span class="aro-search-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
@@ -84,85 +83,86 @@
           <input id="attach-file-input" type="file" style="display:none" />
           <input id="attach-image-input" type="file" accept="image/*" style="display:none" />
         </div>
+
+        <!-- Overlays scoped to #chat-main only so a stuck panel cannot block the sidebar list -->
+        <!-- 群文件面板（仅群聊；覆盖聊天区，复用 history 侧栏壳） -->
+        <div id="room-files-overlay" class="history-overlay" style="display:none;pointer-events:none" role="dialog" aria-modal="true" aria-labelledby="room-files-title" hidden>
+          <div class="history-sheet" role="document">
+            <div class="history-grab" aria-hidden="true"><span class="history-grab-bar"></span></div>
+            <div class="history-header">
+              <div class="history-header-leading">
+                <div class="history-header-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
+                </div>
+                <div class="history-header-text">
+                  <h3 id="room-files-title" class="history-title">群文件</h3>
+                  <div id="room-files-subtitle" class="history-subtitle"></div>
+                </div>
+              </div>
+              <button type="button" id="room-files-close" class="history-close" aria-label="Close">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+            <div class="history-toolbar">
+              <div class="aro-search-bar history-search-bar">
+                <span class="aro-search-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+                <input id="room-files-search" class="aro-search-input" type="search" autocomplete="off" enterkeyhint="search" placeholder="搜索文件名…" />
+              </div>
+              <div id="room-files-filters" class="history-filters" role="tablist" aria-label="Filter">
+                <button type="button" class="history-filter history-filter-active" data-room-files-filter="all" role="tab" aria-selected="true">全部</button>
+                <button type="button" class="history-filter" data-room-files-filter="image" role="tab" aria-selected="false">图片</button>
+                <button type="button" class="history-filter" data-room-files-filter="file" role="tab" aria-selected="false">文件</button>
+              </div>
+            </div>
+            <div id="room-files-list" class="history-list"></div>
+            <div class="history-footer">
+              <div id="room-files-meta" class="history-meta"></div>
+              <button type="button" id="room-files-load-more" class="history-load-more" hidden>加载更多</button>
+              <p id="room-files-hint" class="room-files-hint"></p>
+            </div>
+          </div>
+        </div>
+
+        <!-- 聊天记录面板（覆盖聊天区，不覆盖会话列表） -->
+        <div id="chat-history-overlay" class="history-overlay" style="display:none;pointer-events:none" role="dialog" aria-modal="true" aria-labelledby="history-title" hidden>
+          <div class="history-sheet" role="document">
+            <div class="history-grab" aria-hidden="true"><span class="history-grab-bar"></span></div>
+            <div class="history-header">
+              <div class="history-header-leading">
+                <div class="history-header-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+                </div>
+                <div class="history-header-text">
+                  <h3 id="history-title" class="history-title">聊天记录</h3>
+                  <div id="history-subtitle" class="history-subtitle"></div>
+                </div>
+              </div>
+              <button type="button" id="history-close" class="history-close" aria-label="Close">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+            <div class="history-toolbar">
+              <div class="aro-search-bar history-search-bar">
+                <span class="aro-search-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
+                <input id="history-search" class="aro-search-input" type="search" autocomplete="off" enterkeyhint="search" placeholder="搜索聊天记录…" />
+              </div>
+              <div id="history-filters" class="history-filters" role="tablist" aria-label="Filter">
+                <button type="button" class="history-filter history-filter-active" data-history-filter="all" role="tab" aria-selected="true">全部</button>
+                <button type="button" class="history-filter" data-history-filter="text" role="tab" aria-selected="false">文字</button>
+                <button type="button" class="history-filter" data-history-filter="image" role="tab" aria-selected="false">图片</button>
+                <button type="button" class="history-filter" data-history-filter="file" role="tab" aria-selected="false">文件</button>
+                <button type="button" class="history-filter" data-history-filter="share" role="tab" aria-selected="false">分享</button>
+                <button type="button" class="history-filter" data-history-filter="pinned" role="tab" aria-selected="false">置顶</button>
+              </div>
+            </div>
+            <div id="history-list" class="history-list"></div>
+            <div class="history-footer">
+              <div id="history-meta" class="history-meta"></div>
+              <button type="button" id="history-load-more" class="history-load-more" hidden>加载更早消息</button>
+            </div>
+          </div>
+        </div>
       </main>
-
-      <!-- 群文件面板（仅群聊；覆盖在消息视图上，复用 history 侧栏壳） -->
-      <div id="room-files-overlay" class="history-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="room-files-title" hidden>
-        <div class="history-sheet" role="document">
-          <div class="history-grab" aria-hidden="true"><span class="history-grab-bar"></span></div>
-          <div class="history-header">
-            <div class="history-header-leading">
-              <div class="history-header-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/></svg>
-              </div>
-              <div class="history-header-text">
-                <h3 id="room-files-title" class="history-title">群文件</h3>
-                <div id="room-files-subtitle" class="history-subtitle"></div>
-              </div>
-            </div>
-            <button type="button" id="room-files-close" class="history-close" aria-label="Close">
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
-            </button>
-          </div>
-          <div class="history-toolbar">
-            <div class="aro-search-bar history-search-bar">
-              <span class="aro-search-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
-              <input id="room-files-search" class="aro-search-input" type="search" autocomplete="off" enterkeyhint="search" placeholder="搜索文件名…" />
-            </div>
-            <div id="room-files-filters" class="history-filters" role="tablist" aria-label="Filter">
-              <button type="button" class="history-filter history-filter-active" data-room-files-filter="all" role="tab" aria-selected="true">全部</button>
-              <button type="button" class="history-filter" data-room-files-filter="image" role="tab" aria-selected="false">图片</button>
-              <button type="button" class="history-filter" data-room-files-filter="file" role="tab" aria-selected="false">文件</button>
-            </div>
-          </div>
-          <div id="room-files-list" class="history-list"></div>
-          <div class="history-footer">
-            <div id="room-files-meta" class="history-meta"></div>
-            <button type="button" id="room-files-load-more" class="history-load-more" hidden>加载更多</button>
-            <p id="room-files-hint" class="room-files-hint"></p>
-          </div>
-        </div>
-      </div>
-
-      <!-- 聊天记录面板（覆盖在消息视图上） -->
-      <div id="chat-history-overlay" class="history-overlay" style="display:none" role="dialog" aria-modal="true" aria-labelledby="history-title" hidden>
-        <div class="history-sheet" role="document">
-          <div class="history-grab" aria-hidden="true"><span class="history-grab-bar"></span></div>
-          <div class="history-header">
-            <div class="history-header-leading">
-              <div class="history-header-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
-              </div>
-              <div class="history-header-text">
-                <h3 id="history-title" class="history-title">聊天记录</h3>
-                <div id="history-subtitle" class="history-subtitle"></div>
-              </div>
-            </div>
-            <button type="button" id="history-close" class="history-close" aria-label="Close">
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
-            </button>
-          </div>
-          <div class="history-toolbar">
-            <div class="aro-search-bar history-search-bar">
-              <span class="aro-search-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span>
-              <input id="history-search" class="aro-search-input" type="search" autocomplete="off" enterkeyhint="search" placeholder="搜索聊天记录…" />
-            </div>
-            <div id="history-filters" class="history-filters" role="tablist" aria-label="Filter">
-              <button type="button" class="history-filter history-filter-active" data-history-filter="all" role="tab" aria-selected="true">全部</button>
-              <button type="button" class="history-filter" data-history-filter="text" role="tab" aria-selected="false">文字</button>
-              <button type="button" class="history-filter" data-history-filter="image" role="tab" aria-selected="false">图片</button>
-              <button type="button" class="history-filter" data-history-filter="file" role="tab" aria-selected="false">文件</button>
-              <button type="button" class="history-filter" data-history-filter="share" role="tab" aria-selected="false">分享</button>
-              <button type="button" class="history-filter" data-history-filter="pinned" role="tab" aria-selected="false">置顶</button>
-            </div>
-          </div>
-          <div id="history-list" class="history-list"></div>
-          <div class="history-footer">
-            <div id="history-meta" class="history-meta"></div>
-            <button type="button" id="history-load-more" class="history-load-more" hidden>加载更早消息</button>
-          </div>
-        </div>
-      </div>
 
       <!-- 右侧：成员面板 -->
       <aside id="member-panel" class="member-panel" style="display:none">

--- a/apps/com.myriad.aro/page/api.js
+++ b/apps/com.myriad.aro/page/api.js
@@ -1,10 +1,13 @@
 // ==================== API ====================
 async function loadConversations() {
+  var gen = (state.convLoadGen = (state.convLoadGen || 0) + 1);
   try {
     var results = await Promise.allSettled([
       Tapp.federation.getChannels(),
       Tapp.federation.getRooms(),
     ]);
+    // Stale reload finished after a newer one — do not flash older list data.
+    if (gen !== state.convLoadGen) return;
     var errors = [];
     if (results[0].status === 'fulfilled' && results[0].value) {
       state.channels = results[0].value.channels || [];
@@ -32,6 +35,7 @@ async function loadConversations() {
       refreshDeliveryHealth().catch(function () {});
     }
   } catch (e) {
+    if (gen !== state.convLoadGen) return;
     console.error('[Aro] loadConversations error:', e);
   }
 }
@@ -61,6 +65,10 @@ async function openConversation(kind, id) {
   // ---- Synchronous shell update FIRST (must not await before this) ----
   // Clicks on 最近/list must paint active chat immediately; network teardown
   // (unsubscribeRealtime) and message loads happen after first paint.
+  // Drop click-shields / sheets that would sit above the list or chat.
+  if (typeof dismissTransientUi === 'function') {
+    dismissTransientUi({ keepChat: true });
+  }
   if (typeof resetHistoryOnConversationChange === 'function') resetHistoryOnConversationChange();
   if (typeof resetRoomFilesOnConversationChange === 'function') resetRoomFilesOnConversationChange();
 
@@ -1237,7 +1245,8 @@ function toggleInvitePopover(e) {
     pop.style.top = (rect.bottom + 6) + 'px';
     pop.style.left = Math.max(4, rect.right - 240) + 'px';
     pop.classList.remove('aro-leaving');
-    pop.style.display = '';
+    pop.style.pointerEvents = '';
+    pop.style.display = 'block';
     aroPlayEnter(pop, 'aro-menu-enter');
     renderInvitePopoverContacts();
     var invInput = pop.querySelector('#invite-input');
@@ -1367,13 +1376,24 @@ function showEditRoomDialog() {
     }
   }
   overlay.classList.remove('aro-leaving');
+  overlay.hidden = false;
+  overlay.style.pointerEvents = 'auto';
   overlay.style.display = 'flex';
 }
 
 function hideEditRoomDialog() {
   var overlay = $('edit-room-dialog');
   if (!overlay || overlay.style.display === 'none') return;
-  aroDismiss(overlay, { ms: 170 });
+  overlay.style.pointerEvents = 'none';
+  aroDismiss(overlay, {
+    ms: 170,
+    onDone: function () {
+      try {
+        overlay.hidden = true;
+        overlay.style.pointerEvents = 'none';
+      } catch (e) { /* ignore */ }
+    },
+  });
 }
 
 async function doSaveRoom() {
@@ -1656,6 +1676,8 @@ function showCreateDialog() {
   var overlay = $('create-dialog');
   if (overlay) {
     overlay.classList.remove('aro-leaving');
+    overlay.hidden = false;
+    overlay.style.pointerEvents = 'auto';
     overlay.style.display = 'flex';
   }
   switchCreateTab('channel');
@@ -1669,11 +1691,28 @@ function hideCreateDialog() {
     if (channelInput) channelInput.value = '';
     if (roomInput) roomInput.value = '';
   };
-  if (!overlay || overlay.style.display === 'none') {
+  if (!overlay || overlay.style.display === 'none' || overlay.hidden) {
+    if (overlay) {
+      try {
+        overlay.style.display = 'none';
+        overlay.style.pointerEvents = 'none';
+        overlay.hidden = true;
+      } catch (eSeal) { /* ignore */ }
+    }
     clearInputs();
     return;
   }
-  aroDismiss(overlay, { ms: 170, onDone: clearInputs });
+  overlay.style.pointerEvents = 'none';
+  aroDismiss(overlay, {
+    ms: 170,
+    onDone: function () {
+      try {
+        overlay.hidden = true;
+        overlay.style.pointerEvents = 'none';
+      } catch (eH) { /* ignore */ }
+      clearInputs();
+    },
+  });
 }
 
 function switchCreateTab(tab) {
@@ -1817,6 +1856,10 @@ function switchView(view) {
   var prev = state.currentView;
   if (prev === view) return;
   state.currentView = view;
+  // Leaving a view: clear overlays that can pin over the whole #tapp-content (create/compose).
+  if (typeof dismissTransientUi === 'function') {
+    dismissTransientUi({ keepChat: view === 'messages' });
+  }
   var views = ['messages', 'feed', 'rings'];
   views.forEach(function (v) {
     var el = $('view-' + v);
@@ -1825,8 +1868,11 @@ function switchView(view) {
       if (v !== view) {
         el.style.display = 'none';
         el.classList.remove('aro-view-enter');
+        // Ensure inactive views never intercept pointer hits
+        el.style.pointerEvents = 'none';
       } else {
         el.style.display = '';
+        el.style.pointerEvents = '';
         el.classList.add('aro-view-active');
         if (prev && prev !== view) aroPlayEnter(el, 'aro-view-enter');
       }

--- a/apps/com.myriad.aro/page/api.js
+++ b/apps/com.myriad.aro/page/api.js
@@ -58,10 +58,9 @@ async function openConversation(kind, id) {
   // Stop poll immediately so a prior interval cannot write into the new shell.
   stopPolling();
 
-  // Drop previous realtime subscription before switching
-  await unsubscribeRealtime();
-  if (!isOpenGenCurrent(gen)) return;
-
+  // ---- Synchronous shell update FIRST (must not await before this) ----
+  // Clicks on 最近/list must paint active chat immediately; network teardown
+  // (unsubscribeRealtime) and message loads happen after first paint.
   if (typeof resetHistoryOnConversationChange === 'function') resetHistoryOnConversationChange();
   if (typeof resetRoomFilesOnConversationChange === 'function') resetRoomFilesOnConversationChange();
 
@@ -97,6 +96,11 @@ async function openConversation(kind, id) {
   renderChatHeader();
   // Refresh active highlight without waiting for network
   renderConvList();
+
+  // ---- Async work after first paint (stale-guarded with openGen) ----
+  // Never block UI open on realtime unsubscribe.
+  await unsubscribeRealtime();
+  if (!isOpenGenCurrent(gen)) return;
 
   try {
     if (kind === 'channel') {

--- a/apps/com.myriad.aro/page/chat.js
+++ b/apps/com.myriad.aro/page/chat.js
@@ -43,72 +43,36 @@ function filterConversationItems(items, query) {
 }
 
 /**
- * Apply messenger list filter.
- * - showClosed on: only closed conversations (covers type tab; type selection kept).
- * - showClosed off: recent | dm | room type tabs (non-closed only).
+ * Apply messenger list filter: recent | dm | room only.
+ * Closed conversations are always excluded from the main list
+ * (no UI to browse closed; composer lock for closed detail can remain).
  * recent = open DMs + rooms, sorted by existing last-activity order.
  */
 function filterConversationByTab(items) {
-  if (state.showClosed) {
-    return items.filter(function (item) {
-      // Closed channels; rooms with closed membership if that ever appears
-      if (item.kind === 'channel') return item.status === 'closed';
-      if (item.kind === 'room') return item.status === 'closed';
-      return false;
-    });
-  }
   var tab = state.convTab || 'recent';
   return items.filter(function (item) {
-    if (tab === 'dm') {
-      return item.kind === 'channel' && item.status !== 'closed';
-    }
-    if (tab === 'room') {
-      return item.kind === 'room' && item.status !== 'closed';
-    }
+    if (item.status === 'closed') return false;
+    if (tab === 'dm') return item.kind === 'channel';
+    if (tab === 'room') return item.kind === 'room';
     // recent (default): non-closed DMs + rooms
-    if (item.kind === 'channel') return item.status !== 'closed';
-    if (item.kind === 'room') return item.status !== 'closed';
-    return false;
+    return item.kind === 'channel' || item.kind === 'room';
   });
 }
 
 function syncConvTabsUi() {
   var tab = state.convTab || 'recent';
-  var closedOn = !!state.showClosed;
   document.querySelectorAll('.conv-tab').forEach(function (btn) {
     var on = btn.getAttribute('data-conv-tab') === tab;
     btn.classList.toggle('conv-tab-active', on);
     if (btn.setAttribute) btn.setAttribute('aria-selected', on ? 'true' : 'false');
   });
-  var bar = $('conv-tabs-bar') || document.querySelector('.conv-tabs-bar');
-  if (bar) bar.classList.toggle('conv-tabs-closed-mode', closedOn);
-  var tabs = $('conv-tabs');
-  if (tabs) tabs.classList.toggle('conv-tabs-dimmed', closedOn);
-  var chip = $('conv-closed-toggle');
-  if (chip) {
-    chip.classList.toggle('conv-closed-chip-active', closedOn);
-    chip.setAttribute('aria-pressed', closedOn ? 'true' : 'false');
-  }
 }
 
 function setConvTab(tab) {
   if (tab !== 'recent' && tab !== 'dm' && tab !== 'room') tab = 'recent';
   state.convTab = tab;
-  // Leaving closed mode when user picks a type tab so tabs feel immediately clickable
-  // (closed chip stays available; list returns to the selected type filter).
-  if (state.showClosed) state.showClosed = false;
   syncConvTabsUi();
   renderConvList();
-}
-
-function setShowClosed(on) {
-  state.showClosed = !!on;
-  syncConvTabsUi();
-  renderConvList();
-}
-
-function toggleShowClosed() {
-  setShowClosed(!state.showClosed);
 }
 
 /**
@@ -146,10 +110,7 @@ function renderConvList() {
   if (tabItems.length === 0 && !q) {
     var emptyTitle = lang.noConv || lang.title || 'Messenger';
     var emptyHint = lang.noConvHint || lang.selectHint || 'Start a chat with +';
-    if (state.showClosed) {
-      emptyTitle = lang.convTabClosedEmpty || lang.closed || 'Closed';
-      emptyHint = lang.convTabClosedEmptyHint || 'No closed chats';
-    } else if ((state.convTab || 'recent') === 'room') {
+    if ((state.convTab || 'recent') === 'room') {
       emptyTitle = lang.convTabRoomEmpty || lang.rooms || lang.convTabRoom || 'Groups';
       emptyHint = lang.convTabRoomEmptyHint || lang.noRoomsHint || lang.noConvHint || emptyHint;
     } else if ((state.convTab || 'recent') === 'dm') {
@@ -188,10 +149,6 @@ function renderConvList() {
       + '<span class="conv-preview">' + esc(item.preview) + '</span>';
     if (item.unread > 0) {
       html += '<span class="conv-badge">' + (item.unread > 9 ? '9+' : item.unread) + '</span>';
-    }
-    // Closed badge only in closed filter (never on recent/dm/room rows)
-    if (state.showClosed && item.status === 'closed') {
-      html += '<span class="conv-closed">' + esc(lang.closed) + '</span>';
     }
     if (item.status === 'pending' && item.initiatedBy === 'remote') {
       html += '<span class="conv-pending">' + esc(lang.pending) + '</span>';

--- a/apps/com.myriad.aro/page/events.js
+++ b/apps/com.myriad.aro/page/events.js
@@ -286,12 +286,14 @@
     backBtn.addEventListener('click', function () {
       // Invalidate in-flight open/poll so leaving chat cannot flash stale messages.
       state.openGen = (state.openGen || 0) + 1;
+      if (typeof dismissTransientUi === 'function') dismissTransientUi({});
       var sidebar = $('sidebar');
       var chat = $('chat-container');
       var members = $('member-panel');
       var empty = $('empty-state');
       if (sidebar) {
         sidebar.classList.remove('sidebar-hidden-mobile');
+        sidebar.style.pointerEvents = '';
         aroPlayEnter(sidebar, 'aro-panel-enter');
       }
       if (chat) {
@@ -302,6 +304,7 @@
         members.style.display = 'none';
         members.classList.remove('member-open-mobile');
         members.classList.remove('member-expanded-tablet');
+        members.style.pointerEvents = '';
       }
       if (empty) {
         empty.style.display = '';

--- a/apps/com.myriad.aro/page/events.js
+++ b/apps/com.myriad.aro/page/events.js
@@ -78,7 +78,7 @@
   document.querySelectorAll('.feed-mobile-tab').forEach(function (btn) {
     btn.addEventListener('click', function () { switchFeedSubTab(btn.dataset.sub); });
   });
-  // Messenger sidebar: 最近 / 私信 / 群聊 + 已关闭 chip
+  // Messenger sidebar: 最近 / 私信 / 群聊 (no closed tab/chip)
   // Prefer bar-level delegation so re-renders / i18n text swaps never drop handlers.
   var convTabsBar = $('conv-tabs-bar') || document.querySelector('.conv-tabs-bar');
   if (convTabsBar && convTabsBar.dataset.convTabsBound !== '1') {
@@ -90,12 +90,6 @@
         if (typeof setConvTab === 'function') {
           setConvTab(tabBtn.getAttribute('data-conv-tab') || 'recent');
         }
-        return;
-      }
-      var chip = e.target && e.target.closest ? e.target.closest('#conv-closed-toggle, .conv-closed-chip') : null;
-      if (chip && convTabsBar.contains(chip)) {
-        e.preventDefault();
-        if (typeof toggleShowClosed === 'function') toggleShowClosed();
       }
     });
   } else {
@@ -104,12 +98,6 @@
         if (typeof setConvTab === 'function') setConvTab(btn.getAttribute('data-conv-tab') || 'recent');
       });
     });
-    var closedToggle = $('conv-closed-toggle');
-    if (closedToggle) {
-      closedToggle.addEventListener('click', function () {
-        if (typeof toggleShowClosed === 'function') toggleShowClosed();
-      });
-    }
   }
   // Conversation list: stable delegation (also re-asserted in renderConvList)
   if (typeof bindConvListClicks === 'function') bindConvListClicks();

--- a/apps/com.myriad.aro/page/files.js
+++ b/apps/com.myriad.aro/page/files.js
@@ -63,6 +63,14 @@ function isRoomFilesOpen() {
   return !!(overlay && overlay.style.display !== 'none' && !overlay.hidden);
 }
 
+function sealRoomFilesOverlay(overlay) {
+  if (!overlay) return;
+  overlay.classList.remove('aro-history-enter', 'aro-leaving');
+  overlay.style.display = 'none';
+  overlay.hidden = true;
+  overlay.style.pointerEvents = 'none';
+}
+
 function closeRoomFiles() {
   var rf = ensureRoomFilesState();
   rf.open = false;
@@ -71,16 +79,21 @@ function closeRoomFiles() {
     rf.searchTimer = null;
   }
   var overlay = $('room-files-overlay');
-  if (!overlay || overlay.style.display === 'none') return;
+  if (!overlay) return;
+  // Always seal pointer-events so a stuck flex overlay cannot block the list
+  if (overlay.style.display === 'none' || overlay.hidden) {
+    sealRoomFilesOverlay(overlay);
+    return;
+  }
   overlay.classList.remove('aro-history-enter');
+  overlay.style.pointerEvents = 'none';
   if (typeof aroDismiss === 'function') {
     aroDismiss(overlay, {
       ms: 160,
-      onDone: function () { overlay.hidden = true; },
+      onDone: function () { sealRoomFilesOverlay(overlay); },
     });
   } else {
-    overlay.style.display = 'none';
-    overlay.hidden = true;
+    sealRoomFilesOverlay(overlay);
   }
 }
 
@@ -395,6 +408,7 @@ async function openRoomFiles() {
   if (!overlay) return;
   overlay.hidden = false;
   overlay.style.display = 'flex';
+  overlay.style.pointerEvents = 'auto';
   overlay.classList.remove('aro-leaving', 'aro-history-enter');
   try { void overlay.offsetWidth; } catch (eAnim) { /* ignore */ }
   if (!(typeof prefersReducedMotion === 'function' && prefersReducedMotion())) {

--- a/apps/com.myriad.aro/page/helpers.js
+++ b/apps/com.myriad.aro/page/helpers.js
@@ -85,7 +85,24 @@ function aroPlayEnter(el, className) {
 }
 
 /**
+ * Immediately stop an overlay/menu from receiving clicks (safe even mid-animation).
+ * Use when a stuck layer would dead-lock the messenger UI.
+ */
+function forceHideInteractive(el) {
+  if (!el) return;
+  try {
+    el.classList.remove('aro-leaving', 'aro-history-enter', 'aro-view-enter', 'aro-panel-enter', 'aro-menu-enter', 'open', 'is-open');
+    el.style.pointerEvents = 'none';
+    el.style.display = 'none';
+    if (el.hasAttribute && (el.hasAttribute('hidden') || el.getAttribute('aria-modal') === 'true' || el.classList.contains('history-overlay') || el.classList.contains('create-overlay') || el.classList.contains('confirm-overlay') || el.classList.contains('picker-overlay') || el.classList.contains('forward-overlay'))) {
+      el.hidden = true;
+    }
+  } catch (eForce) { /* ignore */ }
+}
+
+/**
  * Hide or remove an element after a short exit animation (class `aro-leaving`).
+ * Always disables pointer-events immediately so dismiss never leaves a click shield.
  * @param {HTMLElement} el
  * @param {{ remove?: boolean, ms?: number, onDone?: function }} opts
  */
@@ -93,6 +110,8 @@ function aroDismiss(el, opts) {
   opts = opts || {};
   if (!el) { if (opts.onDone) opts.onDone(); return; }
   var finished = false;
+  // Critical: block hits the moment dismiss starts (aro-leaving CSS may lag / fail).
+  try { el.style.pointerEvents = 'none'; } catch (ePe) { /* ignore */ }
   var finish = function () {
     if (finished) return;
     finished = true;
@@ -102,6 +121,10 @@ function aroDismiss(el, opts) {
       try { el.remove(); } catch (e) { /* ignore */ }
     } else {
       el.style.display = 'none';
+      el.style.pointerEvents = 'none';
+      try {
+        if (el.hasAttribute && el.hasAttribute('hidden')) el.hidden = true;
+      } catch (eH) { /* ignore */ }
     }
     if (opts.onDone) opts.onDone();
   };
@@ -110,13 +133,80 @@ function aroDismiss(el, opts) {
     if (e && e.target && e.target !== el) return;
     finish();
   };
-  if (prefersReducedMotion() || el.style.display === 'none') {
+  if (prefersReducedMotion() || el.style.display === 'none' || el.hidden) {
     finish();
     return;
   }
   el.classList.add('aro-leaving');
   el.addEventListener('animationend', onAnimEnd);
   setTimeout(finish, opts.ms || 180);
+}
+
+/**
+ * Close menus/overlays that commonly leave a full-screen click shield.
+ * Safe to call from openConversation / switchView / back.
+ * @param {{ keepChat?: boolean }} [opts]
+ */
+function dismissTransientUi(opts) {
+  opts = opts || {};
+  try { if (typeof closeMsgMenu === 'function') closeMsgMenu(); } catch (e0) { /* ignore */ }
+  try { if (typeof closeAttachMenu === 'function') closeAttachMenu(); } catch (e1) { /* ignore */ }
+  try { if (typeof closeInvitePopover === 'function') closeInvitePopover(); } catch (e2) { /* ignore */ }
+  try { if (typeof closeManageDropdown === 'function') closeManageDropdown(); } catch (e3) { /* ignore */ }
+  try {
+    document.querySelectorAll('.aro-select.is-open').forEach(function (root) {
+      if (root._aroSelect && typeof root._aroSelect.close === 'function') root._aroSelect.close();
+    });
+  } catch (e4) { /* ignore */ }
+  // Force-hide fixed/absolute overlays that may still paint over the app
+  try {
+    ['create-dialog', 'edit-room-dialog', 'ring-create-dialog', 'feed-follow-dialog',
+      'feed-compose-dialog', 'quote-repost-dialog', 'chat-history-overlay', 'room-files-overlay'
+    ].forEach(function (id) {
+      var el = $(id);
+      if (!el) return;
+      if (el.style.display === 'none' || el.hidden) {
+        // Still seal PE in case of partial state
+        try { el.style.pointerEvents = 'none'; } catch (eSeal) { /* ignore */ }
+        return;
+      }
+      // History/files: prefer their close helpers so state stays consistent
+      if (id === 'chat-history-overlay' && typeof closeChatHistory === 'function') {
+        closeChatHistory();
+        return;
+      }
+      if (id === 'room-files-overlay' && typeof closeRoomFiles === 'function') {
+        closeRoomFiles();
+        return;
+      }
+      if (id === 'create-dialog' && typeof hideCreateDialog === 'function') {
+        hideCreateDialog();
+        return;
+      }
+      if (id === 'edit-room-dialog' && typeof hideEditRoomDialog === 'function') {
+        hideEditRoomDialog();
+        return;
+      }
+      forceHideInteractive(el);
+    });
+  } catch (e5) { /* ignore */ }
+  // Dynamically created portals (do NOT kill .confirm-overlay — mid-confirm would hang).
+  try {
+    document.querySelectorAll('.forward-overlay, .picker-overlay, .img-viewer').forEach(function (el) {
+      forceHideInteractive(el);
+      try { el.remove(); } catch (eR) { /* ignore */ }
+    });
+  } catch (e6) { /* ignore */ }
+  // Mobile member sheet must not stick over the conv list after switch
+  try {
+    var panel = $('member-panel');
+    if (panel) {
+      panel.classList.remove('member-open-mobile');
+      if (!opts.keepChat) {
+        panel.classList.remove('member-expanded-tablet');
+      }
+    }
+  } catch (e7) { /* ignore */ }
 }
 
 function timeStr(iso) { try { return new Date(iso).toLocaleTimeString(currentLocale, { hour: '2-digit', minute: '2-digit' }); } catch (e) { return ''; } }
@@ -868,6 +958,7 @@ function initAroSelect(rootOrId, opts) {
   }
 
   function onDocPointer(e) {
+    // Never capture/swallow when closed — leftover open=true must not block messenger.
     if (!open) return;
     if (root.contains(e.target)) return;
     closeMenu();
@@ -947,7 +1038,8 @@ function initAroSelect(rootOrId, opts) {
     trigger.focus();
   });
   root.addEventListener('keydown', onKeyDown);
-  document.addEventListener('click', onDocPointer, true);
+  // Bubble phase only — capture:true previously risked ordering races with list/tab clicks.
+  document.addEventListener('click', onDocPointer, false);
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape' && open) {
       closeMenu();

--- a/apps/com.myriad.aro/page/helpers.js
+++ b/apps/com.myriad.aro/page/helpers.js
@@ -1839,14 +1839,6 @@ function applyLabels() {
   el = $('conv-tab-recent'); if (el) el.textContent = lang.convTabRecent || 'Recent';
   el = $('conv-tab-dm'); if (el) el.textContent = lang.convTabDm || lang.dm || 'DMs';
   el = $('conv-tab-room'); if (el) el.textContent = lang.convTabRoom || lang.rooms || 'Groups';
-  // Closed chip only — never inject into #conv-tabs or empty-state nodes
-  el = $('conv-closed-toggle');
-  if (el && el.classList && el.classList.contains('conv-closed-chip')) {
-    var closedLabel = lang.convTabClosed || lang.closed || 'Closed';
-    el.textContent = closedLabel;
-    el.setAttribute('title', closedLabel);
-    el.setAttribute('aria-label', closedLabel);
-  }
   el = $('feed-empty-title');
   if (el && typeof getFeedEmptyTitle === 'function') {
     el.style.display = 'block';

--- a/apps/com.myriad.aro/page/history.js
+++ b/apps/com.myriad.aro/page/history.js
@@ -229,6 +229,7 @@ function openChatHistory() {
   if (!overlay) return;
   overlay.hidden = false;
   overlay.style.display = 'flex';
+  overlay.style.pointerEvents = 'auto';
   overlay.classList.remove('aro-leaving', 'aro-history-enter');
   // Restart enter animation
   try { void overlay.offsetWidth; } catch (eAnim) { /* ignore */ }
@@ -261,22 +262,36 @@ function openChatHistory() {
   }
 }
 
+function sealHistoryOverlay(overlay) {
+  if (!overlay) return;
+  overlay.classList.remove('aro-history-enter', 'aro-leaving');
+  overlay.style.display = 'none';
+  overlay.hidden = true;
+  overlay.style.pointerEvents = 'none';
+}
+
 function closeChatHistory() {
   ensureHistoryState();
   state.history.open = false;
   var overlay = $('chat-history-overlay');
-  if (!overlay || overlay.style.display === 'none') return;
+  if (!overlay) return;
+  // Always seal pointer-events so a stuck flex overlay cannot block the list
+  if (overlay.style.display === 'none' || overlay.hidden) {
+    sealHistoryOverlay(overlay);
+    return;
+  }
   overlay.classList.remove('aro-history-enter');
+  // Block hits immediately while exit animation runs
+  overlay.style.pointerEvents = 'none';
   if (typeof aroDismiss === 'function') {
     aroDismiss(overlay, {
       ms: 160,
       onDone: function () {
-        overlay.hidden = true;
+        sealHistoryOverlay(overlay);
       },
     });
   } else {
-    overlay.style.display = 'none';
-    overlay.hidden = true;
+    sealHistoryOverlay(overlay);
   }
 }
 

--- a/apps/com.myriad.aro/page/members.js
+++ b/apps/com.myriad.aro/page/members.js
@@ -5,10 +5,24 @@ function renderMembers() {
   if (!panel) return;
 
   if (state.activeKind !== 'room' || !state.roomDetail) {
+    // Always clear mobile full-screen sheet — stuck member-open-mobile blocks the list.
+    panel.classList.remove('member-open-mobile', 'member-expanded-tablet');
     panel.style.display = 'none';
+    panel.style.pointerEvents = '';
     return;
   }
-  panel.style.display = '';
+  // Desktop: show side panel. Mobile: keep hidden until user opens (member-open-mobile).
+  var isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+  if (isMobile) {
+    // Do not force-show; only ensure pointer-events when intentionally open.
+    if (!panel.classList.contains('member-open-mobile')) {
+      panel.style.display = '';
+      // media query keeps it display:none until .member-open-mobile
+    }
+  } else {
+    panel.style.display = '';
+    panel.style.pointerEvents = '';
+  }
   $('member-title').textContent = lang.members + ' (' + state.members.length + ')';
 
   var myRole = state.roomDetail.my_role || '';
@@ -292,6 +306,11 @@ function closeMemberPanel() {
   panel.classList.remove('member-expanded-tablet');
   if (window.innerWidth > 768 && !isTablet()) {
     panel.classList.add('member-collapsed');
+  }
+  // Mobile full-screen sheet: force hide so it cannot block sidebar/list
+  if (window.innerWidth <= 768) {
+    panel.style.display = '';
+    panel.style.pointerEvents = '';
   }
   state.memberPanelOpen = false;
 }

--- a/apps/com.myriad.aro/page/state.js
+++ b/apps/com.myriad.aro/page/state.js
@@ -29,10 +29,8 @@ var state = {
   isAdmin: false,
   // Attachment
   pendingAttach: null, // { type, file?, data?, name, size, mime, ... }
-  /** Messenger sidebar type tab: recent | dm | room */
+  /** Messenger sidebar type tab: recent | dm | room (closed chats never listed). */
   convTab: 'recent',
-  /** When true, list shows only closed conversations (overrides type tab filter). */
-  showClosed: false,
   /**
    * Monotonic generation for openConversation / poll / realtime apply.
    * Bumped on every open or leave so stale awaits cannot flashback UI.

--- a/apps/com.myriad.aro/page/state.js
+++ b/apps/com.myriad.aro/page/state.js
@@ -36,6 +36,8 @@ var state = {
    * Bumped on every open or leave so stale awaits cannot flashback UI.
    */
   openGen: 0,
+  /** Monotonic generation for loadConversations (stale list writes discarded). */
+  convLoadGen: 0,
   // Aro views
   currentView: 'feed',
   // Feed (merged timeline + profile)

--- a/apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
+++ b/apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+/**
+ * Structural audit of SHIPPED Aro messenger page modules.
+ * Greps/parses real files under apps/com.myriad.aro — does not reimplement messenger UI.
+ *
+ * Exit 0 only if every acceptance check passes.
+ * Run: node apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ARO_ROOT = path.resolve(__dirname, '..');
+
+const failures = [];
+const passes = [];
+
+function pass(name, detail) {
+  passes.push(detail ? `${name}: ${detail}` : name);
+}
+
+function fail(name, detail) {
+  failures.push(detail ? `${name}: ${detail}` : name);
+}
+
+function read(rel) {
+  const abs = path.join(ARO_ROOT, rel);
+  if (!fs.existsSync(abs)) {
+    fail('missing-file', rel);
+    return '';
+  }
+  return fs.readFileSync(abs, 'utf8');
+}
+
+function walkFiles(dir, exts, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory()) {
+      // Skip scripts themselves and node_modules if any
+      if (ent.name === 'node_modules' || ent.name === 'scripts') continue;
+      walkFiles(p, exts, out);
+    } else if (exts.some((e) => ent.name.endsWith(e))) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// 1) Zero banned closed-UI symbols in js/html/css
+// ---------------------------------------------------------------------------
+function checkClosedUiBan() {
+  const banned =
+    /showClosed|setShowClosed|toggleShowClosed|conv-closed-toggle|conv-closed-chip|conv-tabs-dimmed|conv-tabs-closed/;
+  const files = walkFiles(ARO_ROOT, ['.js', '.html', '.css']);
+  const hits = [];
+  for (const f of files) {
+    const text = fs.readFileSync(f, 'utf8');
+    const lines = text.split(/\r?\n/);
+    lines.forEach((line, i) => {
+      if (banned.test(line)) {
+        hits.push(`${path.relative(ARO_ROOT, f)}:${i + 1}: ${line.trim().slice(0, 120)}`);
+      }
+    });
+  }
+  if (hits.length === 0) {
+    pass('1-closed-ui-ban', '0 matches in js/html/css');
+  } else {
+    fail('1-closed-ui-ban', `${hits.length} hit(s)\n  ` + hits.slice(0, 20).join('\n  '));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2) openConversation: first real await after shell paint; is unsubscribeRealtime
+// ---------------------------------------------------------------------------
+/** Strip // line comments and /* block comments *\/ (naive, good enough for structural scan). */
+function stripComments(src) {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    if (src[i] === '/' && src[i + 1] === '/') {
+      i += 2;
+      while (i < src.length && src[i] !== '\n') i++;
+      continue;
+    }
+    if (src[i] === '/' && src[i + 1] === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i = Math.min(src.length, i + 2);
+      continue;
+    }
+    // Keep string literals intact so // inside strings is not stripped wrong
+    if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
+      const q = src[i];
+      out += src[i++];
+      while (i < src.length) {
+        if (src[i] === '\\') {
+          out += src[i++];
+          if (i < src.length) out += src[i++];
+          continue;
+        }
+        out += src[i];
+        if (src[i] === q) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    out += src[i++];
+  }
+  return out;
+}
+
+function extractFunctionBody(src, fnSigRe) {
+  const m = fnSigRe.exec(src);
+  if (!m) return null;
+  const start = m.index + m[0].length;
+  // Find opening brace after signature
+  let i = start;
+  while (i < src.length && src[i] !== '{') i++;
+  if (i >= src.length) return null;
+  let depth = 0;
+  const bodyStart = i;
+  for (; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const q = ch;
+      i++;
+      while (i < src.length) {
+        if (src[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (src[i] === q) break;
+        i++;
+      }
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return src.slice(bodyStart + 1, i);
+      }
+    }
+  }
+  return null;
+}
+
+function checkOpenConversationOrder() {
+  const api = read('page/api.js');
+  if (!api) return;
+  const body = extractFunctionBody(api, /async\s+function\s+openConversation\s*\([^)]*\)\s*/);
+  if (!body) {
+    fail('2-openConversation-order', 'could not find async function openConversation in page/api.js');
+    return;
+  }
+  const clean = stripComments(body);
+  // First real await in the function body
+  const awaitRe = /\bawait\s+([A-Za-z0-9_$.]+)\s*\(/g;
+  const first = awaitRe.exec(clean);
+  if (!first) {
+    fail('2-openConversation-order', 'no await found in openConversation');
+    return;
+  }
+  const awaitExpr = first[1];
+  const awaitIndex = first.index;
+  const before = clean.slice(0, awaitIndex);
+
+  const hasActiveKind = /state\.activeKind\s*=/.test(before);
+  const hasActiveId = /state\.activeId\s*=/.test(before);
+  const hasEmptyPaint =
+    /empty-state/.test(before) ||
+    /emptyEl\.style\.display/.test(before) ||
+    /\$\(\s*['"]empty-state['"]\s*\)/.test(before);
+  const hasChatPaint =
+    /chat-container/.test(before) ||
+    /chatEl\.style\.display/.test(before) ||
+    /\$\(\s*['"]chat-container['"]\s*\)/.test(before);
+  const hasRenderConvList = /\brenderConvList\s*\(/.test(before);
+  const isUnsub = /unsubscribeRealtime/.test(awaitExpr);
+
+  const ok =
+    hasActiveKind &&
+    hasActiveId &&
+    hasEmptyPaint &&
+    hasChatPaint &&
+    hasRenderConvList &&
+    isUnsub;
+
+  if (ok) {
+    pass(
+      '2-openConversation-order',
+      `first await is ${awaitExpr}() after activeKind/id + empty/chat shell + renderConvList`,
+    );
+  } else {
+    fail(
+      '2-openConversation-order',
+      [
+        `first await: ${awaitExpr} (need unsubscribeRealtime: ${isUnsub})`,
+        `activeKind before: ${hasActiveKind}`,
+        `activeId before: ${hasActiveId}`,
+        `empty shell before: ${hasEmptyPaint}`,
+        `chat shell before: ${hasChatPaint}`,
+        `renderConvList before: ${hasRenderConvList}`,
+      ].join('; '),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3) bindConvListClicks with closest(.conv-item) delegation
+// ---------------------------------------------------------------------------
+function checkConvListDelegation() {
+  const chat = read('page/chat.js');
+  if (!chat) return;
+  const body = extractFunctionBody(chat, /function\s+bindConvListClicks\s*\([^)]*\)\s*/);
+  if (!body) {
+    fail('3-bindConvListClicks', 'function bindConvListClicks not found in page/chat.js');
+    return;
+  }
+  const hasClosest =
+    /\.closest\s*\(\s*['"]\.conv-item['"]\s*\)/.test(body) ||
+    /\.closest\s*\(\s*['"]\.conv-item['"]\s*\)/.test(stripComments(body));
+  const hasListen = /\.addEventListener\s*\(\s*['"]click['"]/.test(body);
+  if (hasClosest && hasListen) {
+    pass('3-bindConvListClicks', 'closest(.conv-item) click delegation present');
+  } else {
+    fail(
+      '3-bindConvListClicks',
+      `closest(.conv-item)=${hasClosest}, addEventListener(click)=${hasListen}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4) create-overlay in page.css AND styles.css: display:none + PE none
+// ---------------------------------------------------------------------------
+function extractCreateOverlayRules(cssText) {
+  const rules = [];
+  const re = /\.create-overlay\s*\{([^}]*)\}/g;
+  let m;
+  while ((m = re.exec(cssText)) !== null) {
+    rules.push(m[1].replace(/\s+/g, ' ').trim());
+  }
+  return rules;
+}
+
+function checkCreateOverlayCss() {
+  for (const rel of ['page.css', 'styles.css']) {
+    const css = read(rel);
+    if (!css) continue;
+    const rules = extractCreateOverlayRules(css);
+    // Prefer the layout rule (position:fixed / inset) over dark/animation-only shorthands
+    const base =
+      rules.find((r) => /position\s*:\s*fixed/.test(r) || /inset\s*:\s*0/.test(r)) || rules[0];
+    if (!base) {
+      fail(`4-create-overlay-${rel}`, 'no .create-overlay { } rule found');
+      continue;
+    }
+    const hasDisplayNone = /display\s*:\s*none/.test(base);
+    const hasPeNone = /pointer-events\s*:\s*none/.test(base);
+    if (hasDisplayNone && hasPeNone) {
+      pass(`4-create-overlay-${rel}`, 'display:none + pointer-events:none');
+    } else {
+      fail(
+        `4-create-overlay-${rel}`,
+        `display:none=${hasDisplayNone}, pointer-events:none=${hasPeNone}; rule="${base.slice(0, 160)}"`,
+      );
+    }
+  }
+  // Sync check (not required by checklist but catches drift)
+  const a = read('page.css');
+  const b = read('styles.css');
+  if (a && b && a === b) {
+    pass('4-css-sync', 'page.css === styles.css');
+  } else if (a && b) {
+    fail('4-css-sync', 'page.css !== styles.css (must stay in sync)');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5) helpers.js: dismiss helpers, aroDismiss PE early, onDocPointer bubble
+// ---------------------------------------------------------------------------
+function checkHelpers() {
+  const h = read('page/helpers.js');
+  if (!h) return;
+
+  if (/function\s+dismissTransientUi\s*\(/.test(h)) {
+    pass('5-dismissTransientUi', 'function present');
+  } else {
+    fail('5-dismissTransientUi', 'function dismissTransientUi missing');
+  }
+
+  if (/function\s+forceHideInteractive\s*\(/.test(h)) {
+    pass('5-forceHideInteractive', 'function present');
+  } else {
+    fail('5-forceHideInteractive', 'function forceHideInteractive missing');
+  }
+
+  const dismissBody = extractFunctionBody(h, /function\s+aroDismiss\s*\([^)]*\)\s*/);
+  if (!dismissBody) {
+    fail('5-aroDismiss-pe', 'function aroDismiss not found');
+  } else {
+    const clean = stripComments(dismissBody);
+    // PE none must appear before animation end / finish path dependency — "early"
+    // Require pointerEvents = 'none' (or pointer-events) near the top of the body
+    // before addEventListener('animationend' or classList.add('aro-leaving')
+    const peMatch = /(?:style\.)?pointerEvents\s*=\s*['"]none['"]|pointer-events\s*:\s*none/.exec(
+      clean,
+    );
+    if (!peMatch) {
+      fail('5-aroDismiss-pe', "no pointerEvents = 'none' in aroDismiss");
+    } else {
+      const peIdx = peMatch.index;
+      const leavingIdx = clean.search(/aro-leaving|animationend|setTimeout\s*\(\s*finish/);
+      if (leavingIdx === -1 || peIdx < leavingIdx) {
+        pass('5-aroDismiss-pe', 'pointerEvents none set early (before leave animation path)');
+      } else {
+        fail('5-aroDismiss-pe', 'pointerEvents none appears after leave animation wiring');
+      }
+    }
+  }
+
+  // onDocPointer registered with capture false, not true
+  const bubble =
+    /addEventListener\s*\(\s*['"]click['"]\s*,\s*onDocPointer\s*,\s*false\s*\)/.test(h);
+  const capture =
+    /addEventListener\s*\(\s*['"]click['"]\s*,\s*onDocPointer\s*,\s*true\s*\)/.test(h);
+  if (bubble && !capture) {
+    pass('5-onDocPointer-bubble', 'registered with capture false (not true)');
+  } else {
+    fail(
+      '5-onDocPointer-bubble',
+      `bubble(false)=${bubble}, capture(true)=${capture} — need false only`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6) state has openGen + convLoadGen; api uses them
+// ---------------------------------------------------------------------------
+function checkGens() {
+  const state = read('page/state.js');
+  const api = read('page/api.js');
+  if (!state || !api) return;
+
+  const hasOpenGenState = /\bopenGen\s*:/.test(state);
+  const hasConvLoadGenState = /\bconvLoadGen\s*:/.test(state);
+  if (hasOpenGenState && hasConvLoadGenState) {
+    pass('6-state-gens', 'openGen + convLoadGen in state.js');
+  } else {
+    fail(
+      '6-state-gens',
+      `openGen=${hasOpenGenState}, convLoadGen=${hasConvLoadGenState} in state.js`,
+    );
+  }
+
+  const usesOpenGen =
+    /state\.openGen/.test(api) &&
+    (/isOpenGenCurrent/.test(api) || /isConversationCurrent/.test(api));
+  const usesConvLoadGen = /state\.convLoadGen/.test(api);
+  if (usesOpenGen && usesConvLoadGen) {
+    pass('6-api-gens', 'page/api.js uses openGen (guards) + convLoadGen');
+  } else {
+    fail(
+      '6-api-gens',
+      `openGen usage=${usesOpenGen}, convLoadGen usage=${usesConvLoadGen} in page/api.js`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+console.log(`Aro messenger interaction audit\nroot: ${ARO_ROOT}\n`);
+
+checkClosedUiBan();
+checkOpenConversationOrder();
+checkConvListDelegation();
+checkCreateOverlayCss();
+checkHelpers();
+checkGens();
+
+console.log('--- PASS ---');
+for (const p of passes) console.log(`  ✓ ${p}`);
+if (failures.length) {
+  console.log('--- FAIL ---');
+  for (const f of failures) console.log(`  ✗ ${f}`);
+  console.log(`\n${failures.length} check(s) failed, ${passes.length} passed.`);
+  process.exit(1);
+}
+console.log(`\nAll ${passes.length} checks passed (10-round structural audit green).`);
+process.exit(0);

--- a/apps/com.myriad.aro/styles.css
+++ b/apps/com.myriad.aro/styles.css
@@ -361,7 +361,7 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden}
 .sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px}
 .sidebar-title{margin:0;font-size:16px;font-weight:700;color:var(--text-primary,#1a1a1a);letter-spacing:-.02em}
-/* Messenger list: type tabs (最近|私信|群聊) + closed chip same row */
+/* Messenger list type tabs: 最近 | 私信 | 群聊 (no closed chip) */
 .conv-tabs-bar{
   display:flex;flex-wrap:nowrap;align-items:stretch;gap:6px;flex-shrink:0;
   padding:6px 8px 0 6px;border-bottom:1px solid rgba(128,128,128,.06);
@@ -392,52 +392,10 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   font-weight:750;
   border-bottom-color:var(--tapp-primary,#6366f1)!important;
 }
-/* Type tabs stay selected under closed mode but are dimmed (list is closed-only) */
-.conv-tabs-dimmed .conv-tab{opacity:.45}
-.conv-tabs-dimmed .conv-tab-active{opacity:.7}
-/* Keep closed chip on the same row as type tabs (never wraps under) */
-.conv-closed-chip{
-  flex:0 0 auto;flex-shrink:0;align-self:center;
-  margin:0 0 6px 0;padding:5px 10px;
-  border:1px solid rgba(128,128,128,.18);
-  border-radius:999px;background:transparent;cursor:pointer;
-  font-size:11px;font-weight:600;font-family:inherit;
-  color:var(--text-secondary,#8b98a5);
-  white-space:nowrap;line-height:1.2;
-  transition:color .12s,background .12s,border-color .12s,box-shadow .12s;
-  -webkit-tap-highlight-color:transparent;
-  position:relative;z-index:1;
-  max-width:40%;overflow:hidden;text-overflow:ellipsis;
-}
-.conv-closed-chip:hover{
-  color:var(--text-primary,#1a1a1a);
-  background:rgba(128,128,128,.06);
-  border-color:rgba(128,128,128,.28);
-}
-.conv-closed-chip-active{
-  color:var(--tapp-primary,#6366f1)!important;
-  border-color:rgba(var(--tapp-primary-rgb,99,102,241),.45)!important;
-  background:rgba(var(--tapp-primary-rgb,99,102,241),.1)!important;
-  box-shadow:0 0 0 1px rgba(var(--tapp-primary-rgb,99,102,241),.12);
-}
 .dark .conv-tabs-bar{background:rgba(0,0,0,.18);border-color:rgba(255,255,255,.06)}
 .dark .conv-tab{color:rgba(255,255,255,.5)}
 .dark .conv-tab:hover{color:rgba(255,255,255,.9);background:rgba(255,255,255,.04)}
 .dark .conv-tab-active{color:rgba(255,255,255,.95)!important}
-.dark .conv-closed-chip{
-  color:rgba(255,255,255,.5);
-  border-color:rgba(255,255,255,.14);
-}
-.dark .conv-closed-chip:hover{
-  color:rgba(255,255,255,.9);
-  background:rgba(255,255,255,.06);
-  border-color:rgba(255,255,255,.22);
-}
-.dark .conv-closed-chip-active{
-  color:rgba(165,180,252)!important;
-  border-color:rgba(var(--tapp-primary-rgb,99,102,241),.5)!important;
-  background:rgba(var(--tapp-primary-rgb,99,102,241),.16)!important;
-}
 .create-btn{width:36px;height:36px;min-width:36px;min-height:36px;border-radius:10px;border:none;background:var(--tapp-primary,#6366f1);color:#fff;font-size:22px;font-weight:400;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:opacity .15s,transform .12s;flex-shrink:0;line-height:1}
 .create-btn:hover{opacity:.9}
 .create-btn:active{transform:scale(.96)}
@@ -459,13 +417,15 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .forward-search{padding:8px 12px 4px;flex-shrink:0}
 .forward-search .aro-search-input{width:100%;flex:none}
 
-/* ===== Chat history panel ===== */
+/* ===== Chat history / room-files panel (scoped under #chat-main; never covers sidebar) ===== */
 .history-overlay{
   position:absolute;inset:0;z-index:40;display:none;align-items:stretch;justify-content:flex-end;
   background:rgba(15,23,42,.22);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+  /* Closed default: never intercept clicks (JS also sets display:none + hidden) */
+  pointer-events:none;
 }
 .history-overlay.aro-history-enter{animation:aroFadeIn var(--aro-dur) ease both}
-.history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none}
+.history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none!important}
 /* history open uses class on overlay (not aroPlayEnter generic) */
 .history-sheet{
   width:min(400px,100%);max-width:100%;height:100%;

--- a/apps/com.myriad.aro/styles.css
+++ b/apps/com.myriad.aro/styles.css
@@ -7,8 +7,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 #tapp-content{display:flex!important;flex-direction:column!important;overflow:hidden!important}
 
 /* ===== Aro Nav ===== */
-.aro-nav{display:flex;align-items:center;gap:4px;padding:8px 12px;border-bottom:1px solid rgba(128,128,128,.08);flex-shrink:0;background:rgba(255,255,255,.78);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px)}
-.aro-nav-item{min-height:36px;display:flex;align-items:center;gap:8px;padding:0 14px;border:none;background:none;border-radius:11px;font-size:13px;font-weight:600;color:var(--text-secondary,#888);cursor:pointer;transition:background .14s,color .14s;white-space:nowrap}
+.aro-nav{display:flex;align-items:center;gap:4px;padding:8px 12px;border-bottom:1px solid rgba(128,128,128,.08);flex-shrink:0;background:rgba(255,255,255,.78);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px);position:relative;z-index:30;pointer-events:auto}
+.aro-nav-item{min-height:36px;display:flex;align-items:center;gap:8px;padding:0 14px;border:none;background:none;border-radius:11px;font-size:13px;font-weight:600;color:var(--text-secondary,#888);cursor:pointer;transition:background .14s,color .14s;white-space:nowrap;touch-action:manipulation;pointer-events:auto;-webkit-tap-highlight-color:transparent}
 .aro-nav-item:hover{background:rgba(128,128,128,.07);color:var(--text-primary,#222)}
 .aro-nav-item:focus-visible{outline:2px solid rgba(var(--tapp-primary-rgb,99,102,241),.45);outline-offset:1px}
 .aro-nav-active{background:rgba(var(--tapp-primary-rgb,100,100,255),.12)!important;color:var(--tapp-primary,#6366f1)!important}
@@ -20,8 +20,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .nav-feed-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:96px}
 
 /* ===== Aro Views ===== */
-.aro-view{display:none;flex:1;min-height:0;min-width:0;width:100%;overflow:hidden}
-.aro-view-active{display:flex;flex-direction:column;width:100%;max-width:none}
+.aro-view{display:none;flex:1;min-height:0;min-width:0;width:100%;overflow:hidden;pointer-events:none}
+.aro-view-active{display:flex;flex-direction:column;width:100%;max-width:none;pointer-events:auto}
 
 /* ===== Panel Layout (sidebar+content, for rings) ===== */
 .aro-panel-layout{display:flex;flex:1;min-height:0;overflow:hidden}
@@ -358,8 +358,9 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 
 /* ===== Layout ===== */
 .messenger-app{display:flex;flex:1;min-height:0;overflow:hidden;position:relative}
-.sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden}
-.sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px}
+.sidebar{display:flex;flex-direction:column;width:280px;border-right:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden;position:relative;z-index:2;pointer-events:auto}
+.sidebar-header{padding:14px 14px 12px;border-bottom:1px solid rgba(128,128,128,.06);flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:10px;min-height:52px;position:relative;z-index:3;pointer-events:auto}
+.sidebar-header .create-btn{position:relative;z-index:4;pointer-events:auto;touch-action:manipulation}
 .sidebar-title{margin:0;font-size:16px;font-weight:700;color:var(--text-primary,#1a1a1a);letter-spacing:-.02em}
 /* Messenger list type tabs: 最近 | 私信 | 群聊 (no closed chip) */
 .conv-tabs-bar{
@@ -424,8 +425,11 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   /* Closed default: never intercept clicks (JS also sets display:none + hidden) */
   pointer-events:none;
 }
+.history-overlay[style*="display: flex"],
+.history-overlay[style*="display:flex"]{pointer-events:auto}
 .history-overlay.aro-history-enter{animation:aroFadeIn var(--aro-dur) ease both}
 .history-overlay.aro-leaving{animation:aroFadeOut 150ms ease both;pointer-events:none!important}
+.history-overlay[hidden]{display:none!important;pointer-events:none!important}
 /* history open uses class on overlay (not aroPlayEnter generic) */
 .history-sheet{
   width:min(400px,100%);max-width:100%;height:100%;
@@ -1000,7 +1004,7 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 
 .conv-list{flex:1;min-height:0;overflow-y:auto;padding:6px 8px;display:flex;flex-direction:column;gap:2px;position:relative;z-index:1;pointer-events:auto;-webkit-overflow-scrolling:touch}
 .conv-list .conv-item{pointer-events:auto;touch-action:manipulation}
-.chat-main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;overflow:hidden}
+.chat-main{flex:1;min-width:0;display:flex;flex-direction:column;position:relative;overflow:hidden;isolation:isolate}
 .member-panel{display:flex;flex-direction:column;width:220px;border-left:1px solid rgba(128,128,128,.08);flex-shrink:0;overflow:hidden;transition:width .2s}
 .member-panel.member-collapsed{width:0;border-left:none;overflow:hidden}
 .member-back-btn{display:none;background:none;border:none;font-size:16px;color:var(--text-primary,#1a1a1a);cursor:pointer;padding:2px 4px;margin-right:6px;border-radius:6px;flex-shrink:0}
@@ -1212,6 +1216,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .dark .msg-more-btn:hover,.dark .msg-more-btn:focus-visible{background:rgba(255,255,255,.1)}
 
 /* ===== Input ===== */
+/* pointer-events:none on the wrap so the gradient does not steal message-area
+   scrolls/clicks; only children (composer) are interactive. Never stretch over sidebar. */
 .input-float-wrap{position:absolute;bottom:0;left:0;right:0;z-index:20;padding:8px 12px;padding-bottom:calc(8px + env(safe-area-inset-bottom,0px));background:linear-gradient(to top,var(--bg-primary,#fff) 70%,transparent);pointer-events:none}
 .input-float-wrap>*{pointer-events:auto}
 .input-bar{display:flex;align-items:flex-end;gap:8px;padding:8px 10px;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.12);border-radius:18px;box-shadow:0 2px 12px rgba(0,0,0,.06)}
@@ -1839,12 +1845,12 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
   .aro-nav-item{flex-direction:column;gap:3px;padding:8px 12px;font-size:11px}
   .aro-nav-item svg{width:22px;height:22px}
   .nav-feed-avatar{width:24px;height:24px;font-size:11px}
-  .sidebar{width:100%}
-  .sidebar-hidden-mobile{display:none!important}
+  .sidebar{width:100%;z-index:2;pointer-events:auto}
+  .sidebar-hidden-mobile{display:none!important;pointer-events:none!important}
   .back-btn{display:block}
-  .member-panel{display:none;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none}
+  .member-panel{display:none!important;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none;pointer-events:none}
   .dark .member-panel{background:var(--bg-primary,#1a1a1a)}
-  .member-panel.member-open-mobile{display:flex!important}
+  .member-panel.member-open-mobile{display:flex!important;pointer-events:auto}
   .member-back-btn{display:flex}
   .aro-panel-layout .sidebar{width:100%}
   .aro-panel-layout .sidebar-hidden-mobile{display:none!important}
@@ -1872,7 +1878,12 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 }
 
 /* ===== Create Dialog ===== */
-.create-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:100}
+/* Default display:none — previous display:flex default left a full-screen click shield
+   whenever inline style was cleared or dismiss raced. */
+.create-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:100;pointer-events:none}
+.create-overlay[style*="display: flex"],
+.create-overlay[style*="display:flex"]{pointer-events:auto}
+.create-overlay[hidden]{display:none!important;pointer-events:none!important}
 .create-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(360px,90vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.15)}
 .create-dialog-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
 .create-dialog-title{margin:0;font-size:16px;font-weight:600;color:var(--text-primary,#1a1a1a)}
@@ -1986,7 +1997,8 @@ button.aro-select-trigger.create-input{
 
 
 /* ===== In-app Confirm Dialog (native confirm() is blocked in the sandboxed iframe) ===== */
-.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease}
+.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease;pointer-events:auto}
+.confirm-overlay.aro-leaving,.confirm-overlay[hidden]{pointer-events:none!important}
 .confirm-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(320px,88vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.18)}
 .confirm-message{font-size:14px;line-height:1.6;color:var(--text-primary,#1a1a1a);margin-bottom:18px;overflow-wrap:break-word}
 .confirm-actions{display:flex;gap:8px;justify-content:flex-end}

--- a/index.json
+++ b/index.json
@@ -4,7 +4,7 @@
   "version": "1.8.8",
   "api_version": "2",
   "base_url": "https://raw.githubusercontent.com/Myriad-You/tapp-store/main",
-  "updated_at": "2026-07-20T12:35:43Z",
+  "updated_at": "2026-07-21T12:36:36Z",
   "maintainer": {
     "name": "Myriad Team",
     "email": "tapp@myriad.app",
@@ -245,7 +245,7 @@
     {
       "id": "com.myriad.aro",
       "name": "Aro",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "社交中心，统一管理消息、时间线、环网与个人资料",
       "long_description": "社交中心：统一管理联邦消息（Channel/Room）、时间线、环网与个人资料。支持后台新消息通知、附件与多语言（中/英/日）。",
       "locales": {


### PR DESCRIPTION
## Summary

**Supersedes #27.** Full messenger interaction cleanup on `main` after #26.

Aro **1.0.3** — HEAD includes structural audit script (exit 0 = green).

### Commits (series)
1. Delete 已关闭; openConversation UI-first; overlays in `#chat-main`
2. Absorb #27 guards: dismissTransientUi, create-overlay `display:none`, aroDismiss PE, aro-select bubble, convLoadGen, switchView, member-open-mobile
3. **In-repo structural audit** `scripts/messenger-interaction-audit.mjs` (10-round green)

---

## Structural audit (must stay green)

```bash
node apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
# All 12 checks passed (10-round structural audit green).  → exit 0
```

Script greps/parses **shipped** files under `apps/com.myriad.aro` (not a reimplementation):

1. Zero `showClosed|setShowClosed|toggleShowClosed|conv-closed-toggle|conv-closed-chip|conv-tabs-dimmed|conv-tabs-closed` in js/html/css
2. `openConversation` first real `await` is after shell paint (`activeKind`/`activeId`, empty/chat, `renderConvList`) and is `unsubscribeRealtime`
3. `bindConvListClicks` + `closest('.conv-item')` in `page/chat.js`
4. `page.css` **and** `styles.css` `.create-overlay` includes `display:none` + `pointer-events:none`
5. `dismissTransientUi` + `forceHideInteractive`; `aroDismiss` PE none early; `onDocPointer` capture **false**
6. `openGen` + `convLoadGen` in state; used in `page/api.js`

---

## 根因表

| 现象 | 根因 | 修复 |
|------|------|------|
| 「已关闭」仍在 | #26/#27 保留 chip/mode | **删除** DOM/state/CSS；tabs 仅 最近\|私信\|群聊 |
| 列表点了没反应 | `openConversation` 先 await | **同步** active/chat/empty/highlight → 再 await |
| A→B 闪回 | 无 gen / list reload 竞态 | `openGen` + `convLoadGen` |
| 关 dialog 全屏挡点击 | `.create-overlay` 默认 flex | 默认 `display:none; pointer-events:none` |
| history 挡侧栏 | overlay 盖 messenger-app | 挪进 `#chat-main` + 关闭 PE none |
| select 吞点击 | document capture | bubble only |
| dismiss 中仍挡点击 | PE 等到动画结束 | `aroDismiss` 立刻 PE none + dismissTransientUi |
| 切 view 卡死 | inactive view 仍 PE | `.aro-view { PE:none }` + switchView dismiss |

**Do not restore 已关闭.**

## 建议
Close **#27** as superseded by **#28**.

## Test plan
- [ ] `node apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs` exit 0
- [ ] UI 无「已关闭」；三 tab + 列表立刻进聊天
- [ ] 快速 A→B→C 无闪回；关 create/history 后侧栏可点
- [ ] 消息↔动态↔环网 无卡死