### PR TITLE
fix(aro): restore create-overlay opens after dismiss (1.0.4)

### DIFF
--- a/apps/com.myriad.aro/README.md
+++ b/apps/com.myriad.aro/README.md
@@ -2,7 +2,7 @@
 
 社交中心：消息（Channel/Room）、时间线、环网与个人资料。
 
-> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.3）。
+> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.4）。
 
 ## 功能
 
@@ -23,5 +23,5 @@ index.js          # core（与 aro.ts buildCoreCode() 一致）
 page.html / page.css / styles.css
 page/*.js         # pageModules 与 aro.ts PAGE_MODULES 一致
 i18n/{zh,en,ja}.json
-manifest.json     # version 1.0.3
+manifest.json     # version 1.0.4
 ```

--- a/apps/com.myriad.aro/manifest.json
+++ b/apps/com.myriad.aro/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.aro",
   "name": "Aro",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "minSystemVersion": "0.2.1",
   "description": "社交中心，统一管理消息、时间线、环网与个人资料",
   "locales": {

--- a/apps/com.myriad.aro/page/api.js
+++ b/apps/com.myriad.aro/page/api.js
@@ -1375,10 +1375,7 @@ function showEditRoomDialog() {
       idVal.textContent = '';
     }
   }
-  overlay.classList.remove('aro-leaving');
-  overlay.hidden = false;
-  overlay.style.pointerEvents = 'auto';
-  overlay.style.display = 'flex';
+  showAroOverlay(overlay);
 }
 
 function hideEditRoomDialog() {
@@ -1675,10 +1672,7 @@ async function doLeaveRoom() {
 function showCreateDialog() {
   var overlay = $('create-dialog');
   if (overlay) {
-    overlay.classList.remove('aro-leaving');
-    overlay.hidden = false;
-    overlay.style.pointerEvents = 'auto';
-    overlay.style.display = 'flex';
+    showAroOverlay(overlay);
   }
   switchCreateTab('channel');
 }

--- a/apps/com.myriad.aro/page/events.js
+++ b/apps/com.myriad.aro/page/events.js
@@ -1,7 +1,6 @@
     var d = $('ring-create-dialog');
     if (d) {
-      d.classList.remove('aro-leaving');
-      d.style.display = 'flex';
+      showAroOverlay(d);
     }
     if (typeof updateRingCreateCategoryVisibility === 'function') updateRingCreateCategoryVisibility();
   });

--- a/apps/com.myriad.aro/page/helpers.js
+++ b/apps/com.myriad.aro/page/helpers.js
@@ -85,6 +85,21 @@ function aroPlayEnter(el, className) {
 }
 
 /**
+ * Show a create-overlay (or any fixed modal overlay) after dismiss/forceHide.
+ * Restores the full open triad: clear hidden, pointer-events auto, display flex.
+ * Required because .create-overlay[hidden]{display:none!important} beats style.display=flex alone.
+ * @param {HTMLElement|null|undefined} el
+ */
+function showAroOverlay(el) {
+  if (!el) return;
+  el.classList.remove('aro-leaving');
+  el.hidden = false;
+  try { el.removeAttribute('hidden'); } catch (e) { /* ignore */ }
+  el.style.pointerEvents = 'auto';
+  el.style.display = 'flex';
+}
+
+/**
  * Immediately stop an overlay/menu from receiving clicks (safe even mid-animation).
  * Use when a stuck layer would dead-lock the messenger UI.
  */

