### PR TITLE
fix(aro): open detail sheets via showAroOverlay after #30

### DIFF
--- a/apps/com.myriad.aro/README.md
+++ b/apps/com.myriad.aro/README.md
@@ -2,7 +2,7 @@
 
 社交中心：消息（Channel/Room）、时间线、环网与个人资料。
 
-> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.5）。
+> 本包由 Myriad `frontend/src/tapp/examples/tapps/aro.ts` **逐字导出**（version 1.0.6）。
 
 ## 功能
 
@@ -23,5 +23,5 @@ index.js          # core（与 aro.ts buildCoreCode() 一致）
 page.html / page.css / styles.css
 page/*.js         # pageModules 与 aro.ts PAGE_MODULES 一致
 i18n/{zh,en,ja}.json
-manifest.json     # version 1.0.5
+manifest.json     # version 1.0.6
 ```

--- a/apps/com.myriad.aro/manifest.json
+++ b/apps/com.myriad.aro/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.aro",
   "name": "Aro",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "minSystemVersion": "0.2.1",
   "description": "社交中心，统一管理消息、时间线、环网与个人资料",
   "locales": {

--- a/apps/com.myriad.aro/page/chat.js
+++ b/apps/com.myriad.aro/page/chat.js
@@ -1326,6 +1326,9 @@ function createDetailOverlay(title, opts) {
   var overlay = document.createElement('div');
   overlay.className = 'picker-overlay';
   overlay.dataset.aroDismissable = '1';
+  // Closed CSS default is display:none + PE none — open triad after append.
+  overlay.style.display = 'none';
+  overlay.style.pointerEvents = 'none';
   var visual = sheetVisual(opts);
   applySheetAccent(overlay, visual.accent);
   overlay.innerHTML =
@@ -1351,6 +1354,13 @@ function createDetailOverlay(title, opts) {
   document.addEventListener('keydown', onKey);
 
   document.body.appendChild(overlay);
+  // Match createPickerOverlay: CSS defaults to closed; must open explicitly.
+  if (typeof showAroOverlay === 'function') showAroOverlay(overlay);
+  else {
+    overlay.hidden = false;
+    overlay.style.pointerEvents = 'auto';
+    overlay.style.display = 'flex';
+  }
   return overlay;
 }
 

--- a/apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
+++ b/apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
@@ -539,6 +539,85 @@ function checkShowAroOverlay() {
       }
     }
   }
+
+  // createDetailOverlay (share-detail sheets): must open after appendChild
+  // Regression after #30: CSS defaults picker-overlay to display:none + PE none.
+  const chat = read('page/chat.js');
+  if (chat) {
+    const chatClean = stripComments(chat);
+    const detailBody = extractFunctionBody(
+      chatClean,
+      /function\s+createDetailOverlay\s*\([^)]*\)\s*/,
+    );
+    if (!detailBody) {
+      fail('7-createDetailOverlay', 'function createDetailOverlay not found in page/chat.js');
+    } else if (!/appendChild\s*\(\s*overlay\s*\)/.test(detailBody)) {
+      fail('7-createDetailOverlay', 'createDetailOverlay must appendChild(overlay)');
+    } else if (usesShowAroOverlayOrTriad(detailBody)) {
+      pass('7-createDetailOverlay', 'uses showAroOverlay or full open triad after appendChild');
+    } else {
+      fail(
+        '7-createDetailOverlay',
+        'must call showAroOverlay OR set pointerEvents auto + clear hidden + display flex after appendChild',
+      );
+    }
+  }
+
+  // Any function that assigns className 'picker-overlay' must also open it
+  // (createPickerOverlay, createDetailOverlay, and any future builders).
+  checkPickerOverlayOpenPaths();
+}
+
+/**
+ * Scan page/*.js for className = 'picker-overlay' assignments.
+ * The enclosing function body must call showAroOverlay (or full open triad)
+ * before it returns — otherwise the sheet stays display:none after #30 CSS.
+ */
+function checkPickerOverlayOpenPaths() {
+  const pageDir = path.join(ARO_ROOT, 'page');
+  const files = walkFiles(pageDir, ['.js']);
+  let found = 0;
+  for (const f of files) {
+    const rel = path.relative(ARO_ROOT, f);
+    const src = stripComments(fs.readFileSync(f, 'utf8'));
+    // Match className = 'picker-overlay' / "picker-overlay"
+    const assignRe = /\.className\s*=\s*['"]picker-overlay['"]/g;
+    let m;
+    while ((m = assignRe.exec(src)) !== null) {
+      found++;
+      // Walk backward to nearest function declaration
+      const before = src.slice(0, m.index);
+      const fnMatches = [
+        ...before.matchAll(
+          /function\s+([A-Za-z0-9_$]+)\s*\([^)]*\)\s*\{/g,
+        ),
+      ];
+      const lastFn = fnMatches[fnMatches.length - 1];
+      const fnName = lastFn ? lastFn[1] : `anon@${path.basename(f)}:${m.index}`;
+      let body = null;
+      if (lastFn) {
+        body = extractFunctionBody(
+          src.slice(lastFn.index),
+          new RegExp(
+            `function\\s+${fnName.replace(/\$/g, '\\$')}\\s*\\([^)]*\\)\\s*`,
+          ),
+        );
+      }
+      // Fallback: window around the assignment
+      const window = body || src.slice(m.index, Math.min(src.length, m.index + 1200));
+      if (usesShowAroOverlayOrTriad(window)) {
+        pass(`7-picker-overlay-${fnName}`, `${rel}: opens via showAroOverlay/triad`);
+      } else {
+        fail(
+          `7-picker-overlay-${fnName}`,
+          `${rel}: assigns className picker-overlay but never calls showAroOverlay / open triad`,
+        );
+      }
+    }
+  }
+  if (found === 0) {
+    fail('7-picker-overlay-scan', 'no className = picker-overlay assignments found in page/*.js');
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/index.json
+++ b/index.json
@@ -245,7 +245,7 @@
     {
       "id": "com.myriad.aro",
       "name": "Aro",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "description": "社交中心，统一管理消息、时间线、环网与个人资料",
       "long_description": "社交中心：统一管理联邦消息（Channel/Room）、时间线、环网与个人资料。支持后台新消息通知、附件与多语言（中/英/日）。",
       "locales": {


### PR DESCRIPTION
## Summary
- **Regression after #30:** portal CSS defaults `.picker-overlay` to `display:none` + `pointer-events:none`. `createDetailOverlay` appended the sheet but never called `showAroOverlay`, so `openTappDetail` / `openBrewDetail` / `openLibraryDetail` / `openReportDetail` sheets were invisible.
- Call `showAroOverlay` (or full open triad fallback) after `appendChild`, matching `createPickerOverlay` in `attachments.js`.
- Audit: require `createDetailOverlay` open triad; scan all `className = 'picker-overlay'` builders in `page/*.js`.
- Bump Aro **1.0.5 → 1.0.6** (manifest, index.json, README).

## Overlay open-path audit (page modules)
| Site | Class | Open path |
|------|-------|-----------|
| `createPickerOverlay` (attachments.js) | picker-overlay | showAroOverlay ✓ |
| `createDetailOverlay` (chat.js) | picker-overlay | **fixed** showAroOverlay ✓ |
| `doForward` (chat.js) | forward-overlay | showAroOverlay ✓ |
| `openImageViewer` (chat.js) | img-viewer | showAroOverlay ✓ |
| `aroConfirm` (helpers.js) | confirm-overlay | showAroOverlay ✓ |

## Tests
```
node apps/com.myriad.aro/scripts/messenger-interaction-audit.mjs
# → All 32 checks passed (includes 7-createDetailOverlay + 7-picker-overlay-*)
```

## Risks / follow-ups
- Monolithic `index.js` still lacks `showAroOverlay` (unchanged since #30; runtime uses `page/*` modules). Consider syncing in a later export pass.