### PR TITLE
fix(aro): seal portal overlay PE defaults + layer hardening (1.0.5)

### DIFF
--- a/apps/com.myriad.aro/README.md
+++ b/apps/com.myriad.aro/README.md
@@ -2,7 +2,7 @@
 
 社交中心：消息（Channel/Room）、时间线、环网与个人资料。
 
-> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.4）。
+> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.5）。
 
 ## 功能
 
@@ -23,5 +23,5 @@ index.js          # core（与 aro.ts buildCoreCode() 一致）
 page.html / page.css / styles.css
 page/*.js         # pageModules 与 aro.ts PAGE_MODULES 一致
 i18n/{zh,en,ja}.json
-manifest.json     # version 1.0.4
+manifest.json     # version 1.0.5
 ```

--- a/apps/com.myriad.aro/manifest.json
+++ b/apps/com.myriad.aro/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.aro",
   "name": "Aro",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "minSystemVersion": "0.2.1",
   "description": "社交中心，统一管理消息、时间线、环网与个人资料",
   "locales": {

--- a/apps/com.myriad.aro/page.css
+++ b/apps/com.myriad.aro/page.css
@@ -1039,9 +1039,11 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 /* Invite stays primary-tinted */
 .invite-toggle{background:none;color:var(--tapp-primary,#6366f1)}
 .invite-toggle:hover{background:rgba(var(--tapp-primary-rgb,100,100,255),.1)}
-.invite-popover{position:fixed;width:240px;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.1);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,.12);z-index:200;overflow:hidden}
+.invite-popover{position:fixed;width:240px;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.1);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,.12);z-index:200;overflow:hidden;pointer-events:none}
+.invite-popover[style*="display: block"],
+.invite-popover[style*="display:block"]{pointer-events:auto}
 .invite-popover.aro-menu-enter{animation:aroPopIn .14s var(--aro-ease) both}