--- a/apps/com.myriad.aro/page/views.js
+++ b/apps/com.myriad.aro/page/views.js
@@ -821,9 +821,7 @@ function openQuoteRepostModal(objectId) {
   }
   applyQuoteRepostLabels();
   if (dlg) {
-    dlg.hidden = false;
-    dlg.classList.remove('aro-leaving');
-    dlg.style.display = 'flex';
+    showAroOverlay(dlg);
   }
   if (ta) {
     try { ta.focus(); } catch (e) {}
@@ -1802,8 +1800,7 @@ function openFollowDialog() {
   if (!canFollowFromFeed()) return;
   var d = $('feed-follow-dialog');
   if (!d) return;
-  d.classList.remove('aro-leaving');
-  d.style.display = 'flex';
+  showAroOverlay(d);
   var input = $('feed-follow-input');
   if (input) {
     try { input.focus(); } catch (e) { /* ignore */ }
@@ -1829,8 +1826,7 @@ function openComposer() {
     }
     return;
   }
-  d.classList.remove('aro-leaving');
-  d.style.display = 'flex';
+  showAroOverlay(d);
   // Restore draft (storage or in-session), then focus.
   Promise.resolve(restoreComposeDraft()).then(function () {
     var ta = $('feed-compose-text');

--- a/apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
+++ b/apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
@@ -375,6 +375,173 @@ function checkGens() {
 }
 
 // ---------------------------------------------------------------------------
+// 7) showAroOverlay + create-overlay open paths restore full triad
+// After forceHide/dismissTransientUi, hidden=true + PE=none; display:flex alone
+// cannot reopen (.create-overlay[hidden]{display:none!important}).
+// ---------------------------------------------------------------------------
+
+/** Full open triad: clear hidden, pointerEvents auto, display flex (order flexible). */
+function hasOverlayOpenTriad(src) {
+  const pe =
+    /(?:style\.)?pointerEvents\s*=\s*['"]auto['"]/.test(src) ||
+    /pointer-events\s*:\s*auto/.test(src);
+  const hiddenClear =
+    /\.hidden\s*=\s*false/.test(src) ||
+    /removeAttribute\s*\(\s*['"]hidden['"]\s*\)/.test(src);
+  const displayFlex =
+    /(?:style\.)?display\s*=\s*['"]flex['"]/.test(src) ||
+    /display\s*:\s*flex/.test(src);
+  return pe && hiddenClear && displayFlex;
+}
+
+function usesShowAroOverlayOrTriad(src) {
+  return /\bshowAroOverlay\s*\(/.test(src) || hasOverlayOpenTriad(src);
+}
+
+function checkShowAroOverlay() {
+  const helpers = read('page/helpers.js');
+  if (!helpers) return;
+
+  // Strip comments first so extractFunctionBody is not confused by apostrophes in // comments
+  // (e.g. "don't") which would otherwise be parsed as string delimiters.
+  const helpersClean = stripComments(helpers);
+
+  // Function must exist with the restore triad
+  const body = extractFunctionBody(helpersClean, /function\s+showAroOverlay\s*\([^)]*\)\s*/);
+  if (!body) {
+    fail('7-showAroOverlay-fn', 'function showAroOverlay missing in page/helpers.js');
+  } else {
+    const hasHidden =
+      /\.hidden\s*=\s*false/.test(body) ||
+      /removeAttribute\s*\(\s*['"]hidden['"]\s*\)/.test(body);
+    const hasPe = /(?:style\.)?pointerEvents\s*=\s*['"]auto['"]/.test(body);
+    const hasFlex = /(?:style\.)?display\s*=\s*['"]flex['"]/.test(body);
+    const removesLeaving = /classList\.remove\s*\([^)]*aro-leaving/.test(body);
+    if (hasHidden && hasPe && hasFlex) {
+      pass(
+        '7-showAroOverlay-fn',
+        `function present with triad (hidden clear + PE auto + display flex${removesLeaving ? '; clears aro-leaving' : ''})`,
+      );
+    } else {
+      fail(
+        '7-showAroOverlay-fn',
+        `incomplete triad: hiddenClear=${hasHidden}, PE auto=${hasPe}, display flex=${hasFlex}`,
+      );
+    }
+  }
+
+  // openComposer / openFollowDialog in views.js
+  const views = read('page/views.js');
+  if (views) {
+    const viewsClean = stripComments(views);
+    for (const [name, re] of [
+      ['openComposer', /function\s+openComposer\s*\([^)]*\)\s*/],
+      ['openFollowDialog', /function\s+openFollowDialog\s*\([^)]*\)\s*/],
+    ]) {
+      const fnBody = extractFunctionBody(viewsClean, re);
+      if (!fnBody) {
+        fail(`7-${name}`, `function ${name} not found in page/views.js`);
+      } else if (usesShowAroOverlayOrTriad(fnBody)) {
+        pass(`7-${name}`, 'uses showAroOverlay or full open triad');
+      } else {
+        fail(
+          `7-${name}`,
+          'must call showAroOverlay OR set pointerEvents auto + clear hidden + display flex',
+        );
+      }
+    }
+
+    // quote-repost open path (openQuoteRepostModal)
+    const quoteFn =
+      extractFunctionBody(viewsClean, /function\s+openQuoteRepost\w*\s*\([^)]*\)\s*/) ||
+      extractFunctionBody(viewsClean, /function\s+showQuoteRepost\w*\s*\([^)]*\)\s*/) ||
+      extractFunctionBody(viewsClean, /function\s+\w*[Qq]uote[Rr]epost\w*\s*\([^)]*\)\s*/);
+    let quoteOk = false;
+    if (quoteFn && usesShowAroOverlayOrTriad(quoteFn)) {
+      quoteOk = true;
+    } else {
+      // Fallback: scan windows around quote-repost-dialog for open triad / showAroOverlay
+      let from = 0;
+      while (from < viewsClean.length) {
+        const i = viewsClean.indexOf('quote-repost-dialog', from);
+        if (i === -1) break;
+        const window = viewsClean.slice(Math.max(0, i - 80), Math.min(viewsClean.length, i + 400));
+        if (/\bshowAroOverlay\s*\(/.test(window) || hasOverlayOpenTriad(window)) {
+          quoteOk = true;
+          break;
+        }
+        from = i + 20;
+      }
+    }
+    if (quoteOk) {
+      pass('7-quote-repost-open', 'uses showAroOverlay or full open triad');
+    } else {
+      fail(
+        '7-quote-repost-open',
+        'quote-repost open path must call showAroOverlay OR pointerEvents auto + clear hidden + display flex',
+      );
+    }
+  }
+
+  // ring-create open path in events.js (bindEvents split across views/events)
+  const events = read('page/events.js');
+  if (events) {
+    const cleanEv = stripComments(events);
+    let ringOk = false;
+    let from = 0;
+    while (from < cleanEv.length) {
+      const i = cleanEv.indexOf('ring-create-dialog', from);
+      if (i === -1) break;
+      const window = cleanEv.slice(Math.max(0, i - 80), Math.min(cleanEv.length, i + 350));
+      // Open path: showAroOverlay or display flex with triad — not aroDismiss-only close
+      if (/\bshowAroOverlay\s*\(/.test(window) || hasOverlayOpenTriad(window)) {
+        ringOk = true;
+        break;
+      }
+      from = i + 20;
+    }
+    if (ringOk) {
+      pass('7-ring-create-open', 'uses showAroOverlay or full open triad');
+    } else {
+      fail(
+        '7-ring-create-open',
+        'ring-create open path must call showAroOverlay OR pointerEvents auto + clear hidden + display flex',
+      );
+    }
+  }
+
+  // showCreateDialog in api.js
+  const api = read('page/api.js');
+  if (api) {
+    const apiClean = stripComments(api);
+    const createBody = extractFunctionBody(apiClean, /function\s+showCreateDialog\s*\([^)]*\)\s*/);
+    if (!createBody) {
+      fail('7-showCreateDialog', 'function showCreateDialog not found in page/api.js');
+    } else if (usesShowAroOverlayOrTriad(createBody)) {
+      pass('7-showCreateDialog', 'uses showAroOverlay or full open triad');
+    } else {
+      fail(
+        '7-showCreateDialog',
+        'must call showAroOverlay OR set pointerEvents auto + clear hidden + display flex',
+      );
+    }
+
+    // showEditRoomDialog is also a create-overlay open path (bonus consistency)
+    const editBody = extractFunctionBody(apiClean, /function\s+showEditRoomDialog\s*\([^)]*\)\s*/);
+    if (editBody) {
+      if (usesShowAroOverlayOrTriad(editBody)) {
+        pass('7-showEditRoomDialog', 'uses showAroOverlay or full open triad');
+      } else {
+        fail(
+          '7-showEditRoomDialog',
+          'must call showAroOverlay OR set pointerEvents auto + clear hidden + display flex',
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Run
 // ---------------------------------------------------------------------------
 console.log(`Aro messenger interaction audit\nroot: ${ARO_ROOT}\n`);
@@ -385,6 +552,7 @@ checkConvListDelegation();
 checkCreateOverlayCss();
 checkHelpers();
 checkGens();
+checkShowAroOverlay();
 
 console.log('--- PASS ---');
 for (const p of passes) console.log(`  ✓ ${p}`);

--- a/index.json
+++ b/index.json
@@ -245,7 +245,7 @@
     {
       "id": "com.myriad.aro",
       "name": "Aro",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "社交中心，统一管理消息、时间线、环网与个人资料",
       "long_description": "社交中心：统一管理联邦消息（Channel/Room）、时间线、环网与个人资料。支持后台新消息通知、附件与多语言（中/英/日）。",
       "locales": {
@@ -324,7 +324,7 @@
       "featured": true,
       "verified": true,
       "created_at": "2025-12-01T00:00:00Z",
-      "updated_at": "2026-07-21T12:00:00Z"
+      "updated_at": "2026-07-21T14:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- After #28, `dismissTransientUi` / `forceHideInteractive` leave create-overlays with `hidden=true` and `pointer-events:none`. Open paths that only set `display:flex` cannot reopen because `.create-overlay[hidden]{display:none!important}`.
- Add `showAroOverlay(el)` in `page/helpers.js` (clear `aro-leaving` + hidden, `pointerEvents=auto`, `display=flex`).
- Wire all create-overlay openers: `showCreateDialog`, `showEditRoomDialog`, `openFollowDialog`, `openComposer`, ring-create open, quote-repost open.
- Extend `messenger-interaction-audit.mjs` section 7 to require `showAroOverlay` / full open triad.
- Bump Aro **1.0.3 → 1.0.4** (manifest, index.json, README). JS-only; no CSS drift.

## Tests
```
node apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
# exit 0 — All 19 checks passed
```

## Risks / follow-ups
- Background `index.js` monolith still has older open paths if used outside pageModules; page path is the shipped page UI.