-.invite-popover.aro-leaving{animation:aroFadeOut .12s ease both;pointer-events:none}
+.invite-popover.aro-leaving{animation:aroFadeOut .12s ease both;pointer-events:none!important}
 .invite-pop-section{padding:8px}
 .invite-pop-label{font-size:10px;font-weight:600;color:var(--text-secondary,#888);text-transform:uppercase;letter-spacing:.04em;padding:4px 6px 6px}
 .invite-pop-list{max-height:180px;overflow-y:auto}
@@ -1240,7 +1242,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 /* ===== Attachment Menu ===== */
 .attach-menu{position:absolute;bottom:calc(100% + 6px);left:0;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.1);border-radius:14px;box-shadow:0 6px 20px rgba(0,0,0,.1);z-index:60;padding:6px;display:grid;grid-template-columns:repeat(3,1fr);gap:2px;min-width:228px}
 .attach-menu.aro-menu-enter{animation:aroPopIn .16s var(--aro-ease) both}
-.attach-menu.aro-leaving{animation:aroFadeOut .12s ease both;pointer-events:none}
+/* Leaving / leftover nodes must never intercept hits (menu is DOM-only when open). */
+.attach-menu.aro-leaving{animation:aroFadeOut .12s ease both;pointer-events:none!important}
 .attach-menu-item{display:flex;flex-direction:column;align-items:center;gap:5px;min-height:64px;padding:10px 6px;border:none;background:none;border-radius:10px;cursor:pointer;transition:background .12s;color:var(--text-primary,#1a1a1a);font-size:10px;font-weight:500;white-space:nowrap}
 .attach-menu-item:hover{background:rgba(128,128,128,.06)}
 .attach-menu-icon{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:18px}
@@ -1285,13 +1288,17 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   --sheet-chip-hover:rgba(15,23,42,.08);
   --sheet-ink:var(--text-primary,#0f172a);
   --sheet-ink-dim:rgba(15,23,42,.55);
-  position:fixed;inset:0;z-index:200;display:flex;align-items:center;justify-content:center;
+  /* Closed default: never intercept clicks (JS opens via showAroOverlay triad) */
+  position:fixed;inset:0;z-index:200;display:none;align-items:center;justify-content:center;
   padding:24px 20px calc(24px + env(safe-area-inset-bottom,0px));
   padding-top:calc(24px + env(safe-area-inset-top,0px));
   background:rgba(9,9,14,.5);
   backdrop-filter:blur(10px) saturate(1.05);-webkit-backdrop-filter:blur(10px) saturate(1.05);
   animation:pickerFadeIn .2s ease;
+  pointer-events:none;
 }
+.picker-overlay[style*="display: flex"],
+.picker-overlay[style*="display:flex"]{pointer-events:auto}
 .dark .picker-overlay{
   --sheet-bg:#15151a;
   --sheet-hair:rgba(255,255,255,.09);
@@ -1510,7 +1517,10 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .quote-preview-close:hover{background:rgba(128,128,128,.1)}
 
 /* -- Forward Overlay -- */
-.forward-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:200;animation:ctxFadeIn .15s ease}
+/* Closed default: never intercept clicks; JS opens via showAroOverlay triad */
+.forward-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:200;animation:ctxFadeIn .15s ease;pointer-events:none}
+.forward-overlay[style*="display: flex"],
+.forward-overlay[style*="display:flex"]{pointer-events:auto}
 .forward-sheet{background:var(--bg-primary,#fff);border-radius:16px;width:min(340px,90vw);max-height:60vh;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 16px 48px rgba(0,0,0,.15)}
 .forward-header{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid rgba(128,128,128,.08)}
 .forward-title{font-size:15px;font-weight:600;color:var(--text-primary,#1a1a1a)}
@@ -1753,7 +1763,10 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 }
 
 /* ----- Full-screen image viewer ----- */
-.img-viewer{position:fixed;inset:0;z-index:400;display:flex;flex-direction:column;background:rgba(9,9,14,.82);backdrop-filter:blur(22px) saturate(1.1);-webkit-backdrop-filter:blur(22px) saturate(1.1)}
+/* Closed default: never intercept clicks; JS opens via showAroOverlay triad */
+.img-viewer{position:fixed;inset:0;z-index:400;display:none;flex-direction:column;background:rgba(9,9,14,.82);backdrop-filter:blur(22px) saturate(1.1);-webkit-backdrop-filter:blur(22px) saturate(1.1);pointer-events:none}
+.img-viewer[style*="display: flex"],
+.img-viewer[style*="display:flex"]{pointer-events:auto}
 .img-viewer-bar{display:flex;align-items:center;gap:10px;padding:12px 14px;padding-top:calc(12px + env(safe-area-inset-top,0px));color:rgba(255,255,255,.9);flex-shrink:0}
 .img-viewer-name{flex:1;min-width:0;font-size:13px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(255,255,255,.82)}
 .img-viewer-btn{width:36px;height:36px;flex-shrink:0;border:none;border-radius:12px;display:flex;align-items:center;justify-content:center;font-size:17px;color:#fff;background:rgba(255,255,255,.12);cursor:pointer;transition:background .15s,transform .12s}
@@ -1848,9 +1861,10 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
   .sidebar{width:100%;z-index:2;pointer-events:auto}
   .sidebar-hidden-mobile{display:none!important;pointer-events:none!important}
   .back-btn{display:block}
-  .member-panel{display:none!important;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none;pointer-events:none}
+  /* Closed always PE none; open only via .member-open-mobile (never cover desktop sidebar) */
+  .member-panel{display:none!important;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none;pointer-events:none!important}
   .dark .member-panel{background:var(--bg-primary,#1a1a1a)}
-  .member-panel.member-open-mobile{display:flex!important;pointer-events:auto}
+  .member-panel.member-open-mobile{display:flex!important;pointer-events:auto!important}
   .member-back-btn{display:flex}
   .aro-panel-layout .sidebar{width:100%}
   .aro-panel-layout .sidebar-hidden-mobile{display:none!important}
@@ -1997,7 +2011,10 @@ button.aro-select-trigger.create-input{
 
 
 /* ===== In-app Confirm Dialog (native confirm() is blocked in the sandboxed iframe) ===== */
-.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease;pointer-events:auto}
+/* Closed default: never intercept clicks; JS opens via showAroOverlay triad */
+.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease;pointer-events:none}
+.confirm-overlay[style*="display: flex"],
+.confirm-overlay[style*="display:flex"]{pointer-events:auto}
 .confirm-overlay.aro-leaving,.confirm-overlay[hidden]{pointer-events:none!important}
 .confirm-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(320px,88vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.18)}
 .confirm-message{font-size:14px;line-height:1.6;color:var(--text-primary,#1a1a1a);margin-bottom:18px;overflow-wrap:break-word}

--- a/apps/com.myriad.aro/page/api.js
+++ b/apps/com.myriad.aro/page/api.js
@@ -1193,6 +1193,7 @@ function ensureInvitePopover() {
   div.id = 'invite-popover';
   div.className = 'invite-popover';
   div.style.display = 'none';
+  div.style.pointerEvents = 'none';
   var contactSearchPh = lang.searchContacts || lang.pickerSearchPlaceholder || 'Search…';
   div.innerHTML = '<div class="invite-pop-section">'
     + '<div class="invite-pop-label" id="invite-pop-contacts-label">' + esc(lang.inviteFromContacts) + '</div>'
@@ -1245,7 +1246,9 @@ function toggleInvitePopover(e) {
     pop.style.top = (rect.bottom + 6) + 'px';
     pop.style.left = Math.max(4, rect.right - 240) + 'px';
     pop.classList.remove('aro-leaving');
-    pop.style.pointerEvents = '';
+    pop.hidden = false;
+    try { pop.removeAttribute('hidden'); } catch (eH) { /* ignore */ }
+    pop.style.pointerEvents = 'auto';
     pop.style.display = 'block';
     aroPlayEnter(pop, 'aro-menu-enter');
     renderInvitePopoverContacts();
@@ -1256,7 +1259,13 @@ function toggleInvitePopover(e) {
   }
 }
 function closeInvitePopover() {
-  if (!_invitePopover || _invitePopover.style.display === 'none') return;
+  if (!_invitePopover) return;
+  // Always seal PE + display none (even if already half-closed).
+  try { _invitePopover.style.pointerEvents = 'none'; } catch (ePe) { /* ignore */ }
+  if (_invitePopover.style.display === 'none') {
+    try { _invitePopover.style.display = 'none'; } catch (eD) { /* ignore */ }
+    return;
+  }
   aroDismiss(_invitePopover, { ms: 120 });
 }
 document.addEventListener('click', function (e) {

--- a/apps/com.myriad.aro/page/attachments.js
+++ b/apps/com.myriad.aro/page/attachments.js
@@ -70,6 +70,8 @@ function closeAttachMenu() {
   var btn = $('attach-btn');
   if (btn) btn.classList.remove('attach-btn-active');
   document.removeEventListener('click', _attachOutsideClick);
+  // PE none first (aroDismiss also does this); leftover .aro-leaving must not eat clicks.
+  try { menu.style.pointerEvents = 'none'; } catch (ePe) { /* ignore */ }
   aroDismiss(menu, { remove: true, ms: 120 });
 }
 
@@ -272,6 +274,9 @@ function pickFedContent(type) {
 function createPickerOverlay(type, icons, titles) {
   var overlay = document.createElement('div');
   overlay.className = 'picker-overlay';
+  // Closed CSS default is display:none + PE none — open triad after append.
+  overlay.style.display = 'none';
+  overlay.style.pointerEvents = 'none';
   var visual = sheetVisual({ type: type, rawSvg: icons[type], fallback: SVG_ICONS.file });
   applySheetAccent(overlay, visual.accent);
   overlay.innerHTML =
@@ -297,6 +302,11 @@ function createPickerOverlay(type, icons, titles) {
   overlay.addEventListener('click', function (e) { if (e.target === overlay) dismissPicker(); });
   overlay.dataset.aroDismissable = '1';
   document.body.appendChild(overlay);
+  if (typeof showAroOverlay === 'function') showAroOverlay(overlay);
+  else {
+    overlay.style.pointerEvents = 'auto';
+    overlay.style.display = 'flex';
+  }
   return overlay;
 }
 
@@ -322,6 +332,8 @@ function bindPickerSearch(overlay, getItems, renderFn, filterFn) {
 
 function dismissPickerOverlay(overlay) {
   if (!overlay) return;
+  // Seal PE immediately so a half-closed sheet never blocks the chat shell.
+  try { overlay.style.pointerEvents = 'none'; } catch (ePe) { /* ignore */ }
   aroDismiss(overlay, { remove: true, ms: 170 });
 }
 

--- a/apps/com.myriad.aro/page/chat.js
+++ b/apps/com.myriad.aro/page/chat.js
@@ -521,6 +521,9 @@ function doForward(msg) {
   var overlay = document.createElement('div');
   overlay.className = 'forward-overlay';
   overlay.dataset.aroDismissable = '1';
+  // Closed CSS default is display:none + PE none — open after append.
+  overlay.style.display = 'none';
+  overlay.style.pointerEvents = 'none';
   var searchPh = lang.searchForward || lang.searchConversations || lang.pickerSearchPlaceholder || 'Search…';
   overlay.innerHTML =
     '<div class="forward-sheet" role="dialog" aria-label="' + esc(lang.forwardTo) + '">'
@@ -590,6 +593,11 @@ function doForward(msg) {
     if (e.target === overlay) dismissForward();
   });
   document.body.appendChild(overlay);
+  if (typeof showAroOverlay === 'function') showAroOverlay(overlay);
+  else {
+    overlay.style.pointerEvents = 'auto';
+    overlay.style.display = 'flex';
+  }
   if (searchInput) {
     try { searchInput.focus(); } catch (eFocus) { /* ignore */ }
   }
@@ -1105,6 +1113,9 @@ function openImageViewer(src, name) {
   var overlay = document.createElement('div');
   overlay.className = 'img-viewer';
   overlay.dataset.aroDismissable = '1';
+  // Closed CSS default is display:none + PE none — open triad after append.
+  overlay.style.display = 'none';
+  overlay.style.pointerEvents = 'none';
   overlay.innerHTML = '<div class="img-viewer-bar">'
     + '<span class="img-viewer-name"></span>'
     + '<button type="button" class="img-viewer-btn" data-act="save" title="' + esc(lang.downloadFile || 'Download') + '" aria-label="' + esc(lang.downloadFile || 'Download') + '">' + SVG_ICONS.download + '</button>'
@@ -1135,6 +1146,11 @@ function openImageViewer(src, name) {
   document.addEventListener('keydown', onKey);
 
   document.body.appendChild(overlay);
+  if (typeof showAroOverlay === 'function') showAroOverlay(overlay);
+  else {
+    overlay.style.pointerEvents = 'auto';
+    overlay.style.display = 'flex';
+  }
   aroPlayEnter(overlay, 'aro-viewer-enter');
 }
 

--- a/apps/com.myriad.aro/page/events.js
+++ b/apps/com.myriad.aro/page/events.js
@@ -285,7 +285,30 @@
     backBtn.addEventListener('click', function () {
       // Invalidate in-flight open/poll so leaving chat cannot flash stale messages.
       state.openGen = (state.openGen || 0) + 1;
-      if (typeof dismissTransientUi === 'function') dismissTransientUi({});
+      // History/files live under #chat-main (siblings of #chat-container), and on mobile
+      // .history-overlay is position:fixed;z-index:90 — must seal BEFORE hiding chat shell.
+      if (typeof dismissTransientUi === 'function') {
+        dismissTransientUi({ keepChat: false });
+      } else {
+        try { if (typeof closeChatHistory === 'function') closeChatHistory(); } catch (eH) { /* ignore */ }
+        try { if (typeof closeRoomFiles === 'function') closeRoomFiles(); } catch (eF) { /* ignore */ }
+        try { if (typeof closeInvitePopover === 'function') closeInvitePopover(); } catch (eI) { /* ignore */ }
+        try { if (typeof closeAttachMenu === 'function') closeAttachMenu(); } catch (eA) { /* ignore */ }
+        try { if (typeof closeManageDropdown === 'function') closeManageDropdown(); } catch (eM) { /* ignore */ }
+      }
+      // Hard-seal fixed history/files immediately (close helpers may animate; PE must die now).
+      try {
+        ['chat-history-overlay', 'room-files-overlay'].forEach(function (id) {
+          var el = $(id);
+          if (!el) return;
+          if (typeof forceHideInteractive === 'function') forceHideInteractive(el);
+          else {
+            el.style.pointerEvents = 'none';
+            el.style.display = 'none';
+            el.hidden = true;
+          }
+        });
+      } catch (eSealHist) { /* ignore */ }
       var sidebar = $('sidebar');
       var chat = $('chat-container');
       var members = $('member-panel');
@@ -303,7 +326,8 @@
         members.style.display = 'none';
         members.classList.remove('member-open-mobile');
         members.classList.remove('member-expanded-tablet');
-        members.style.pointerEvents = '';
+        // Closed mobile sheet must not intercept list clicks (CSS PE none may lose to inline auto).
+        members.style.pointerEvents = 'none';
       }
       if (empty) {
         empty.style.display = '';

--- a/apps/com.myriad.aro/page/helpers.js
+++ b/apps/com.myriad.aro/page/helpers.js
@@ -219,6 +219,7 @@ function dismissTransientUi(opts) {
       panel.classList.remove('member-open-mobile');
       if (!opts.keepChat) {
         panel.classList.remove('member-expanded-tablet');
+        try { panel.style.pointerEvents = 'none'; } catch (ePeM) { /* ignore */ }
       }
     }
   } catch (e7) { /* ignore */ }
@@ -1365,6 +1366,9 @@ function aroConfirm(message, danger) {
   return new Promise(function (resolve) {
     var overlay = document.createElement('div');
     overlay.className = 'confirm-overlay';
+    // Closed CSS default is display:none + PE none — open triad required.
+    overlay.style.display = 'none';
+    overlay.style.pointerEvents = 'none';
     overlay.innerHTML = '<div class="confirm-dialog">'
       + '<div class="confirm-message">' + esc(message) + '</div>'
       + '<div class="confirm-actions">'
@@ -1385,6 +1389,11 @@ function aroConfirm(message, danger) {
     overlay.querySelector('.confirm-btn-ok').addEventListener('click', function () { done(true); });
     overlay.addEventListener('click', function (e) { if (e.target === overlay) done(false); });
     document.body.appendChild(overlay);
+    if (typeof showAroOverlay === 'function') showAroOverlay(overlay);
+    else {
+      overlay.style.pointerEvents = 'auto';
+      overlay.style.display = 'flex';
+    }
     overlay.querySelector('.confirm-btn-ok').focus();
   });
 }

--- a/apps/com.myriad.aro/page/members.js
+++ b/apps/com.myriad.aro/page/members.js
@@ -8,7 +8,7 @@ function renderMembers() {
     // Always clear mobile full-screen sheet — stuck member-open-mobile blocks the list.
     panel.classList.remove('member-open-mobile', 'member-expanded-tablet');
     panel.style.display = 'none';
-    panel.style.pointerEvents = '';
+    panel.style.pointerEvents = 'none';
     return;
   }
   // Desktop: show side panel. Mobile: keep hidden until user opens (member-open-mobile).
@@ -17,9 +17,13 @@ function renderMembers() {
     // Do not force-show; only ensure pointer-events when intentionally open.
     if (!panel.classList.contains('member-open-mobile')) {
       panel.style.display = '';
+      panel.style.pointerEvents = 'none';
       // media query keeps it display:none until .member-open-mobile
+    } else {
+      panel.style.pointerEvents = 'auto';
     }
   } else {
+    // Desktop/tablet: never cover the sidebar list — panel is a side column only.
     panel.style.display = '';
     panel.style.pointerEvents = '';
   }
@@ -290,6 +294,11 @@ function toggleMemberPanel() {
   var isMobile = window.innerWidth <= 768;
   if (isMobile) {
     panel.classList.toggle('member-open-mobile');
+    if (panel.classList.contains('member-open-mobile')) {
+      panel.style.pointerEvents = 'auto';
+    } else {
+      panel.style.pointerEvents = 'none';
+    }
   } else if (isTablet()) {
     panel.classList.toggle('member-expanded-tablet');
     state.memberPanelOpen = panel.classList.contains('member-expanded-tablet');
@@ -310,7 +319,7 @@ function closeMemberPanel() {
   // Mobile full-screen sheet: force hide so it cannot block sidebar/list
   if (window.innerWidth <= 768) {
     panel.style.display = '';
-    panel.style.pointerEvents = '';
+    panel.style.pointerEvents = 'none';
   }
   state.memberPanelOpen = false;
 }

--- a/apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
+++ b/apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
@@ -542,6 +542,149 @@ function checkShowAroOverlay() {
 }
 
 // ---------------------------------------------------------------------------
+// 8) Full-screen portal CSS defaults: confirm/forward/picker/img-viewer
+// Must be display:none + pointer-events:none when closed (both CSS files).
+// ---------------------------------------------------------------------------
+function extractClassRules(cssText, className) {
+  const rules = [];
+  // Escape dots in class names for regex (className is without leading dot)
+  const re = new RegExp(`\\.${className.replace(/\./g, '\\.')}\\s*\\{([^}]*)\\}`, 'g');
+  let m;
+  while ((m = re.exec(cssText)) !== null) {
+    rules.push(m[1].replace(/\s+/g, ' ').trim());
+  }
+  return rules;
+}
+
+function pickBaseLayoutRule(rules) {
+  // Prefer the layout rule (position:fixed / inset) over animation-only shorthands
+  return (
+    rules.find((r) => /position\s*:\s*fixed/.test(r) || /inset\s*:\s*0/.test(r)) || rules[0]
+  );
+}
+
+function checkPortalOverlayCss() {
+  const portals = [
+    'confirm-overlay',
+    'forward-overlay',
+    'picker-overlay',
+    'img-viewer',
+  ];
+  for (const rel of ['page.css', 'styles.css']) {
+    const css = read(rel);
+    if (!css) continue;
+    for (const cls of portals) {
+      const rules = extractClassRules(css, cls);
+      const base = pickBaseLayoutRule(rules);
+      if (!base) {
+        fail(`8-${cls}-${rel}`, `no .${cls} { } rule found`);
+        continue;
+      }
+      const hasDisplayNone = /display\s*:\s*none/.test(base);
+      const hasPeNone = /pointer-events\s*:\s*none/.test(base);
+      // Reject dangerous open-by-default PE auto or display:flex as sole display
+      const hasDangerousDisplayFlex =
+        /display\s*:\s*flex/.test(base) && !/display\s*:\s*none/.test(base);
+      const hasDangerousPeAuto =
+        /pointer-events\s*:\s*auto/.test(base) && !/pointer-events\s*:\s*none/.test(base);
+      if (hasDisplayNone && hasPeNone && !hasDangerousDisplayFlex && !hasDangerousPeAuto) {
+        pass(`8-${cls}-${rel}`, 'display:none + pointer-events:none');
+      } else {
+        fail(
+          `8-${cls}-${rel}`,
+          `display:none=${hasDisplayNone}, PE none=${hasPeNone}, dangerousFlex=${hasDangerousDisplayFlex}, dangerousPeAuto=${hasDangerousPeAuto}; rule="${base.slice(0, 180)}"`,
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 9) back-btn path must dismiss history/files (or dismissTransientUi)
+// History/files are siblings of #chat-container under #chat-main; on mobile
+// .history-overlay is position:fixed and will block the list if left open.
+// ---------------------------------------------------------------------------
+function checkBackBtnDismissesLayers() {
+  const events = read('page/events.js');
+  if (!events) return;
+  const clean = stripComments(events);
+  // Locate back-btn wiring — either $('back-btn') or getElementById('back-btn')
+  const backIdx =
+    clean.search(/\$\(\s*['"]back-btn['"]\s*\)/) !== -1
+      ? clean.search(/\$\(\s*['"]back-btn['"]\s*\)/)
+      : clean.search(/getElementById\s*\(\s*['"]back-btn['"]\s*\)/);
+  if (backIdx === -1) {
+    fail('9-back-btn', "could not find back-btn reference in page/events.js");
+    return;
+  }
+  // Scan a generous window after the first back-btn hit for the click handler body
+  const window = clean.slice(backIdx, Math.min(clean.length, backIdx + 3500));
+  const hasDismiss =
+    /dismissTransientUi\s*\(/.test(window) ||
+    (/closeChatHistory\s*\(/.test(window) && /closeRoomFiles\s*\(/.test(window));
+  if (hasDismiss) {
+    pass(
+      '9-back-btn-dismiss',
+      /dismissTransientUi\s*\(/.test(window)
+        ? 'back-btn path calls dismissTransientUi'
+        : 'back-btn path calls closeChatHistory + closeRoomFiles',
+    );
+  } else {
+    fail(
+      '9-back-btn-dismiss',
+      'back-btn handler must call dismissTransientUi OR closeChatHistory+closeRoomFiles before clearing chat',
+    );
+  }
+  // Prefer explicit keepChat:false when using dismissTransientUi
+  if (
+    /dismissTransientUi\s*\(/.test(window) &&
+    /keepChat\s*:\s*false/.test(window)
+  ) {
+    pass('9-back-btn-keepChat-false', 'dismissTransientUi({ keepChat: false })');
+  } else if (/dismissTransientUi\s*\(/.test(window)) {
+    // Soft pass — empty opts also means keepChat falsy, but explicit is better
+    pass('9-back-btn-keepChat-false', 'dismissTransientUi present (keepChat not required if falsy default)');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 10) Optional layer inventory dump (informational; never fails the audit)
+// ---------------------------------------------------------------------------
+function dumpLayerInventory() {
+  if (!process.argv.includes('--inventory') && process.env.ARO_AUDIT_INVENTORY !== '1') {
+    return;
+  }
+  const layers = [
+    { cls: 'history-overlay', note: 'chat history / room files (scoped #chat-main)' },
+    { cls: 'create-overlay', note: 'create/edit/compose dialogs' },
+    { cls: 'confirm-overlay', note: 'in-app confirm portal' },
+    { cls: 'forward-overlay', note: 'message forward portal' },
+    { cls: 'picker-overlay', note: 'attachment picker portal' },
+    { cls: 'img-viewer', note: 'full-screen image viewer' },
+    { cls: 'invite-popover', note: 'room invite popover' },
+    { cls: 'attach-menu', note: 'composer attach menu' },
+    { cls: 'member-panel', note: 'room members (mobile full-screen sheet)' },
+    { cls: 'manage-dropdown', note: 'header manage menu' },
+    { cls: 'msg-ctx-menu', note: 'message context menu' },
+  ];
+  console.log('--- LAYER INVENTORY (optional) ---');
+  for (const rel of ['page.css', 'styles.css']) {
+    const css = read(rel);
+    if (!css) continue;
+    console.log(`  [${rel}]`);
+    for (const { cls, note } of layers) {
+      const rules = extractClassRules(css, cls);
+      const base = pickBaseLayoutRule(rules) || '';
+      const display = (base.match(/display\s*:\s*([^;]+)/) || [])[1] || '?';
+      const pe = (base.match(/pointer-events\s*:\s*([^;]+)/) || [])[1] || '(inherit)';
+      const z = (base.match(/z-index\s*:\s*([^;]+)/) || [])[1] || '?';
+      console.log(`    .${cls}: display=${display.trim()} PE=${pe.trim()} z=${z.trim()} — ${note}`);
+    }
+  }
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
 // Run
 // ---------------------------------------------------------------------------
 console.log(`Aro messenger interaction audit\nroot: ${ARO_ROOT}\n`);
@@ -553,6 +696,9 @@ checkCreateOverlayCss();
 checkHelpers();
 checkGens();
 checkShowAroOverlay();
+checkPortalOverlayCss();
+checkBackBtnDismissesLayers();
+dumpLayerInventory();
 
 console.log('--- PASS ---');
 for (const p of passes) console.log(`  ✓ ${p}`);
@@ -562,5 +708,5 @@ if (failures.length) {
   console.log(`\n${failures.length} check(s) failed, ${passes.length} passed.`);
   process.exit(1);
 }
-console.log(`\nAll ${passes.length} checks passed (10-round structural audit green).`);
+console.log(`\nAll ${passes.length} checks passed (layering audit green).`);
 process.exit(0);

--- a/apps/com.myriad.aro/styles.css
+++ b/apps/com.myriad.aro/styles.css
@@ -1039,9 +1039,11 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 /* Invite stays primary-tinted */
 .invite-toggle{background:none;color:var(--tapp-primary,#6366f1)}
 .invite-toggle:hover{background:rgba(var(--tapp-primary-rgb,100,100,255),.1)}
-.invite-popover{position:fixed;width:240px;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.1);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,.12);z-index:200;overflow:hidden}
+.invite-popover{position:fixed;width:240px;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.1);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,.12);z-index:200;overflow:hidden;pointer-events:none}
+.invite-popover[style*="display: block"],
+.invite-popover[style*="display:block"]{pointer-events:auto}
 .invite-popover.aro-menu-enter{animation:aroPopIn .14s var(--aro-ease) both}
-.invite-popover.aro-leaving{animation:aroFadeOut .12s ease both;pointer-events:none}
+.invite-popover.aro-leaving{animation:aroFadeOut .12s ease both;pointer-events:none!important}
 .invite-pop-section{padding:8px}
 .invite-pop-label{font-size:10px;font-weight:600;color:var(--text-secondary,#888);text-transform:uppercase;letter-spacing:.04em;padding:4px 6px 6px}
 .invite-pop-list{max-height:180px;overflow-y:auto}
@@ -1240,7 +1242,8 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 /* ===== Attachment Menu ===== */
 .attach-menu{position:absolute;bottom:calc(100% + 6px);left:0;background:var(--bg-primary,#fff);border:1px solid rgba(128,128,128,.1);border-radius:14px;box-shadow:0 6px 20px rgba(0,0,0,.1);z-index:60;padding:6px;display:grid;grid-template-columns:repeat(3,1fr);gap:2px;min-width:228px}
 .attach-menu.aro-menu-enter{animation:aroPopIn .16s var(--aro-ease) both}
-.attach-menu.aro-leaving{animation:aroFadeOut .12s ease both;pointer-events:none}
+/* Leaving / leftover nodes must never intercept hits (menu is DOM-only when open). */
+.attach-menu.aro-leaving{animation:aroFadeOut .12s ease both;pointer-events:none!important}
 .attach-menu-item{display:flex;flex-direction:column;align-items:center;gap:5px;min-height:64px;padding:10px 6px;border:none;background:none;border-radius:10px;cursor:pointer;transition:background .12s;color:var(--text-primary,#1a1a1a);font-size:10px;font-weight:500;white-space:nowrap}
 .attach-menu-item:hover{background:rgba(128,128,128,.06)}
 .attach-menu-icon{width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:18px}
@@ -1285,13 +1288,17 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
   --sheet-chip-hover:rgba(15,23,42,.08);
   --sheet-ink:var(--text-primary,#0f172a);
   --sheet-ink-dim:rgba(15,23,42,.55);
-  position:fixed;inset:0;z-index:200;display:flex;align-items:center;justify-content:center;
+  /* Closed default: never intercept clicks (JS opens via showAroOverlay triad) */
+  position:fixed;inset:0;z-index:200;display:none;align-items:center;justify-content:center;
   padding:24px 20px calc(24px + env(safe-area-inset-bottom,0px));
   padding-top:calc(24px + env(safe-area-inset-top,0px));
   background:rgba(9,9,14,.5);
   backdrop-filter:blur(10px) saturate(1.05);-webkit-backdrop-filter:blur(10px) saturate(1.05);
   animation:pickerFadeIn .2s ease;
+  pointer-events:none;
 }
+.picker-overlay[style*="display: flex"],
+.picker-overlay[style*="display:flex"]{pointer-events:auto}
 .dark .picker-overlay{
   --sheet-bg:#15151a;
   --sheet-hair:rgba(255,255,255,.09);
@@ -1510,7 +1517,10 @@ body.dark{background:#0a0a0a;color:rgba(255,255,255,.92)}
 .quote-preview-close:hover{background:rgba(128,128,128,.1)}
 
 /* -- Forward Overlay -- */
-.forward-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:200;animation:ctxFadeIn .15s ease}
+/* Closed default: never intercept clicks; JS opens via showAroOverlay triad */
+.forward-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:200;animation:ctxFadeIn .15s ease;pointer-events:none}
+.forward-overlay[style*="display: flex"],
+.forward-overlay[style*="display:flex"]{pointer-events:auto}
 .forward-sheet{background:var(--bg-primary,#fff);border-radius:16px;width:min(340px,90vw);max-height:60vh;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 16px 48px rgba(0,0,0,.15)}
 .forward-header{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid rgba(128,128,128,.08)}
 .forward-title{font-size:15px;font-weight:600;color:var(--text-primary,#1a1a1a)}
@@ -1753,7 +1763,10 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
 }
 
 /* ----- Full-screen image viewer ----- */
-.img-viewer{position:fixed;inset:0;z-index:400;display:flex;flex-direction:column;background:rgba(9,9,14,.82);backdrop-filter:blur(22px) saturate(1.1);-webkit-backdrop-filter:blur(22px) saturate(1.1)}
+/* Closed default: never intercept clicks; JS opens via showAroOverlay triad */
+.img-viewer{position:fixed;inset:0;z-index:400;display:none;flex-direction:column;background:rgba(9,9,14,.82);backdrop-filter:blur(22px) saturate(1.1);-webkit-backdrop-filter:blur(22px) saturate(1.1);pointer-events:none}
+.img-viewer[style*="display: flex"],
+.img-viewer[style*="display:flex"]{pointer-events:auto}
 .img-viewer-bar{display:flex;align-items:center;gap:10px;padding:12px 14px;padding-top:calc(12px + env(safe-area-inset-top,0px));color:rgba(255,255,255,.9);flex-shrink:0}
 .img-viewer-name{flex:1;min-width:0;font-size:13px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(255,255,255,.82)}
 .img-viewer-btn{width:36px;height:36px;flex-shrink:0;border:none;border-radius:12px;display:flex;align-items:center;justify-content:center;font-size:17px;color:#fff;background:rgba(255,255,255,.12);cursor:pointer;transition:background .15s,transform .12s}
@@ -1848,9 +1861,10 @@ button.msg-file-card:hover .msg-file-action{color:rgb(var(--acc));background:rgb
   .sidebar{width:100%;z-index:2;pointer-events:auto}
   .sidebar-hidden-mobile{display:none!important;pointer-events:none!important}
   .back-btn{display:block}
-  .member-panel{display:none!important;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none;pointer-events:none}
+  /* Closed always PE none; open only via .member-open-mobile (never cover desktop sidebar) */
+  .member-panel{display:none!important;position:fixed;inset:0;width:100%!important;z-index:80;background:var(--bg-primary,#fff);border-left:none;pointer-events:none!important}
   .dark .member-panel{background:var(--bg-primary,#1a1a1a)}
-  .member-panel.member-open-mobile{display:flex!important;pointer-events:auto}
+  .member-panel.member-open-mobile{display:flex!important;pointer-events:auto!important}
   .member-back-btn{display:flex}
   .aro-panel-layout .sidebar{width:100%}
   .aro-panel-layout .sidebar-hidden-mobile{display:none!important}
@@ -1997,7 +2011,10 @@ button.aro-select-trigger.create-input{
 
 
 /* ===== In-app Confirm Dialog (native confirm() is blocked in the sandboxed iframe) ===== */
-.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease;pointer-events:auto}
+/* Closed default: never intercept clicks; JS opens via showAroOverlay triad */
+.confirm-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;z-index:300;animation:ctxFadeIn .12s ease;pointer-events:none}
+.confirm-overlay[style*="display: flex"],
+.confirm-overlay[style*="display:flex"]{pointer-events:auto}
 .confirm-overlay.aro-leaving,.confirm-overlay[hidden]{pointer-events:none!important}
 .confirm-dialog{background:var(--bg-primary,#fff);border-radius:16px;width:min(320px,88vw);padding:20px;box-shadow:0 16px 48px rgba(0,0,0,.18)}
 .confirm-message{font-size:14px;line-height:1.6;color:var(--text-primary,#1a1a1a);margin-bottom:18px;overflow-wrap:break-word}

--- a/index.json
+++ b/index.json
@@ -245,7 +245,7 @@
     {
       "id": "com.myriad.aro",
       "name": "Aro",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "description": "社交中心，统一管理消息、时间线、环网与个人资料",
       "long_description": "社交中心：统一管理联邦消息（Channel/Room）、时间线、环网与个人资料。支持后台新消息通知、附件与多语言（中/英/日）。",
       "locales": {


### PR DESCRIPTION
## Summary

Hardens Aro messenger layering so “随便一点又是层级 bug” stops happening after #28/#29.

### Root causes fixed

1. **Mobile back left history/files shield**  
   `#chat-history-overlay` / `#room-files-overlay` are siblings of `#chat-container` under `#chat-main` (not children). On mobile `.history-overlay` is `position:fixed; z-index:90`. Back now calls `dismissTransientUi({ keepChat: false })` then **force-seals** both overlays with `forceHideInteractive` before clearing chat shell. Member sheet PE sealed to `none`.

2. **Dangerous CSS defaults for full-screen portals** (page.css + styles.css)  
   `.confirm-overlay`, `.forward-overlay`, `.picker-overlay`, `.img-viewer` default to `display:none; pointer-events:none` when closed. Open paths set the triad via `showAroOverlay` (or PE auto + display flex) in:
   - `aroConfirm` (helpers.js)
   - forward overlay (chat.js)
   - `createPickerOverlay` / dismiss (attachments.js)
   - img-viewer open (chat.js)

3. **invite-popover** — close always seals PE none; CSS closed PE none; open sets PE auto.

4. **attach-menu** — PE none before remove; CSS `.aro-leaving` uses `pointer-events:none!important`.

5. **member-panel** mobile — closed always PE none (`!important` in media query); desktop remains a side column and never covers the sidebar list.

### Prior green bars kept

No closed-chip UI; openConversation shell-before-await; openGen/convLoadGen; create-overlay defaults; history scoped to `#chat-main`.

### Audit

`messenger-interaction-audit.mjs` adds:
- **8** confirm/forward/picker/img-viewer CSS defaults (both CSS files)
- **9** back-btn path must call `dismissTransientUi` or `closeChatHistory`+`closeRoomFiles`
- optional `--inventory` / `ARO_AUDIT_INVENTORY=1` layer dump

### Version

Aro **1.0.5** (user-visible layering fixes; 1.0.4 already shipped in #29).

## Test plan

- [x] `node apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs` → 29 checks pass
- [ ] Mobile: open chat → history → back → list fully clickable
- [ ] Mobile: open chat → room files → back → list fully clickable
- [ ] Mobile: open members → back → list fully clickable
- [ ] Confirm / forward / picker / image viewer open and dismiss without residual click shield
- [ ] Invite popover open/close; attach menu dismiss