### PR TITLE
Add @myriad/tapp-cli v0.1.0

### DIFF
--- a/tapp-cli/README.md
+++ b/tapp-cli/README.md
@@ -1,0 +1,184 @@
+# Myriad Tapp CLI
+
+Offline project tooling for Myriad Tapps. The backend installer remains the final
+authority; this CLI catches common contract problems before upload.
+
+## Requirements
+
+- Node.js 20 or newer;
+- access to a Myriad instance when you are ready to install the generated package.
+
+The examples pin `@myriad/tapp-cli` to `0.1.0`. Keep the version explicit in
+automation and upgrade it deliberately when a newer release is available.
+
+## For agents
+
+Use a pinned package version and the explicit binary name in automation. `--yes`
+accepts npm's temporary-install prompt; `--package` makes the selected package and
+binary unambiguous in CI.
+
+```bash
+npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp init ./my-tapp --type page
+npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp check ./my-tapp --json
+npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp pack ./my-tapp --json
+```
+
+Treat a non-zero status as failure. When `check --json` returns status `1`, repair
+the reported diagnostics and repeat `check`; run `pack --json` only after it
+succeeds. `pack` writes `dist/{manifest.id}.tapp` unless `--out` is supplied.
+
+For a checked-in dependency, pin the package in the lockfile and invoke its binary
+through `npm exec`:
+
+```bash
+npm install --save-dev --save-exact @myriad/tapp-cli@0.1.0
+npm exec -- myriad-tapp check . --json
+```
+
+Do not infer success from human-readable output. Read the JSON object and process
+exit status described in [Automation contract](#automation-contract).
+
+## For users
+
+Install the pinned CLI globally when you want a short interactive command:
+
+```bash
+npm install --global @myriad/tapp-cli@0.1.0
+```
+
+Create a starter, edit its `manifest.json` and source files, then validate and
+package it:
+
+```bash
+myriad-tapp init ./my-tapp --type page
+cd ./my-tapp
+myriad-tapp check .
+myriad-tapp permissions .
+myriad-tapp pack .
+```
+
+`pack` writes `dist/{manifest.id}.tapp` by default. In Myriad, open the Tapp
+management page, choose the install action, and upload that file. The CLI does not
+currently log in to a Myriad server or upload packages itself.
+
+## Commands
+
+Run `myriad-tapp <command> --help` for the command-specific interface and exit
+status. Each command accepts at most one optional directory; it defaults to the
+current directory.
+
+| Command | Purpose | Allowed options |
+| --- | --- | --- |
+| `init [directory]` | Create a project. | `--type <page\|widget\|both>`, `--id <id>`, `--name <name>`, `--author <name>`, `--force`, `--json` |
+| `check [directory]` | Validate a project. | `--json` |
+| `permissions [directory]` | List declared and inferred permissions. | `--json` |
+| `pack [directory]` | Validate and write a `.tapp` archive. | `-o, --out <path>`, `--json` |
+
+`init --force` allows initialization in a non-empty directory. It overwrites only
+the starter files managed by the CLI; it does not delete unrelated files or clean
+existing package resource directories.
+
+Unsupported options are usage errors. `--version` returns the installed CLI
+version; `--help` returns global help when supplied without a command.
+
+## Automation contract
+
+| Exit status | Meaning | JSON-mode output |
+| --- | --- | --- |
+| `0` | Requested operation succeeded. | Command result. |
+| `1` | Validation, packaging, or execution failed. | Inspection report for validation failures; error envelope for execution failures. |
+| `2` | Command-line usage is invalid. | Error envelope. |
+
+When executing a subcommand with `--json`, stdout is exactly one JSON object and
+stderr is empty. Successful `init` returns `{ result, report }`; `check` and
+`permissions` return an inspection report; successful `pack` returns
+`{ outputPath, sizeBytes, entries, diagnostics }`. Validation failures return their
+inspection report so callers can read diagnostics.
+Command-line errors return this envelope:
+
+```json
+{
+  "error": { "code": "usage-error", "message": "..." },
+  "exitCode": 2
+}
+```
+
+Execution errors use the same shape with `code: "execution-error"` and
+`exitCode: 1`. The package also exposes `tapp` and `tapp-cli`; use `myriad-tapp`
+in automation to keep the selected binary explicit.
+
+## Checks
+
+- strict Manifest fields including Widget settings/refresh, AI, events, Agent and Data Exchange;
+- declared paths, extensions, missing files, Agent schemas, i18n and asset quotas;
+- symlink containment: declared resources and auto-included `i18n/`, `page/`,
+  `schemas/` directories must be regular files inside the project root;
+- permission names and permissions inferred from static `Tapp.*` calls;
+- `Tapp.api("name")` declarations, the fixed HTTP method allow-list, and
+  HTTP/builtin API permissions;
+- literal `Tapp.assets.*("path")` references;
+- runtime surface consistency (`hasPage` resources, widgets ↔ `widget:register`);
+- headless capability profile: actions denied in background core;
+- `manifest.json` size, per-resource byte limits, and `.tapp` entry count and
+  package size limits.
+
+Dynamic property access and computed API names cannot be proven statically. They are
+reported as warnings or left to the backend/runtime permission checks.
+
+Generated editor assets under `src/generated/`:
+
+- `contract.json` — full offline contract (schema, limits, permissions, capabilities)
+- `manifest.schema.json` — JSON Schema for `manifest.json`
+- `capability-profiles.json` — Page/Widget/headless profile data
+- `tapp-sdk.d.ts` — sandbox `window.Tapp` types for editor tooling
+
+`init` copies `tapp-sdk.d.ts` into `types/` and adds a `jsconfig.json` + triple-slash
+reference so editors understand `Tapp.*` without a full npm SDK package. Those local
+editor files are not packed into `.tapp`.
+
+## Generated contract
+
+The committed contract combines the Rust Manifest schema and semantic rules
+from `crates/tapp-contract` (shared with backend install validation) with the
+runtime permission map and sandbox capability profiles:
+
+```bash
+cd tools/tapp-cli
+npm run sync-contract
+```
+
+Run this command after changing `crates/tapp-contract` (Manifest types or
+contract rules), `frontend/src/tapp/runtime/permissionConfig.ts`, or
+`frontend/src/tapp/runtime/sandbox/capabilityProfiles.ts`. Templates and ZIP
+packaging remain handwritten; validation consumes `src/generated/contract.json`.
+
+`sync-contract` is a repository-maintainer command. It is run by
+`prepublishOnly` before publishing and is not included in the published tarball;
+end users only consume the committed generated contract.
+
+The generated contract has two layers:
+
+1. **Structure layer**: `crates/tapp-contract/src/manifest.rs` derives the JSON
+   Schema used for Manifest fields, nested objects, required fields and Rust
+   enum values.
+2. **Semantic layer**: `crates/tapp-contract/src/contract_rules.rs` exports
+   limits, path/extensions, conditional field rules, API/event/Data Exchange
+   relationships and permission requirements. Backend install validation reuses
+   the same constants, so `check` results cannot drift from the installer.
+
+`init` starter files and `pack` ZIP mechanics are intentionally handwritten;
+everything else in the CLI reads the generated contract rather than copying
+backend values.
+
+## Publishing
+
+From this directory, a release check runs the contract exporter and the complete
+test suite before npm accepts the publish:
+
+```bash
+npm run pack:check
+npm publish
+```
+
+Publishing requires an authenticated npm account with access to the `@myriad`
+scope. The package declares public scoped access in `publishConfig`.

--- a/tapp-cli/bin/myriad-tapp.mjs
+++ b/tapp-cli/bin/myriad-tapp.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { runCli } from '../src/cli.mjs'
+
+try {
+  process.exitCode = await runCli(process.argv.slice(2))
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (process.argv.slice(2).includes('--json')) {
+    console.log(JSON.stringify({ error: { code: 'execution-error', message }, exitCode: 1 }))
+  } else {
+    console.error(`myriad-tapp: ${message}`)
+  }
+  process.exitCode = 1
+}

--- a/tapp-cli/package-lock.json
+++ b/tapp-cli/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "@myriad/tapp-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@myriad/tapp-cli",
+      "version": "0.1.0",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "myriad-tapp": "bin/myriad-tapp.mjs",
+        "tapp": "bin/myriad-tapp.mjs",
+        "tapp-cli": "bin/myriad-tapp.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/tapp-cli/package.json
+++ b/tapp-cli/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@myriad/tapp-cli",
+  "version": "0.1.0",
+  "description": "Offline project tooling for Myriad Tapps",
+  "type": "module",
+  "files": [
+    "bin",
+    "src",
+    "README.md"
+  ],
+  "bin": {
+    "myriad-tapp": "bin/myriad-tapp.mjs",
+    "tapp": "bin/myriad-tapp.mjs",
+    "tapp-cli": "bin/myriad-tapp.mjs"
+  },
+  "scripts": {
+    "sync-contract": "node ./scripts/sync-contract.mjs",
+    "sync-generated": "npm run sync-contract",
+    "test": "node --test",
+    "pack:check": "npm pack --dry-run",
+    "prepublishOnly": "npm run sync-contract && npm test"
+  },
+  "dependencies": {
+    "typescript": "^6.0.3"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "GPL-3.0-only",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/myriad-you/Myriad.git",
+    "directory": "tools/tapp-cli"
+  },
+  "homepage": "https://github.com/myriad-you/Myriad/tree/main/tools/tapp-cli",
+  "bugs": {
+    "url": "https://github.com/myriad-you/Myriad/issues"
+  }
+}

--- a/tapp-cli/scripts/capability-source.mjs
+++ b/tapp-cli/scripts/capability-source.mjs
@@ -1,0 +1,64 @@
+import ts from 'typescript'
+
+function unwrap(node) {
+  while (ts.isAsExpression(node) || ts.isSatisfiesExpression(node)) node = node.expression
+  return node
+}
+
+function variableInitializer(sourceFile, name) {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === name) {
+        return declaration.initializer
+      }
+    }
+  }
+  throw new Error(`Unable to locate ${name}`)
+}
+
+function literalProfiles(type) {
+  if (ts.isUnionTypeNode(type)) return type.types.flatMap(literalProfiles)
+  return ts.isLiteralTypeNode(type) && ts.isStringLiteral(type.literal)
+    ? [type.literal.text]
+    : []
+}
+
+function requireParseable(sourceFile) {
+  if (sourceFile.parseDiagnostics.length > 0) {
+    throw new Error('capabilityProfiles.ts contains TypeScript syntax errors')
+  }
+}
+
+export function parseCapabilitySource(source) {
+  const sourceFile = ts.createSourceFile(
+    'capabilityProfiles.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  requireParseable(sourceFile)
+  const denied = unwrap(variableInitializer(sourceFile, 'HEADLESS_DENIED_ACTIONS'))
+  if (!ts.isArrayLiteralExpression(denied)) {
+    throw new Error('HEADLESS_DENIED_ACTIONS must be an array literal')
+  }
+  const headlessDeniedActions = denied.elements.map((element) => {
+    const value = unwrap(element)
+    if (!ts.isStringLiteralLike(value)) throw new Error('HEADLESS_DENIED_ACTIONS must contain strings')
+    return value.text
+  })
+  if (headlessDeniedActions.length < 10) {
+    throw new Error('Capability profile parse produced unexpectedly few denied actions')
+  }
+
+  const profile = sourceFile.statements.find(
+    (statement) => ts.isTypeAliasDeclaration(statement) && statement.name.text === 'SandboxCapabilityProfile',
+  )
+  const profiles = profile ? literalProfiles(profile.type) : []
+  if (profiles.length === 0) {
+    throw new Error('Unable to locate SandboxCapabilityProfile literals')
+  }
+
+  return { profiles, headlessDeniedActions }
+}

--- a/tapp-cli/scripts/permission-source.mjs
+++ b/tapp-cli/scripts/permission-source.mjs
@@ -1,0 +1,79 @@
+import ts from 'typescript'
+
+function initializer(sourceFile, name) {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === name) {
+        return declaration.initializer
+      }
+    }
+  }
+  throw new Error(`Unable to locate ${name}`)
+}
+
+function unwrap(node) {
+  while (ts.isAsExpression(node) || ts.isSatisfiesExpression(node)) node = node.expression
+  return node
+}
+
+function stringValue(node) {
+  node = unwrap(node)
+  return ts.isStringLiteralLike(node) ? node.text : undefined
+}
+
+function propertyName(node) {
+  return ts.isIdentifier(node) || ts.isStringLiteralLike(node) ? node.text : undefined
+}
+
+function requireParseable(sourceFile) {
+  if (sourceFile.parseDiagnostics.length > 0) {
+    throw new Error('permissionConfig.ts contains TypeScript syntax errors')
+  }
+}
+
+export function parsePermissionSource(source) {
+  const sourceFile = ts.createSourceFile(
+    'permissionConfig.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  )
+  requireParseable(sourceFile)
+  const levels = unwrap(initializer(sourceFile, 'PERMISSION_LEVELS'))
+  if (!ts.isObjectLiteralExpression(levels)) {
+    throw new Error('PERMISSION_LEVELS must be an object literal')
+  }
+
+  const permissionLevels = {}
+  for (const property of levels.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    const name = propertyName(property.name)
+    const value = stringValue(property.initializer)
+    if (name && value !== undefined) permissionLevels[name] = value
+  }
+
+  const permissionMap = unwrap(initializer(sourceFile, 'PERMISSION_MAP'))
+  if (!ts.isNewExpression(permissionMap) || !ts.isIdentifier(permissionMap.expression) || permissionMap.expression.text !== 'Map') {
+    throw new Error('PERMISSION_MAP must be a Map literal')
+  }
+  const entries = unwrap(permissionMap.arguments?.[0])
+  if (!ts.isArrayLiteralExpression(entries)) {
+    throw new Error('PERMISSION_MAP must contain an entry array')
+  }
+
+  const actions = {}
+  for (const entry of entries.elements) {
+    if (!ts.isArrayLiteralExpression(entry) || entry.elements.length !== 2) continue
+    const action = stringValue(entry.elements[0])
+    const permission = stringValue(entry.elements[1])
+    if (action !== undefined && permission !== undefined) actions[action] = permission
+  }
+
+  if (Object.keys(permissionLevels).length < 30 || Object.keys(actions).length < 150) {
+    throw new Error('Permission catalog parse produced unexpectedly few entries')
+  }
+
+  return { permissionLevels, actions }
+}

--- a/tapp-cli/scripts/sdk-dts.mjs
+++ b/tapp-cli/scripts/sdk-dts.mjs
@@ -1,0 +1,274 @@
+/**
+ * Generate sandbox-facing tapp-sdk.d.ts from the action permission catalog.
+ * High-traffic namespaces use curated signatures; remaining namespaces are
+ * projected generically from PERMISSION_MAP so the file stays complete.
+ */
+
+function indent(level) {
+  return '  '.repeat(level)
+}
+
+function buildTree(actions) {
+  const tree = {}
+  for (const action of Object.keys(actions).sort()) {
+    const parts = action.split('.')
+    if (parts.length < 2) continue
+    let cursor = tree
+    for (let i = 0; i < parts.length - 1; i += 1) {
+      const part = parts[i]
+      cursor[part] ||= { methods: {}, children: {} }
+      if (i === parts.length - 2) {
+        cursor[part].methods[parts[i + 1]] = actions[action]
+      } else {
+        cursor = cursor[part].children
+      }
+    }
+  }
+  return tree
+}
+
+function renderNamespace(name, node, level = 1) {
+  const lines = []
+  const pad = indent(level)
+  lines.push(`${pad}${name}: {`)
+  for (const method of Object.keys(node.methods).sort()) {
+    const permission = node.methods[method]
+    const note =
+      permission && permission !== 'public' ? ` // permission: ${permission}` : ''
+    lines.push(
+      `${indent(level + 1)}${method}(...args: unknown[]): Promise<unknown>${note}`,
+    )
+  }
+  for (const child of Object.keys(node.children).sort()) {
+    lines.push(...renderNamespace(child, node.children[child], level + 1))
+  }
+  lines.push(`${pad}}`)
+  return lines
+}
+
+function localMembers() {
+  return `  lifecycle: {
+    onReady(callback: () => void | Promise<void>): void
+    onDestroy(callback: () => void): void
+    onPause(callback: () => void): void
+    onResume(callback: () => void): void
+    getInfo(): { id: string; version: string; name: string; permissions: string[]; sandboxed: true }
+  }
+
+  i18n: {
+    t(key: string, params?: Record<string, unknown>): string
+    getLocale(): string
+    getAll(): Record<string, unknown>
+  }
+
+  storage: {
+    get(key: string): Promise<unknown>
+    set(key: string, value: unknown): Promise<unknown>
+    remove(key: string): Promise<unknown>
+    keys(): Promise<string[]>
+    getAll(): Promise<Record<string, unknown>>
+    clear(): Promise<unknown>
+    usage(): Promise<unknown>
+    onChanged(callback: (event: { key?: string; operation?: string }) => void): () => void
+  }
+
+  settings: {
+    get(key: string): Promise<unknown>
+    set(key: string, value: unknown): Promise<unknown>
+    getAll(): Promise<Record<string, unknown>>
+  }
+
+  ui: {
+    setTitle(title: string): Promise<unknown>
+    getTheme(): Promise<unknown>
+    onThemeChange(callback: (theme: unknown) => void): () => void
+    getPrimaryColor(): Promise<unknown>
+    onPrimaryColorChange(callback: (color: unknown) => void): () => void
+    getLocale(): Promise<unknown>
+    onLocaleChange(callback: (locale: unknown) => void): () => void
+    showNotification(options: unknown): Promise<unknown>
+    confirm(message: string): Promise<boolean>
+    requestFullscreen(): Promise<unknown>
+    exitFullscreen(): Promise<unknown>
+    fullscreen: {
+      request(): Promise<unknown>
+      exit(): Promise<unknown>
+      toggle(): Promise<unknown>
+      isFullscreen(): Promise<boolean>
+    }
+  }
+
+  api: {
+    (name: string, params?: unknown): Promise<unknown>
+    list(): Promise<unknown>
+  }
+
+  assets: {
+    list(): Promise<unknown>
+    get(path: string): Promise<unknown>
+    getUrl(path: string): Promise<{ url: string; mimeType?: string; size?: number; path?: string }>
+    getArrayBuffer(path: string): Promise<{ path: string; mimeType?: string; size?: number; buffer: ArrayBuffer }>
+    revoke(url: string): void
+    revokeAll(): void
+  }
+
+  dataExchange: {
+    request(request: unknown): Promise<unknown>
+    provide(exportId: string, handler: (request: unknown) => unknown | Promise<unknown>): Promise<() => void>
+  }
+
+  event: {
+    publish(request: unknown): Promise<unknown>
+    on(topic: string, callback: (event: unknown) => void): () => void
+  }
+
+  agent: {
+    onInteraction(
+      type: string,
+      callback: (interaction: {
+        type: string
+        interactionId: string
+        accept(): Promise<unknown>
+        submitResult(result: unknown): Promise<unknown>
+        reject(reason?: unknown): Promise<unknown>
+        requestIntent(request: unknown): Promise<unknown>
+        [key: string]: unknown
+      }) => void,
+    ): () => void
+  }
+
+  media: {
+    play(): Promise<unknown>
+    pause(): Promise<unknown>
+    next(): Promise<unknown>
+    prev(): Promise<unknown>
+    seek(position: unknown): Promise<unknown>
+    setVolume(volume: unknown): Promise<unknown>
+    setMode(mode: unknown): Promise<unknown>
+    mute(): Promise<unknown>
+    unmute(): Promise<unknown>
+    getStatus(): Promise<unknown>
+    getPlaylist(): Promise<unknown>
+    getSpectrum(): Promise<unknown>
+    getLyrics(options?: unknown): Promise<unknown>
+    getBeatGrid(): Promise<unknown>
+    playTrack(id: unknown, index?: unknown): Promise<unknown>
+    jumpToIndex(index: unknown): Promise<unknown>
+    loadNeteasePlaylist(playlistId: unknown): Promise<unknown>
+    getSkipVip(): Promise<unknown>
+    setSkipVip(value: unknown): Promise<unknown>
+    onStateChange(callback: (state: unknown) => void): () => void
+    onProgress(callback: (progress: unknown) => void): () => void
+  }
+
+  ai: {
+    tasks: {
+      create(request: unknown): Promise<unknown>
+      get(taskId: string): Promise<unknown>
+      cancel(taskId: string): Promise<unknown>
+      usage(): Promise<unknown>
+      subscribe(
+        taskId: string,
+        callback: (event: { event: unknown; data: unknown }) => void,
+      ): Promise<() => void>
+    }
+  }
+
+  scheduler: {
+    register(options: unknown): Promise<unknown>
+    unregister(taskId: string): Promise<unknown>
+    list(): Promise<unknown>
+    get(taskId: string): Promise<unknown>
+    enable(taskId: string): Promise<unknown>
+    disable(taskId: string): Promise<unknown>
+    trigger(taskId: string): Promise<unknown>
+    onTask(
+      taskId: string,
+      callback: (payload: unknown, event: unknown) => unknown | Promise<unknown>,
+    ): () => void
+  }
+
+  widgets: Record<
+    string,
+    {
+      render(
+        container: HTMLElement,
+        props: {
+          size?: string
+          theme?: string
+          settings?: Record<string, unknown>
+          [key: string]: unknown
+        },
+      ): void | Promise<void>
+    }
+  >
+
+  pages: Record<
+    string,
+    {
+      render(container: HTMLElement): void | Promise<void>
+    }
+  >
+
+  dom: {
+    setAttribute(element: Element, name: string, value: string): void
+    [key: string]: unknown
+  }
+`
+}
+
+/**
+ * @param {{ actions: Record<string, string>, headlessDeniedActions?: string[] }} catalog
+ */
+export function generateTappSdkDts(catalog) {
+  const actions = catalog.actions || {}
+  const tree = buildTree(actions)
+  const denied = [...(catalog.headlessDeniedActions || [])].sort()
+  const curated = new Set([
+    'lifecycle',
+    'storage',
+    'settings',
+    'ui',
+    'api',
+    'assets',
+    'dataExchange',
+    'event',
+    'agent',
+    'media',
+    'ai',
+    'scheduler',
+  ])
+
+  const genericLines = []
+  for (const name of Object.keys(tree).sort()) {
+    if (curated.has(name)) continue
+    genericLines.push(...renderNamespace(name, tree[name], 1))
+  }
+
+  const deniedComment =
+    denied.length > 0
+      ? `\n * Headless-denied Bridge actions: ${denied.join(', ')}\n *`
+      : ''
+
+  return `/**
+ * Myriad Tapp sandbox SDK (window.Tapp).
+ * Generated from the runtime permission catalog. Call sites still need
+ * matching Manifest permissions and a handler in the current sandbox profile.
+ *${deniedComment}
+ * Do not edit by hand — run: npm run sync-contract
+ */
+
+export interface TappSdk {
+${localMembers()}
+${genericLines.join('\n')}
+}
+
+declare const Tapp: TappSdk
+
+interface Window {
+  Tapp: TappSdk
+}
+
+export {}
+`
+}

--- a/tapp-cli/scripts/sync-contract.mjs
+++ b/tapp-cli/scripts/sync-contract.mjs
@@ -1,0 +1,85 @@
+import { execFile } from 'node:child_process'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { promisify } from 'node:util'
+import { fileURLToPath } from 'node:url'
+import { parseCapabilitySource } from './capability-source.mjs'
+import { parsePermissionSource } from './permission-source.mjs'
+import { generateTappSdkDts } from './sdk-dts.mjs'
+
+const execFileAsync = promisify(execFile)
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '../../..')
+const permissionSourcePath = resolve(
+  repoRoot,
+  'frontend/src/tapp/runtime/permissionConfig.ts',
+)
+const capabilitySourcePath = resolve(
+  repoRoot,
+  'frontend/src/tapp/runtime/sandbox/capabilityProfiles.ts',
+)
+const exporterManifestPath = resolve(
+  repoRoot,
+  'tools/tapp-contract-export/Cargo.toml',
+)
+const generatedDir = resolve(here, '../src/generated')
+const outputPath = resolve(generatedDir, 'contract.json')
+const schemaPath = resolve(generatedDir, 'manifest.schema.json')
+const capabilityPath = resolve(generatedDir, 'capability-profiles.json')
+const sdkDtsPath = resolve(generatedDir, 'tapp-sdk.d.ts')
+
+const { stdout } = await execFileAsync(
+  'cargo',
+  [
+    'run',
+    '--quiet',
+    '--locked',
+    '--manifest-path',
+    exporterManifestPath,
+  ],
+  { cwd: repoRoot, maxBuffer: 4 * 1024 * 1024 },
+)
+const backendContract = JSON.parse(stdout)
+const permissionSource = await readFile(permissionSourcePath, 'utf8')
+const { permissionLevels, actions } = parsePermissionSource(permissionSource)
+const capabilitySource = await readFile(capabilitySourcePath, 'utf8')
+const capabilities = parseCapabilitySource(capabilitySource)
+
+const contract = {
+  generatedFrom: [
+    'crates/tapp-contract/src/manifest.rs',
+    'crates/tapp-contract/src/contract_rules.rs',
+    'frontend/src/tapp/runtime/permissionConfig.ts',
+    'frontend/src/tapp/runtime/sandbox/capabilityProfiles.ts',
+  ],
+  ...backendContract,
+  permissions: { permissionLevels, actions },
+  capabilities,
+}
+
+// Keep CLI-facing metadata after the spread so backend schema fields cannot replace it.
+const manifestSchema = {
+  ...backendContract.schema,
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://myriad.local/tapp/manifest.schema.json',
+  title: 'Myriad Tapp Manifest',
+  description:
+    'Generated from backend TappManifest schema. Semantic limits and permission rules live in contract.json.',
+}
+
+const sdkDts = generateTappSdkDts({
+  actions,
+  headlessDeniedActions: capabilities.headlessDeniedActions,
+})
+
+await mkdir(generatedDir, { recursive: true })
+await writeFile(outputPath, `${JSON.stringify(contract, null, 2)}\n`)
+await writeFile(schemaPath, `${JSON.stringify(manifestSchema, null, 2)}\n`)
+await writeFile(capabilityPath, `${JSON.stringify(capabilities, null, 2)}\n`)
+await writeFile(sdkDtsPath, sdkDts.endsWith('\n') ? sdkDts : `${sdkDts}\n`)
+console.log(
+  `Wrote TApp contract with ${Object.keys(actions).length} actions, ${Object.keys(permissionLevels).length} permissions, and ${capabilities.headlessDeniedActions.length} headless-denied actions to ${outputPath}`,
+)
+console.log(`Wrote Manifest JSON Schema to ${schemaPath}`)
+console.log(`Wrote capability profiles to ${capabilityPath}`)
+console.log(`Wrote sandbox SDK types to ${sdkDtsPath}`)

--- a/tapp-cli/src/cli.mjs
+++ b/tapp-cli/src/cli.mjs
@@ -1,0 +1,267 @@
+import { createProject, inspectProject, packProject } from './project.mjs'
+import { readFile } from 'node:fs/promises'
+
+const { version: VERSION } = JSON.parse(
+  await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+)
+
+const COMMANDS = {
+  init: {
+    usage: 'myriad-tapp init [directory] [options]',
+    summary: 'Create a Tapp project. directory defaults to the current directory.',
+    options: [
+      '--type <page|widget|both>  Starter surface; defaults to page.',
+      '--id <id>                  Manifest id.',
+      '--name <name>              Display name.',
+      '--author <name>            Author name.',
+      '--force                    Allow a non-empty target directory.',
+      '--json                     stdout is a single JSON object.',
+    ],
+    allowedOptions: new Set(['type', 'id', 'name', 'author', 'force', 'json']),
+    success: 'Project was created and passes validation.',
+  },
+  check: {
+    usage: 'myriad-tapp check [directory] [--json]',
+    summary: 'Validate a Tapp project. directory defaults to the current directory.',
+    options: ['--json  stdout is a single JSON object containing the inspection report.'],
+    allowedOptions: new Set(['json']),
+    success: 'Validation succeeded.',
+  },
+  permissions: {
+    usage: 'myriad-tapp permissions [directory] [--json]',
+    summary: 'List declared and statically inferred permissions.',
+    options: ['--json  stdout is a single JSON object containing the inspection report.'],
+    allowedOptions: new Set(['json']),
+    success: 'Permissions were inspected without validation errors.',
+  },
+  pack: {
+    usage: 'myriad-tapp pack [directory] [--out file.tapp] [--json]',
+    summary: 'Validate and package a Tapp project. directory defaults to the current directory.',
+    options: [
+      '-o, --out <path>  Archive path; defaults to dist/{manifest.id}.tapp.',
+      '--json             stdout is a single JSON object containing the package result.',
+    ],
+    allowedOptions: new Set(['out', 'json']),
+    success: 'Validation succeeded and the archive was written.',
+  },
+}
+
+const HELP = `Myriad Tapp CLI
+
+Usage:
+  myriad-tapp init [directory] [options]
+  myriad-tapp check [directory] [--json]
+  myriad-tapp permissions [directory] [--json]
+  myriad-tapp pack [directory] [--out file.tapp] [--json]
+
+Run "myriad-tapp <command> --help" for command options, JSON output, and exit status.
+
+Global options:
+  -h, --help     Show help.
+  -v, --version  Show the CLI version.
+`
+
+class UsageError extends Error {}
+
+function commandHelp(command) {
+  const spec = COMMANDS[command]
+  if (!spec) return HELP.trimEnd()
+  return `Myriad Tapp CLI
+
+Usage:
+  ${spec.usage}
+
+${spec.summary}
+
+Options:
+  ${spec.options.join('\n  ')}
+  -h, --help          Show this command help.
+
+Exit status:
+  0  ${spec.success}
+  1  Project validation or packaging failed.
+  2  Command-line usage error.`
+}
+
+function parseArguments(args) {
+  const options = {}
+  const positional = []
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index]
+    if (value === '--json') options.json = true
+    else if (value === '--force') options.force = true
+    else if (value === '--help' || value === '-h') options.help = true
+    else if (value === '--version' || value === '-v') options.version = true
+    else if (['--type', '--id', '--name', '--author', '--out', '-o'].includes(value)) {
+      const next = args[index + 1]
+      if (!next || next.startsWith('-')) throw new UsageError(`${value} requires a value`)
+      options[value === '-o' ? 'out' : value.slice(2)] = next
+      index += 1
+    } else if (value.startsWith('-')) {
+      throw new UsageError(`Unknown option: ${value}`)
+    } else positional.push(value)
+  }
+  return { options, positional }
+}
+
+function validateCommand(command, options, positional) {
+  const spec = COMMANDS[command]
+  if (!spec) return
+  if (positional.length > 1) throw new UsageError(`${command} accepts at most one directory`)
+  for (const option of Object.keys(options)) {
+    if (option === 'help' || option === 'version') continue
+    if (!spec.allowedOptions.has(option)) {
+      throw new UsageError(`--${option} is only valid with ${Object.entries(COMMANDS)
+        .filter(([, value]) => value.allowedOptions.has(option))
+        .map(([name]) => name)
+        .join(' or ')}`)
+    }
+  }
+}
+
+function printUsageError(io, error, json) {
+  const message = error instanceof Error ? error.message : String(error)
+  if (json) io.stdout(JSON.stringify({ error: { code: 'usage-error', message }, exitCode: 2 }))
+  else io.stderr(`myriad-tapp: ${message}`)
+  return 2
+}
+
+function formatLocation(item) {
+  return `${item.file || 'manifest.json'}${item.line ? `:${item.line}:${item.column || 1}` : ''}`
+}
+
+function printDiagnostics(report, io) {
+  for (const item of report.diagnostics) {
+    io.stdout(
+      `${formatLocation(item)} ${item.severity.toUpperCase()} ${item.code} ${item.message}`,
+    )
+  }
+  const errors = report.diagnostics.filter(({ severity }) => severity === 'error').length
+  const warnings = report.diagnostics.filter(({ severity }) => severity === 'warning').length
+  io.stdout(
+    `${errors === 0 ? 'OK' : 'FAILED'} ${report.manifest?.id || report.root}: ${errors} error(s), ${warnings} warning(s)`,
+  )
+}
+
+function printPermissions(report, io) {
+  const declared = new Map(
+    report.permissions.declared.map((entry) => [entry.permission, entry]),
+  )
+  const required = new Map(
+    report.permissions.required.map((entry) => [entry.permission, entry]),
+  )
+  const names = [...new Set([...declared.keys(), ...required.keys()])].sort()
+  if (names.length === 0) {
+    io.stdout('No permissions declared or inferred.')
+    return
+  }
+  for (const permission of names) {
+    const request = declared.get(permission)
+    const need = required.get(permission)
+    const state = request ? (need ? 'declared+used' : 'declared') : 'MISSING'
+    const level = request?.level || need?.level || 'unknown'
+    const reasons = need?.reasons?.join('; ') || 'manifest declaration only'
+    io.stdout(`${state.padEnd(13)} ${level.padEnd(10)} ${permission}  ${reasons}`)
+  }
+}
+
+function defaultIo() {
+  return {
+    stdout: (line) => console.log(line),
+    stderr: (line) => console.error(line),
+  }
+}
+
+export async function runCli(argv, providedIo = defaultIo()) {
+  const io = providedIo
+  const command = argv[0]
+  let options
+  let positional
+  try {
+    ;({ options, positional } = parseArguments(argv.slice(command ? 1 : 0)))
+    validateCommand(command, options, positional)
+  } catch (error) {
+    return printUsageError(io, error, argv.includes('--json'))
+  }
+
+  if (
+    !command ||
+    options.help ||
+    command === 'help' ||
+    command === '--help' ||
+    command === '-h'
+  ) {
+    io.stdout(commandHelp(command === 'help' ? positional[0] : command))
+    return 0
+  }
+  if (
+    options.version ||
+    command === 'version' ||
+    command === '--version' ||
+    command === '-v'
+  ) {
+    io.stdout(VERSION)
+    return 0
+  }
+
+  if (command === 'init') {
+    const result = await createProject(positional[0] || '.', options)
+    const report = await inspectProject(result.root)
+    if (options.json) io.stdout(JSON.stringify({ result, report }, null, 2))
+    else {
+      io.stdout(`Created ${result.type} Tapp at ${result.root}`)
+      printDiagnostics(report, io)
+    }
+    return report.diagnostics.some(({ severity }) => severity === 'error') ? 1 : 0
+  }
+
+  if (command === 'check' || command === 'permissions') {
+    const report = await inspectProject(positional[0] || '.')
+    if (options.json) io.stdout(JSON.stringify(report, null, 2))
+    else if (command === 'permissions') printPermissions(report, io)
+    else printDiagnostics(report, io)
+    return report.diagnostics.some(({ severity }) => severity === 'error') ? 1 : 0
+  }
+
+  if (command === 'pack') {
+    try {
+      const result = await packProject(positional[0] || '.', options.out)
+      if (options.json) {
+        io.stdout(
+          JSON.stringify(
+            {
+              outputPath: result.outputPath,
+              sizeBytes: result.sizeBytes,
+              entries: result.entries,
+              diagnostics: result.report.diagnostics,
+            },
+            null,
+            2,
+          ),
+        )
+      } else {
+        printDiagnostics(result.report, io)
+        io.stdout(
+          `Packed ${result.entries} file(s), ${result.sizeBytes} bytes -> ${result.outputPath}`,
+        )
+      }
+      return 0
+    } catch (error) {
+      if (error.report) {
+        if (options.json) io.stdout(JSON.stringify(error.report, null, 2))
+        else printDiagnostics(error.report, io)
+        return 1
+      }
+      throw error
+    }
+  }
+
+  if (options.json) {
+    return printUsageError(io, new UsageError(`Unknown command: ${command}`), true)
+  }
+  io.stderr(`Unknown command: ${command}`)
+  io.stderr('Run myriad-tapp --help for usage.')
+  return 2
+}
+
+export { HELP }

--- a/tapp-cli/src/generated/capability-profiles.json
+++ b/tapp-cli/src/generated/capability-profiles.json
@@ -1,0 +1,41 @@
+{
+  "profiles": [
+    "page",
+    "widget",
+    "headless"
+  ],
+  "headlessDeniedActions": [
+    "ui.setTitle",
+    "ui.confirm",
+    "ui.requestFullscreen",
+    "ui.exitFullscreen",
+    "ui.toggleFullscreen",
+    "ui.isFullscreen",
+    "widget.register",
+    "widget.unregister",
+    "widget.listRegistered",
+    "widget.updateConfig",
+    "tappList.list",
+    "tappList.get",
+    "tappList.getRecent",
+    "tappList.getInstallPackage",
+    "tappList.resolveStoreSource",
+    "tappList.install",
+    "tappList.uninstall",
+    "tappList.start",
+    "tappList.stop",
+    "tappList.export",
+    "component.registerTheme",
+    "component.registerAgent",
+    "component.unregister",
+    "component.list",
+    "shortcut.register",
+    "shortcut.unregister",
+    "shortcut.list",
+    "dynamicContent.set",
+    "dynamicContent.update",
+    "dynamicContent.get",
+    "dynamicContent.remove",
+    "file.download"
+  ]
+}

--- a/tapp-cli/src/generated/contract.json
+++ b/tapp-cli/src/generated/contract.json
@@ -1,0 +1,1440 @@
+{
+  "generatedFrom": [
+    "crates/tapp-contract/src/manifest.rs",
+    "crates/tapp-contract/src/contract_rules.rs",
+    "frontend/src/tapp/runtime/permissionConfig.ts",
+    "frontend/src/tapp/runtime/sandbox/capabilityProfiles.ts"
+  ],
+  "limits": {
+    "agentIntents": 16,
+    "agentInteractions": 32,
+    "agentSchemaBytes": 65536,
+    "aiContextSources": 4,
+    "aiOperations": 4,
+    "aiOutputFormats": 3,
+    "apiCacheTtlSeconds": 86400,
+    "apiInjectAliases": 32,
+    "apiInjectTemplateLength": 2048,
+    "archiveBytes": 26214400,
+    "archiveFiles": 512,
+    "archiveUncompressedBytes": 104857600,
+    "assetBytes": 5242880,
+    "assets": 64,
+    "assetsTotalBytes": 20971520,
+    "authorEmailLength": 320,
+    "backgroundRequirements": 16,
+    "dataExchangeDeclarations": 32,
+    "dataExchangeDescriptionLength": 500,
+    "dataExchangeIdLength": 128,
+    "dataExchangeRecords": 10000,
+    "dataExchangeResponseBytes": 524288,
+    "dataExchangeSchemaBytes": 65536,
+    "eventTopics": 100,
+    "httpUrlLength": 2048,
+    "i18nFiles": 32,
+    "i18nResourceBytes": 1048576,
+    "inlineSchemaDepth": 32,
+    "localeTagLength": 35,
+    "manifestBytes": 262144,
+    "pageModules": 64,
+    "resourceBytes": 26214400,
+    "resourcePathLength": 256,
+    "settingLabelLength": 255,
+    "settingOptionValueLength": 255,
+    "settingOptions": 100,
+    "storageKeyLength": 256,
+    "tappApis": 64,
+    "tappDescriptionLength": 2000,
+    "tappIconLength": 2048,
+    "tappIconSvgBytes": 65536,
+    "tappIdLength": 128,
+    "tappLocales": 32,
+    "tappNameLength": 255,
+    "tappPermissions": 64,
+    "tappSettings": 64,
+    "widgetRefreshIntervalMaxSeconds": 86400,
+    "widgetRefreshIntervalMinSeconds": 15,
+    "widgetSizes": 10,
+    "widgets": 64
+  },
+  "patterns": {
+    "localeTag": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{1,8})*$",
+    "namedValue": "^[A-Za-z0-9._-]+$",
+    "safeComponent": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+    "semver": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$",
+    "storageKey": "^[A-Za-z0-9_.:-]+$",
+    "themeColor": "^#[0-9A-Fa-f]{6}$"
+  },
+  "rules": {
+    "agentIntents": [
+      "ui.open",
+      "report.create",
+      "dataExchange.request"
+    ],
+    "agentSchemaFields": [
+      "inputSchema",
+      "resultSchema"
+    ],
+    "aiBuiltinOutputFormat": "text",
+    "aiContextPermissionRules": {
+      "platform": "platform:read",
+      "report": "report:read"
+    },
+    "aiOperationOutputRules": {
+      "image": "image"
+    },
+    "aiOperationPermissions": {
+      "analyze": "ai:analyze",
+      "chat": "ai:chat",
+      "generate": "ai:generate",
+      "image": "ai:image"
+    },
+    "apiBuiltinAiOperations": {
+      "ai:chat": "chat",
+      "ai:generate": "generate"
+    },
+    "apiBuiltinPermissions": {
+      "ai:chat": "ai:chat",
+      "ai:generate": "ai:generate"
+    },
+    "apiBuiltins": [
+      "geo",
+      "ai:chat",
+      "ai:generate"
+    ],
+    "apiInjectReservedPrefixes": [
+      "user.",
+      "geo.",
+      "secrets.",
+      "params."
+    ],
+    "apiTypes": [
+      "http",
+      "builtin"
+    ],
+    "assetDirectory": "assets",
+    "assetForbiddenExtensions": [
+      ".js",
+      ".html"
+    ],
+    "assetLiteralMethods": [
+      "get",
+      "getUrl",
+      "getArrayBuffer"
+    ],
+    "backgroundRequirements": [
+      "media",
+      "sync",
+      "notification",
+      "scheduler",
+      "event-listener",
+      "realtime"
+    ],
+    "builtinApiType": "builtin",
+    "cssModes": [
+      "unified",
+      "separated"
+    ],
+    "dataExchangeDirections": {
+      "exports": "export",
+      "imports": "import"
+    },
+    "defaultApiType": "http",
+    "defaultHttpMethod": "GET",
+    "eventPermissionRules": {
+      "publish": "event:publish",
+      "subscribe": "event:subscribe"
+    },
+    "eventSubscribePrefixes": [
+      "tapp.",
+      "system."
+    ],
+    "eventTopicPrefixes": {
+      "publish": [
+        "tapp.{id}."
+      ],
+      "subscribe": [
+        "tapp.",
+        "system."
+      ]
+    },
+    "httpApiPermission": "network:fetch",
+    "httpApiType": "http",
+    "httpMethods": [
+      "GET",
+      "HEAD",
+      "POST",
+      "PUT",
+      "DELETE",
+      "CONNECT",
+      "OPTIONS",
+      "TRACE",
+      "PATCH"
+    ],
+    "httpOnlyApiFields": [
+      "endpoint",
+      "headers",
+      "body",
+      "spoof",
+      "inject"
+    ],
+    "httpUrlSchemes": [
+      "http",
+      "https"
+    ],
+    "inlineSchemaRootKeys": [
+      "type",
+      "properties",
+      "enum",
+      "const"
+    ],
+    "manifestResourceFields": {
+      "main": "main",
+      "pageStyles": "pageStyles",
+      "pageTemplate": "pageTemplate",
+      "styles": "styles",
+      "widgetStyles": "widgetStyles"
+    },
+    "packageJsonObjectDirectories": [
+      "i18n"
+    ],
+    "packageResourceByteLimits": {
+      "i18n": "i18nResourceBytes"
+    },
+    "packageResourceDirectories": [
+      "i18n",
+      "page",
+      "schemas"
+    ],
+    "packageResourceExtensions": {
+      "i18n": ".json",
+      "page": ".js",
+      "schemas": ".json"
+    },
+    "packageResourceFileLimits": {
+      "i18n": "i18nFiles"
+    },
+    "pageModuleDirectory": "page",
+    "protocolVersion": 2,
+    "requiredManifestFields": [
+      "category"
+    ],
+    "resourceExtensions": {
+      "agentSchema": ".json",
+      "i18n": ".json",
+      "main": ".js",
+      "pageModule": ".js",
+      "pageStyles": ".css",
+      "pageTemplate": ".html",
+      "styles": ".css",
+      "widgetStyles": ".css",
+      "widgetTemplate": ".html"
+    },
+    "semverPrefixes": [
+      "v"
+    ],
+    "settingDefaultKinds": {
+      "color": "string",
+      "input": "string",
+      "number": "number",
+      "select": "option",
+      "toggle": "boolean"
+    },
+    "settingFieldTypes": {
+      "max": "number",
+      "min": "number",
+      "options": "select",
+      "placeholder": "input",
+      "step": "number"
+    },
+    "settingTypes": [
+      "toggle",
+      "select",
+      "input",
+      "number",
+      "color"
+    ],
+    "sourceCodeExtensions": [
+      ".js",
+      ".mjs",
+      ".cjs",
+      ".ts",
+      ".tsx",
+      ".jsx"
+    ],
+    "sourceScanSkipDirectories": [
+      ".git",
+      "node_modules",
+      "dist",
+      "build",
+      "coverage"
+    ],
+    "tappCategoryAliases": [
+      "data-extension",
+      "platform",
+      "visualization",
+      "development",
+      "dev",
+      "games",
+      "entertainment",
+      "music",
+      "communication",
+      "demo",
+      "page",
+      "test",
+      "tool",
+      "tools",
+      "utilities",
+      "widget"
+    ],
+    "urlFields": [
+      "homepage",
+      "repository"
+    ],
+    "widgetCategoryAliases": [
+      "tool"
+    ],
+    "widgetManifestPermission": "widget:register",
+    "widgetRefreshModes": {
+      "event": "event",
+      "interval": "interval"
+    },
+    "widgetSizes": [
+      "1x1",
+      "1x2",
+      "2x1",
+      "2x2",
+      "2x3",
+      "3x2",
+      "4x1",
+      "4x2",
+      "2x4",
+      "3x3",
+      "4x4"
+    ]
+  },
+  "schema": {
+    "$defs": {
+      "TappAgentInteractionDef": {
+        "additionalProperties": false,
+        "properties": {
+          "inputSchema": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "resultSchema": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "TappAgentManifest": {
+        "additionalProperties": false,
+        "properties": {
+          "intents": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "interactions": {
+            "items": {
+              "$ref": "#/$defs/TappAgentInteractionDef"
+            },
+            "type": "array"
+          },
+          "protocolVersion": {
+            "format": "uint8",
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "protocolVersion",
+          "interactions"
+        ],
+        "type": "object"
+      },
+      "TappAiContextSource": {
+        "enum": [
+          "platform",
+          "report",
+          "profile",
+          "custom"
+        ],
+        "type": "string"
+      },
+      "TappAiManifest": {
+        "additionalProperties": false,
+        "properties": {
+          "contextSources": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/TappAiContextSource"
+            },
+            "type": "array"
+          },
+          "modelTier": {
+            "$ref": "#/$defs/TappAiModelTier"
+          },
+          "operations": {
+            "items": {
+              "$ref": "#/$defs/TappAiOperation"
+            },
+            "type": "array"
+          },
+          "outputFormats": {
+            "items": {
+              "$ref": "#/$defs/TappAiOutputFormat"
+            },
+            "type": "array"
+          },
+          "protocolVersion": {
+            "format": "uint8",
+            "maximum": 255,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "protocolVersion",
+          "operations",
+          "modelTier",
+          "outputFormats"
+        ],
+        "type": "object"
+      },
+      "TappAiModelTier": {
+        "enum": [
+          "standard",
+          "pro"
+        ],
+        "type": "string"
+      },
+      "TappAiOperation": {
+        "enum": [
+          "generate",
+          "analyze",
+          "chat",
+          "image"
+        ],
+        "type": "string"
+      },
+      "TappAiOutputFormat": {
+        "enum": [
+          "text",
+          "json",
+          "image"
+        ],
+        "type": "string"
+      },
+      "TappApiAccess": {
+        "enum": [
+          "public",
+          "protected"
+        ],
+        "type": "string"
+      },
+      "TappApiDef": {
+        "additionalProperties": false,
+        "properties": {
+          "access": {
+            "$ref": "#/$defs/TappApiAccess",
+            "default": "protected"
+          },
+          "body": true,
+          "builtin": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cacheTtl": {
+            "default": 0,
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "endpoint": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "inject": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "method": {
+            "default": "GET",
+            "enum": [
+              "GET",
+              "HEAD",
+              "POST",
+              "PUT",
+              "DELETE",
+              "CONNECT",
+              "OPTIONS",
+              "TRACE",
+              "PATCH"
+            ],
+            "type": "string"
+          },
+          "spoof": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": {
+            "default": "http",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TappAuthor": {
+        "additionalProperties": false,
+        "properties": {
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "TappCategory": {
+        "enum": [
+          "ai",
+          "data",
+          "developer",
+          "game",
+          "media",
+          "productivity",
+          "social",
+          "utility"
+        ],
+        "type": "string"
+      },
+      "TappDataExchangeManifest": {
+        "additionalProperties": false,
+        "properties": {
+          "exports": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/TappDataExport"
+            },
+            "type": "array"
+          },
+          "imports": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/TappDataImport"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TappDataExport": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "maxBytes": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "maxRecords": {
+            "default": null,
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "schema": {
+            "description": "Supported inline JSON Schema subset; remote and file `$ref` are denied."
+          }
+        },
+        "required": [
+          "id",
+          "schema",
+          "maxBytes"
+        ],
+        "type": "object"
+      },
+      "TappDataImport": {
+        "additionalProperties": false,
+        "properties": {
+          "exportId": {
+            "type": "string"
+          },
+          "tappId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tappId",
+          "exportId"
+        ],
+        "type": "object"
+      },
+      "TappEventsManifest": {
+        "additionalProperties": false,
+        "properties": {
+          "publish": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subscribe": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TappManifestLocaleEntry": {
+        "additionalProperties": false,
+        "description": "单个语言下的清单展示文案覆盖",
+        "properties": {
+          "description": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "TappSettingDef": {
+        "additionalProperties": false,
+        "properties": {
+          "defaultValue": true,
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "max": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "min": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "options": {
+            "items": {
+              "$ref": "#/$defs/TappSettingOption"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "placeholder": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "step": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "type"
+        ],
+        "type": "object"
+      },
+      "TappSettingOption": {
+        "additionalProperties": false,
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TappWidgetCategory": {
+        "enum": [
+          "stats",
+          "activity",
+          "visualization",
+          "utility",
+          "custom"
+        ],
+        "type": "string"
+      },
+      "TappWidgetDef": {
+        "additionalProperties": false,
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TappWidgetCategory"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "defaultSize": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "icon": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "refreshPolicy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TappWidgetRefreshPolicy"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "settings": {
+            "items": {
+              "$ref": "#/$defs/TappSettingDef"
+            },
+            "type": "array"
+          },
+          "sizes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "templates": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "defaultSize",
+          "sizes"
+        ],
+        "type": "object"
+      },
+      "TappWidgetRefreshMode": {
+        "enum": [
+          "event",
+          "interval"
+        ],
+        "type": "string"
+      },
+      "TappWidgetRefreshPolicy": {
+        "additionalProperties": false,
+        "properties": {
+          "intervalSeconds": {
+            "default": null,
+            "format": "uint32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "mode": {
+            "$ref": "#/$defs/TappWidgetRefreshMode"
+          },
+          "refreshOnVisible": {
+            "default": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TappAgentManifest"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "ai": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TappAiManifest"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "apis": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TappApiDef"
+        },
+        "default": null,
+        "type": [
+          "object",
+          "null"
+        ]
+      },
+      "assets": {
+        "items": {
+          "type": "string"
+        },
+        "type": [
+          "array",
+          "null"
+        ]
+      },
+      "author": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TappAuthor"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "backgroundRequirements": {
+        "default": null,
+        "items": {
+          "type": "string"
+        },
+        "type": [
+          "array",
+          "null"
+        ]
+      },
+      "category": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TappCategory"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "cssMode": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "dataExchange": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TappDataExchangeManifest"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "description": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "events": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TappEventsManifest"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "hasPage": {
+        "default": false,
+        "type": "boolean"
+      },
+      "homepage": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "icon": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "iconSvg": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "id": {
+        "type": "string"
+      },
+      "locales": {
+        "additionalProperties": {
+          "$ref": "#/$defs/TappManifestLocaleEntry"
+        },
+        "description": "展示文案的多语言覆盖：语言标签 → { name?, description? }",
+        "type": [
+          "object",
+          "null"
+        ]
+      },
+      "main": {
+        "type": "string"
+      },
+      "minSystemVersion": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "name": {
+        "type": "string"
+      },
+      "pageModules": {
+        "default": null,
+        "items": {
+          "type": "string"
+        },
+        "type": [
+          "array",
+          "null"
+        ]
+      },
+      "pageStyles": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "pageTemplate": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "permissions": {
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "repository": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "settings": {
+        "items": {
+          "$ref": "#/$defs/TappSettingDef"
+        },
+        "type": [
+          "array",
+          "null"
+        ]
+      },
+      "styles": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "themeColor": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "version": {
+        "type": "string"
+      },
+      "widgetStyles": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "widgets": {
+        "items": {
+          "$ref": "#/$defs/TappWidgetDef"
+        },
+        "type": [
+          "array",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "id",
+      "name",
+      "version",
+      "main"
+    ],
+    "title": "TappManifest",
+    "type": "object"
+  },
+  "permissions": {
+    "permissionLevels": {
+      "widget:register": "privileged",
+      "platform:read": "basic",
+      "platform:write": "privileged",
+      "platform:register": "privileged",
+      "ai:generate": "elevated",
+      "ai:analyze": "elevated",
+      "ai:chat": "elevated",
+      "ai:image": "elevated",
+      "report:read": "basic",
+      "report:write": "privileged",
+      "storage": "basic",
+      "ui:notification": "basic",
+      "ui:fullscreen": "basic",
+      "ui:theme": "basic",
+      "ui:confirm": "basic",
+      "network:fetch": "elevated",
+      "media:control": "elevated",
+      "media:read": "basic",
+      "media:audio": "basic",
+      "component:theme": "elevated",
+      "component:agent": "privileged",
+      "shortcut:register": "elevated",
+      "event:publish": "elevated",
+      "event:subscribe": "basic",
+      "scheduler:register": "elevated",
+      "speech:tts": "elevated",
+      "speech:asr": "elevated",
+      "tappList:read": "basic",
+      "tappList:manage": "privileged",
+      "brew:read": "basic",
+      "brew:write": "basic",
+      "brew:comment": "basic",
+      "brew:manage": "privileged",
+      "federation:read": "basic",
+      "federation:write": "basic",
+      "federation:message": "basic",
+      "federation:trust": "privileged",
+      "federation:files": "basic"
+    },
+    "actions": {
+      "lifecycle.ready": "public",
+      "lifecycle.error": "public",
+      "ui.getTheme": "public",
+      "ui.getPrimaryColor": "public",
+      "ui.getLocale": "public",
+      "ui.setTitle": "public",
+      "context.getApp": "public",
+      "context.getUser": "public",
+      "context.getPlayer": "public",
+      "context.getNavigation": "public",
+      "context.getSystem": "public",
+      "context.getGeo": "public",
+      "user.getRole": "public",
+      "user.isAdmin": "public",
+      "user.isGuest": "public",
+      "user.isLoggedIn": "public",
+      "user.getAllowedPermissionLevels": "public",
+      "user.canUsePermissionLevel": "public",
+      "component.list": "public",
+      "shortcut.list": "public",
+      "background.list": "public",
+      "background.has": "public",
+      "animation.getLevel": "public",
+      "animation.shouldAnimate": "public",
+      "animation.getConfig": "public",
+      "animation.getStaggerDelay": "public",
+      "dynamicContent.get": "public",
+      "api.execute": "public",
+      "api.list": "public",
+      "dataExchange.registerProvider": "public",
+      "dataExchange.unregisterProvider": "public",
+      "dataExchange.request": "public",
+      "dataExchange.respond": "public",
+      "widget.register": "widget:register",
+      "widget.unregister": "widget:register",
+      "widget.listRegistered": "widget:register",
+      "widget.updateConfig": "widget:register",
+      "widget.instanceSettings.update": "public",
+      "widget.invalidate": "public",
+      "tappList.list": "tappList:read",
+      "tappList.get": "tappList:read",
+      "tappList.getRecent": "tappList:read",
+      "tappList.getInstallPackage": "tappList:read",
+      "tappList.resolveStoreSource": "tappList:read",
+      "tappList.install": "tappList:manage",
+      "tappList.uninstall": "tappList:manage",
+      "tappList.start": "tappList:manage",
+      "tappList.stop": "tappList:manage",
+      "tappList.export": "tappList:manage",
+      "brewList.list": "brew:read",
+      "brewList.get": "brew:read",
+      "brewList.sources": "brew:read",
+      "brewList.categories": "brew:read",
+      "brewList.stats": "brew:read",
+      "brewList.discover": "brew:manage",
+      "brewList.exportOpml": "brew:read",
+      "brewList.markRead": "brew:write",
+      "brewList.markUnread": "brew:write",
+      "brewList.star": "brew:write",
+      "brewList.unstar": "brew:write",
+      "brewList.markAllRead": "brew:write",
+      "brewList.getComments": "brew:comment",
+      "brewList.createComment": "brew:comment",
+      "brewList.updateComment": "brew:comment",
+      "brewList.deleteComment": "brew:comment",
+      "brewList.getReplies": "brew:comment",
+      "brewList.createReply": "brew:comment",
+      "brewList.addSource": "brew:manage",
+      "brewList.updateSource": "brew:manage",
+      "brewList.deleteSource": "brew:manage",
+      "brewList.refreshSource": "brew:manage",
+      "brewList.importOpml": "brew:manage",
+      "brewList.createCategory": "brew:manage",
+      "brewList.deleteCategory": "brew:manage",
+      "platform.listEnabled": "platform:read",
+      "platform.getData": "platform:read",
+      "platform.getStats": "platform:read",
+      "platform.getDistribution": "platform:read",
+      "platform.addItem": "platform:write",
+      "platform.addItems": "platform:write",
+      "platform.registerPlatform": "platform:register",
+      "data.transform": "public",
+      "ai.tasks.create": "public",
+      "ai.tasks.get": "public",
+      "ai.tasks.cancel": "public",
+      "ai.tasks.usage": "public",
+      "ai.tasks.subscribe": "public",
+      "ai.tasks.unsubscribe": "public",
+      "report.listReports": "report:read",
+      "report.getReport": "report:read",
+      "report.getPlatformReport": "report:read",
+      "report.create": "report:write",
+      "report.list": "report:read",
+      "report.get": "report:read",
+      "report.update": "report:write",
+      "report.delete": "report:write",
+      "storage.get": "storage",
+      "storage.set": "storage",
+      "storage.remove": "storage",
+      "storage.keys": "storage",
+      "storage.getAll": "storage",
+      "storage.clear": "storage",
+      "storage.usage": "storage",
+      "settings.get": "storage",
+      "settings.set": "storage",
+      "settings.getAll": "storage",
+      "ui.showNotification": "ui:notification",
+      "ui.confirm": "ui:confirm",
+      "ui.requestFullscreen": "ui:fullscreen",
+      "ui.exitFullscreen": "ui:fullscreen",
+      "ui.toggleFullscreen": "ui:fullscreen",
+      "ui.isFullscreen": "ui:fullscreen",
+      "media.control": "media:control",
+      "media.getStatus": "media:read",
+      "media.getPlaylist": "media:read",
+      "media.playTrack": "media:control",
+      "media.jumpToIndex": "media:control",
+      "media.getSpectrum": "media:read",
+      "media.getLyrics": "media:read",
+      "media.getBeatGrid": "media:read",
+      "media.loadNeteasePlaylist": "media:control",
+      "media.getSkipVip": "media:read",
+      "media.setSkipVip": "media:control",
+      "component.registerTheme": "component:theme",
+      "component.registerAgent": "component:agent",
+      "component.unregister": "public",
+      "shortcut.register": "shortcut:register",
+      "shortcut.unregister": "shortcut:register",
+      "event.publish": "event:publish",
+      "agent.v2.accept": "public",
+      "agent.v2.result": "public",
+      "agent.v2.reject": "public",
+      "agent.v2.intent": "public",
+      "background.require": "event:subscribe",
+      "background.release": "event:subscribe",
+      "dynamicContent.set": "ui:notification",
+      "dynamicContent.update": "ui:notification",
+      "dynamicContent.remove": "ui:notification",
+      "file.download": "storage",
+      "assets.get": "public",
+      "assets.list": "public",
+      "scheduler.register": "scheduler:register",
+      "scheduler.unregister": "scheduler:register",
+      "scheduler.list": "scheduler:register",
+      "scheduler.get": "scheduler:register",
+      "scheduler.enable": "scheduler:register",
+      "scheduler.disable": "scheduler:register",
+      "scheduler.trigger": "scheduler:register",
+      "scheduler.subscribe": "scheduler:register",
+      "scheduler.unsubscribe": "scheduler:register",
+      "scheduler.complete": "scheduler:register",
+      "speech.tts": "speech:tts",
+      "speech.getVoices": "speech:tts",
+      "speech.getStatus": "speech:tts",
+      "speech.asr": "speech:asr",
+      "federation.getIdentity": "federation:read",
+      "federation.rotateKeys": "federation:write",
+      "federation.getFeed": "federation:read",
+      "federation.getTimeline": "federation:read",
+      "federation.getFollowing": "federation:read",
+      "federation.getFollowers": "federation:read",
+      "federation.getPublished": "federation:read",
+      "federation.getChannels": "federation:read",
+      "federation.getChannel": "federation:read",
+      "federation.getMessages": "federation:read",
+      "federation.getRooms": "federation:read",
+      "federation.getRoom": "federation:read",
+      "federation.getRoomMembers": "federation:read",
+      "federation.getRoomMessages": "federation:read",
+      "federation.getRings": "federation:read",
+      "federation.getRing": "federation:read",
+      "federation.getRingPeers": "federation:read",
+      "federation.follow": "federation:write",
+      "federation.unfollow": "federation:write",
+      "federation.publish": "federation:write",
+      "federation.createNote": "federation:write",
+      "federation.like": "federation:write",
+      "federation.unlike": "federation:write",
+      "federation.bookmark": "federation:write",
+      "federation.unbookmark": "federation:write",
+      "federation.getBookmarks": "federation:read",
+      "federation.getExternalShareStatus": "federation:read",
+      "federation.composeExternalShare": "federation:read",
+      "federation.announce": "federation:write",
+      "federation.unannounce": "federation:write",
+      "federation.uploadMedia": "federation:write",
+      "federation.unpublish": "federation:write",
+      "federation.createChannel": "federation:write",
+      "federation.acceptChannel": "federation:write",
+      "federation.closeChannel": "federation:write",
+      "federation.deleteChannel": "federation:write",
+      "federation.createRoom": "federation:write",
+      "federation.updateRoom": "federation:write",
+      "federation.deleteRoom": "federation:write",
+      "federation.inviteMember": "federation:write",
+      "federation.acceptRoomInvite": "federation:write",
+      "federation.rejectRoomInvite": "federation:write",
+      "federation.removeMember": "federation:write",
+      "federation.leaveRoom": "federation:write",
+      "federation.transferRoomOwnership": "federation:write",
+      "federation.initiateChannelE2e": "federation:write",
+      "federation.initiateRoomE2e": "federation:write",
+      "federation.pinRoomMessage": "federation:write",
+      "federation.createRing": "federation:write",
+      "federation.leaveRing": "federation:write",
+      "federation.addPeer": "federation:write",
+      "federation.removePeer": "federation:write",
+      "federation.triggerSync": "federation:write",
+      "federation.sendMessage": "federation:message",
+      "federation.sendRoomMessage": "federation:message",
+      "federation.subscribeChannel": "federation:message",
+      "federation.unsubscribeChannel": "federation:message",
+      "federation.subscribeRoom": "federation:message",
+      "federation.unsubscribeRoom": "federation:message",
+      "federation.getTrustPolicy": "federation:trust",
+      "federation.updateTrustPolicy": "federation:trust",
+      "federation.getInstances": "federation:trust",
+      "federation.getDeliveryStats": "federation:read",
+      "federation.listDelivery": "federation:read",
+      "federation.retryDelivery": "federation:write",
+      "federation.cancelDelivery": "federation:write",
+      "federation.retryAllDeadDelivery": "federation:write",
+      "federation.cancelAllPendingDelivery": "federation:write",
+      "federation.dismissDelivery": "federation:write",
+      "federation.purgeDeadDelivery": "federation:write",
+      "federation.joinRoom": "federation:write",
+      "federation.updateInstanceTrust": "federation:trust",
+      "federation.toggleInstanceBlock": "federation:trust",
+      "federation.initiateTransfer": "federation:files",
+      "federation.listTransfers": "federation:files",
+      "federation.initiateRoomTransfer": "federation:files",
+      "federation.listRoomTransfers": "federation:files",
+      "federation.listRoomFiles": "federation:files",
+      "federation.getTransfer": "federation:files",
+      "federation.downloadTransfer": "federation:files",
+      "federation.uploadChunk": "federation:files",
+      "federation.cancelTransfer": "federation:files"
+    }
+  },
+  "capabilities": {
+    "profiles": [
+      "page",
+      "widget",
+      "headless"
+    ],
+    "headlessDeniedActions": [
+      "ui.setTitle",
+      "ui.confirm",
+      "ui.requestFullscreen",
+      "ui.exitFullscreen",
+      "ui.toggleFullscreen",
+      "ui.isFullscreen",
+      "widget.register",
+      "widget.unregister",
+      "widget.listRegistered",
+      "widget.updateConfig",
+      "tappList.list",
+      "tappList.get",
+      "tappList.getRecent",
+      "tappList.getInstallPackage",
+      "tappList.resolveStoreSource",
+      "tappList.install",
+      "tappList.uninstall",
+      "tappList.start",
+      "tappList.stop",
+      "tappList.export",
+      "component.registerTheme",
+      "component.registerAgent",
+      "component.unregister",
+      "component.list",
+      "shortcut.register",
+      "shortcut.unregister",
+      "shortcut.list",
+      "dynamicContent.set",
+      "dynamicContent.update",
+      "dynamicContent.get",
+      "dynamicContent.remove",
+      "file.download"
+    ]
+  }
+}

--- a/tapp-cli/src/generated/manifest.schema.json
+++ b/tapp-cli/src/generated/manifest.schema.json
@@ -1,0 +1,804 @@
+{
+  "$defs": {
+    "TappAgentInteractionDef": {
+      "additionalProperties": false,
+      "properties": {
+        "inputSchema": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resultSchema": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "TappAgentManifest": {
+      "additionalProperties": false,
+      "properties": {
+        "intents": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "interactions": {
+          "items": {
+            "$ref": "#/$defs/TappAgentInteractionDef"
+          },
+          "type": "array"
+        },
+        "protocolVersion": {
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "protocolVersion",
+        "interactions"
+      ],
+      "type": "object"
+    },
+    "TappAiContextSource": {
+      "enum": [
+        "platform",
+        "report",
+        "profile",
+        "custom"
+      ],
+      "type": "string"
+    },
+    "TappAiManifest": {
+      "additionalProperties": false,
+      "properties": {
+        "contextSources": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/TappAiContextSource"
+          },
+          "type": "array"
+        },
+        "modelTier": {
+          "$ref": "#/$defs/TappAiModelTier"
+        },
+        "operations": {
+          "items": {
+            "$ref": "#/$defs/TappAiOperation"
+          },
+          "type": "array"
+        },
+        "outputFormats": {
+          "items": {
+            "$ref": "#/$defs/TappAiOutputFormat"
+          },
+          "type": "array"
+        },
+        "protocolVersion": {
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "protocolVersion",
+        "operations",
+        "modelTier",
+        "outputFormats"
+      ],
+      "type": "object"
+    },
+    "TappAiModelTier": {
+      "enum": [
+        "standard",
+        "pro"
+      ],
+      "type": "string"
+    },
+    "TappAiOperation": {
+      "enum": [
+        "generate",
+        "analyze",
+        "chat",
+        "image"
+      ],
+      "type": "string"
+    },
+    "TappAiOutputFormat": {
+      "enum": [
+        "text",
+        "json",
+        "image"
+      ],
+      "type": "string"
+    },
+    "TappApiAccess": {
+      "enum": [
+        "public",
+        "protected"
+      ],
+      "type": "string"
+    },
+    "TappApiDef": {
+      "additionalProperties": false,
+      "properties": {
+        "access": {
+          "$ref": "#/$defs/TappApiAccess",
+          "default": "protected"
+        },
+        "body": true,
+        "builtin": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cacheTtl": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "inject": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "method": {
+          "default": "GET",
+          "enum": [
+            "GET",
+            "HEAD",
+            "POST",
+            "PUT",
+            "DELETE",
+            "CONNECT",
+            "OPTIONS",
+            "TRACE",
+            "PATCH"
+          ],
+          "type": "string"
+        },
+        "spoof": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "default": "http",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "TappAuthor": {
+      "additionalProperties": false,
+      "properties": {
+        "email": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "TappCategory": {
+      "enum": [
+        "ai",
+        "data",
+        "developer",
+        "game",
+        "media",
+        "productivity",
+        "social",
+        "utility"
+      ],
+      "type": "string"
+    },
+    "TappDataExchangeManifest": {
+      "additionalProperties": false,
+      "properties": {
+        "exports": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/TappDataExport"
+          },
+          "type": "array"
+        },
+        "imports": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/TappDataImport"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "TappDataExport": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "maxBytes": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "maxRecords": {
+          "default": null,
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "schema": {
+          "description": "Supported inline JSON Schema subset; remote and file `$ref` are denied."
+        }
+      },
+      "required": [
+        "id",
+        "schema",
+        "maxBytes"
+      ],
+      "type": "object"
+    },
+    "TappDataImport": {
+      "additionalProperties": false,
+      "properties": {
+        "exportId": {
+          "type": "string"
+        },
+        "tappId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tappId",
+        "exportId"
+      ],
+      "type": "object"
+    },
+    "TappEventsManifest": {
+      "additionalProperties": false,
+      "properties": {
+        "publish": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "subscribe": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "TappManifestLocaleEntry": {
+      "additionalProperties": false,
+      "description": "单个语言下的清单展示文案覆盖",
+      "properties": {
+        "description": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "TappSettingDef": {
+      "additionalProperties": false,
+      "properties": {
+        "defaultValue": true,
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "key": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "min": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "options": {
+          "items": {
+            "$ref": "#/$defs/TappSettingOption"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "step": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "label",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TappSettingOption": {
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "label"
+      ],
+      "type": "object"
+    },
+    "TappWidgetCategory": {
+      "enum": [
+        "stats",
+        "activity",
+        "visualization",
+        "utility",
+        "custom"
+      ],
+      "type": "string"
+    },
+    "TappWidgetDef": {
+      "additionalProperties": false,
+      "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TappWidgetCategory"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultSize": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "refreshPolicy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TappWidgetRefreshPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "settings": {
+          "items": {
+            "$ref": "#/$defs/TappSettingDef"
+          },
+          "type": "array"
+        },
+        "sizes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "templates": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "defaultSize",
+        "sizes"
+      ],
+      "type": "object"
+    },
+    "TappWidgetRefreshMode": {
+      "enum": [
+        "event",
+        "interval"
+      ],
+      "type": "string"
+    },
+    "TappWidgetRefreshPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "intervalSeconds": {
+          "default": null,
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/TappWidgetRefreshMode"
+        },
+        "refreshOnVisible": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "mode"
+      ],
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "agent": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TappAgentManifest"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "ai": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TappAiManifest"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "apis": {
+      "additionalProperties": {
+        "$ref": "#/$defs/TappApiDef"
+      },
+      "default": null,
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "assets": {
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "author": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TappAuthor"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "backgroundRequirements": {
+      "default": null,
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "category": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TappCategory"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "cssMode": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "dataExchange": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TappDataExchangeManifest"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "description": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "events": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TappEventsManifest"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "hasPage": {
+      "default": false,
+      "type": "boolean"
+    },
+    "homepage": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "icon": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "iconSvg": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "id": {
+      "type": "string"
+    },
+    "locales": {
+      "additionalProperties": {
+        "$ref": "#/$defs/TappManifestLocaleEntry"
+      },
+      "description": "展示文案的多语言覆盖：语言标签 → { name?, description? }",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "main": {
+      "type": "string"
+    },
+    "minSystemVersion": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "name": {
+      "type": "string"
+    },
+    "pageModules": {
+      "default": null,
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "pageStyles": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "pageTemplate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "permissions": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "repository": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "settings": {
+      "items": {
+        "$ref": "#/$defs/TappSettingDef"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "styles": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "themeColor": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "version": {
+      "type": "string"
+    },
+    "widgetStyles": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "widgets": {
+      "items": {
+        "$ref": "#/$defs/TappWidgetDef"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "version",
+    "main"
+  ],
+  "title": "Myriad Tapp Manifest",
+  "type": "object",
+  "$id": "https://myriad.local/tapp/manifest.schema.json",
+  "description": "Generated from backend TappManifest schema. Semantic limits and permission rules live in contract.json."
+}

--- a/tapp-cli/src/generated/tapp-sdk.d.ts
+++ b/tapp-cli/src/generated/tapp-sdk.d.ts
@@ -1,0 +1,397 @@
+/**
+ * Myriad Tapp sandbox SDK (window.Tapp).
+ * Generated from the runtime permission catalog. Call sites still need
+ * matching Manifest permissions and a handler in the current sandbox profile.
+ *
+ * Headless-denied Bridge actions: component.list, component.registerAgent, component.registerTheme, component.unregister, dynamicContent.get, dynamicContent.remove, dynamicContent.set, dynamicContent.update, file.download, shortcut.list, shortcut.register, shortcut.unregister, tappList.export, tappList.get, tappList.getInstallPackage, tappList.getRecent, tappList.install, tappList.list, tappList.resolveStoreSource, tappList.start, tappList.stop, tappList.uninstall, ui.confirm, ui.exitFullscreen, ui.isFullscreen, ui.requestFullscreen, ui.setTitle, ui.toggleFullscreen, widget.listRegistered, widget.register, widget.unregister, widget.updateConfig
+ *
+ * Do not edit by hand — run: npm run sync-contract
+ */
+
+export interface TappSdk {
+  lifecycle: {
+    onReady(callback: () => void | Promise<void>): void
+    onDestroy(callback: () => void): void
+    onPause(callback: () => void): void
+    onResume(callback: () => void): void
+    getInfo(): { id: string; version: string; name: string; permissions: string[]; sandboxed: true }
+  }
+
+  i18n: {
+    t(key: string, params?: Record<string, unknown>): string
+    getLocale(): string
+    getAll(): Record<string, unknown>
+  }
+
+  storage: {
+    get(key: string): Promise<unknown>
+    set(key: string, value: unknown): Promise<unknown>
+    remove(key: string): Promise<unknown>
+    keys(): Promise<string[]>
+    getAll(): Promise<Record<string, unknown>>
+    clear(): Promise<unknown>
+    usage(): Promise<unknown>
+    onChanged(callback: (event: { key?: string; operation?: string }) => void): () => void
+  }
+
+  settings: {
+    get(key: string): Promise<unknown>
+    set(key: string, value: unknown): Promise<unknown>
+    getAll(): Promise<Record<string, unknown>>
+  }
+
+  ui: {
+    setTitle(title: string): Promise<unknown>
+    getTheme(): Promise<unknown>
+    onThemeChange(callback: (theme: unknown) => void): () => void
+    getPrimaryColor(): Promise<unknown>
+    onPrimaryColorChange(callback: (color: unknown) => void): () => void
+    getLocale(): Promise<unknown>
+    onLocaleChange(callback: (locale: unknown) => void): () => void
+    showNotification(options: unknown): Promise<unknown>
+    confirm(message: string): Promise<boolean>
+    requestFullscreen(): Promise<unknown>
+    exitFullscreen(): Promise<unknown>
+    fullscreen: {
+      request(): Promise<unknown>
+      exit(): Promise<unknown>
+      toggle(): Promise<unknown>
+      isFullscreen(): Promise<boolean>
+    }
+  }
+
+  api: {
+    (name: string, params?: unknown): Promise<unknown>
+    list(): Promise<unknown>
+  }
+
+  assets: {
+    list(): Promise<unknown>
+    get(path: string): Promise<unknown>
+    getUrl(path: string): Promise<{ url: string; mimeType?: string; size?: number; path?: string }>
+    getArrayBuffer(path: string): Promise<{ path: string; mimeType?: string; size?: number; buffer: ArrayBuffer }>
+    revoke(url: string): void
+    revokeAll(): void
+  }
+
+  dataExchange: {
+    request(request: unknown): Promise<unknown>
+    provide(exportId: string, handler: (request: unknown) => unknown | Promise<unknown>): Promise<() => void>
+  }
+
+  event: {
+    publish(request: unknown): Promise<unknown>
+    on(topic: string, callback: (event: unknown) => void): () => void
+  }
+
+  agent: {
+    onInteraction(
+      type: string,
+      callback: (interaction: {
+        type: string
+        interactionId: string
+        accept(): Promise<unknown>
+        submitResult(result: unknown): Promise<unknown>
+        reject(reason?: unknown): Promise<unknown>
+        requestIntent(request: unknown): Promise<unknown>
+        [key: string]: unknown
+      }) => void,
+    ): () => void
+  }
+
+  media: {
+    play(): Promise<unknown>
+    pause(): Promise<unknown>
+    next(): Promise<unknown>
+    prev(): Promise<unknown>
+    seek(position: unknown): Promise<unknown>
+    setVolume(volume: unknown): Promise<unknown>
+    setMode(mode: unknown): Promise<unknown>
+    mute(): Promise<unknown>
+    unmute(): Promise<unknown>
+    getStatus(): Promise<unknown>
+    getPlaylist(): Promise<unknown>
+    getSpectrum(): Promise<unknown>
+    getLyrics(options?: unknown): Promise<unknown>
+    getBeatGrid(): Promise<unknown>
+    playTrack(id: unknown, index?: unknown): Promise<unknown>
+    jumpToIndex(index: unknown): Promise<unknown>
+    loadNeteasePlaylist(playlistId: unknown): Promise<unknown>
+    getSkipVip(): Promise<unknown>
+    setSkipVip(value: unknown): Promise<unknown>
+    onStateChange(callback: (state: unknown) => void): () => void
+    onProgress(callback: (progress: unknown) => void): () => void
+  }
+
+  ai: {
+    tasks: {
+      create(request: unknown): Promise<unknown>
+      get(taskId: string): Promise<unknown>
+      cancel(taskId: string): Promise<unknown>
+      usage(): Promise<unknown>
+      subscribe(
+        taskId: string,
+        callback: (event: { event: unknown; data: unknown }) => void,
+      ): Promise<() => void>
+    }
+  }
+
+  scheduler: {
+    register(options: unknown): Promise<unknown>
+    unregister(taskId: string): Promise<unknown>
+    list(): Promise<unknown>
+    get(taskId: string): Promise<unknown>
+    enable(taskId: string): Promise<unknown>
+    disable(taskId: string): Promise<unknown>
+    trigger(taskId: string): Promise<unknown>
+    onTask(
+      taskId: string,
+      callback: (payload: unknown, event: unknown) => unknown | Promise<unknown>,
+    ): () => void
+  }
+
+  widgets: Record<
+    string,
+    {
+      render(
+        container: HTMLElement,
+        props: {
+          size?: string
+          theme?: string
+          settings?: Record<string, unknown>
+          [key: string]: unknown
+        },
+      ): void | Promise<void>
+    }
+  >
+
+  pages: Record<
+    string,
+    {
+      render(container: HTMLElement): void | Promise<void>
+    }
+  >
+
+  dom: {
+    setAttribute(element: Element, name: string, value: string): void
+    [key: string]: unknown
+  }
+
+  animation: {
+    getConfig(...args: unknown[]): Promise<unknown>
+    getLevel(...args: unknown[]): Promise<unknown>
+    getStaggerDelay(...args: unknown[]): Promise<unknown>
+    shouldAnimate(...args: unknown[]): Promise<unknown>
+  }
+  background: {
+    has(...args: unknown[]): Promise<unknown>
+    list(...args: unknown[]): Promise<unknown>
+    release(...args: unknown[]): Promise<unknown> // permission: event:subscribe
+    require(...args: unknown[]): Promise<unknown> // permission: event:subscribe
+  }
+  brewList: {
+    addSource(...args: unknown[]): Promise<unknown> // permission: brew:manage
+    categories(...args: unknown[]): Promise<unknown> // permission: brew:read
+    createCategory(...args: unknown[]): Promise<unknown> // permission: brew:manage
+    createComment(...args: unknown[]): Promise<unknown> // permission: brew:comment
+    createReply(...args: unknown[]): Promise<unknown> // permission: brew:comment
+    deleteCategory(...args: unknown[]): Promise<unknown> // permission: brew:manage
+    deleteComment(...args: unknown[]): Promise<unknown> // permission: brew:comment
+    deleteSource(...args: unknown[]): Promise<unknown> // permission: brew:manage
+    discover(...args: unknown[]): Promise<unknown> // permission: brew:manage
+    exportOpml(...args: unknown[]): Promise<unknown> // permission: brew:read
+    get(...args: unknown[]): Promise<unknown> // permission: brew:read
+    getComments(...args: unknown[]): Promise<unknown> // permission: brew:comment
+    getReplies(...args: unknown[]): Promise<unknown> // permission: brew:comment
+    importOpml(...args: unknown[]): Promise<unknown> // permission: brew:manage
+    list(...args: unknown[]): Promise<unknown> // permission: brew:read
+    markAllRead(...args: unknown[]): Promise<unknown> // permission: brew:write
+    markRead(...args: unknown[]): Promise<unknown> // permission: brew:write
+    markUnread(...args: unknown[]): Promise<unknown> // permission: brew:write
+    refreshSource(...args: unknown[]): Promise<unknown> // permission: brew:manage
+    sources(...args: unknown[]): Promise<unknown> // permission: brew:read
+    star(...args: unknown[]): Promise<unknown> // permission: brew:write
+    stats(...args: unknown[]): Promise<unknown> // permission: brew:read
+    unstar(...args: unknown[]): Promise<unknown> // permission: brew:write
+    updateComment(...args: unknown[]): Promise<unknown> // permission: brew:comment
+    updateSource(...args: unknown[]): Promise<unknown> // permission: brew:manage
+  }
+  component: {
+    list(...args: unknown[]): Promise<unknown>
+    registerAgent(...args: unknown[]): Promise<unknown> // permission: component:agent
+    registerTheme(...args: unknown[]): Promise<unknown> // permission: component:theme
+    unregister(...args: unknown[]): Promise<unknown>
+  }
+  context: {
+    getApp(...args: unknown[]): Promise<unknown>
+    getGeo(...args: unknown[]): Promise<unknown>
+    getNavigation(...args: unknown[]): Promise<unknown>
+    getPlayer(...args: unknown[]): Promise<unknown>
+    getSystem(...args: unknown[]): Promise<unknown>
+    getUser(...args: unknown[]): Promise<unknown>
+  }
+  data: {
+    transform(...args: unknown[]): Promise<unknown>
+  }
+  dynamicContent: {
+    get(...args: unknown[]): Promise<unknown>
+    remove(...args: unknown[]): Promise<unknown> // permission: ui:notification
+    set(...args: unknown[]): Promise<unknown> // permission: ui:notification
+    update(...args: unknown[]): Promise<unknown> // permission: ui:notification
+  }
+  federation: {
+    acceptChannel(...args: unknown[]): Promise<unknown> // permission: federation:write
+    acceptRoomInvite(...args: unknown[]): Promise<unknown> // permission: federation:write
+    addPeer(...args: unknown[]): Promise<unknown> // permission: federation:write
+    announce(...args: unknown[]): Promise<unknown> // permission: federation:write
+    bookmark(...args: unknown[]): Promise<unknown> // permission: federation:write
+    cancelAllPendingDelivery(...args: unknown[]): Promise<unknown> // permission: federation:write
+    cancelDelivery(...args: unknown[]): Promise<unknown> // permission: federation:write
+    cancelTransfer(...args: unknown[]): Promise<unknown> // permission: federation:files
+    closeChannel(...args: unknown[]): Promise<unknown> // permission: federation:write
+    composeExternalShare(...args: unknown[]): Promise<unknown> // permission: federation:read
+    createChannel(...args: unknown[]): Promise<unknown> // permission: federation:write
+    createNote(...args: unknown[]): Promise<unknown> // permission: federation:write
+    createRing(...args: unknown[]): Promise<unknown> // permission: federation:write
+    createRoom(...args: unknown[]): Promise<unknown> // permission: federation:write
+    deleteChannel(...args: unknown[]): Promise<unknown> // permission: federation:write
+    deleteRoom(...args: unknown[]): Promise<unknown> // permission: federation:write
+    dismissDelivery(...args: unknown[]): Promise<unknown> // permission: federation:write
+    downloadTransfer(...args: unknown[]): Promise<unknown> // permission: federation:files
+    follow(...args: unknown[]): Promise<unknown> // permission: federation:write
+    getBookmarks(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getChannel(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getChannels(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getDeliveryStats(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getExternalShareStatus(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getFeed(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getFollowers(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getFollowing(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getIdentity(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getInstances(...args: unknown[]): Promise<unknown> // permission: federation:trust
+    getMessages(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getPublished(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getRing(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getRingPeers(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getRings(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getRoom(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getRoomMembers(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getRoomMessages(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getRooms(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getTimeline(...args: unknown[]): Promise<unknown> // permission: federation:read
+    getTransfer(...args: unknown[]): Promise<unknown> // permission: federation:files
+    getTrustPolicy(...args: unknown[]): Promise<unknown> // permission: federation:trust
+    initiateChannelE2e(...args: unknown[]): Promise<unknown> // permission: federation:write
+    initiateRoomE2e(...args: unknown[]): Promise<unknown> // permission: federation:write
+    initiateRoomTransfer(...args: unknown[]): Promise<unknown> // permission: federation:files
+    initiateTransfer(...args: unknown[]): Promise<unknown> // permission: federation:files
+    inviteMember(...args: unknown[]): Promise<unknown> // permission: federation:write
+    joinRoom(...args: unknown[]): Promise<unknown> // permission: federation:write
+    leaveRing(...args: unknown[]): Promise<unknown> // permission: federation:write
+    leaveRoom(...args: unknown[]): Promise<unknown> // permission: federation:write
+    like(...args: unknown[]): Promise<unknown> // permission: federation:write
+    listDelivery(...args: unknown[]): Promise<unknown> // permission: federation:read
+    listRoomFiles(...args: unknown[]): Promise<unknown> // permission: federation:files
+    listRoomTransfers(...args: unknown[]): Promise<unknown> // permission: federation:files
+    listTransfers(...args: unknown[]): Promise<unknown> // permission: federation:files
+    pinRoomMessage(...args: unknown[]): Promise<unknown> // permission: federation:write
+    publish(...args: unknown[]): Promise<unknown> // permission: federation:write
+    purgeDeadDelivery(...args: unknown[]): Promise<unknown> // permission: federation:write
+    rejectRoomInvite(...args: unknown[]): Promise<unknown> // permission: federation:write
+    removeMember(...args: unknown[]): Promise<unknown> // permission: federation:write
+    removePeer(...args: unknown[]): Promise<unknown> // permission: federation:write
+    retryAllDeadDelivery(...args: unknown[]): Promise<unknown> // permission: federation:write
+    retryDelivery(...args: unknown[]): Promise<unknown> // permission: federation:write
+    rotateKeys(...args: unknown[]): Promise<unknown> // permission: federation:write
+    sendMessage(...args: unknown[]): Promise<unknown> // permission: federation:message
+    sendRoomMessage(...args: unknown[]): Promise<unknown> // permission: federation:message
+    subscribeChannel(...args: unknown[]): Promise<unknown> // permission: federation:message
+    subscribeRoom(...args: unknown[]): Promise<unknown> // permission: federation:message
+    toggleInstanceBlock(...args: unknown[]): Promise<unknown> // permission: federation:trust
+    transferRoomOwnership(...args: unknown[]): Promise<unknown> // permission: federation:write
+    triggerSync(...args: unknown[]): Promise<unknown> // permission: federation:write
+    unannounce(...args: unknown[]): Promise<unknown> // permission: federation:write
+    unbookmark(...args: unknown[]): Promise<unknown> // permission: federation:write
+    unfollow(...args: unknown[]): Promise<unknown> // permission: federation:write
+    unlike(...args: unknown[]): Promise<unknown> // permission: federation:write
+    unpublish(...args: unknown[]): Promise<unknown> // permission: federation:write
+    unsubscribeChannel(...args: unknown[]): Promise<unknown> // permission: federation:message
+    unsubscribeRoom(...args: unknown[]): Promise<unknown> // permission: federation:message
+    updateInstanceTrust(...args: unknown[]): Promise<unknown> // permission: federation:trust
+    updateRoom(...args: unknown[]): Promise<unknown> // permission: federation:write
+    updateTrustPolicy(...args: unknown[]): Promise<unknown> // permission: federation:trust
+    uploadChunk(...args: unknown[]): Promise<unknown> // permission: federation:files
+    uploadMedia(...args: unknown[]): Promise<unknown> // permission: federation:write
+  }
+  file: {
+    download(...args: unknown[]): Promise<unknown> // permission: storage
+  }
+  platform: {
+    addItem(...args: unknown[]): Promise<unknown> // permission: platform:write
+    addItems(...args: unknown[]): Promise<unknown> // permission: platform:write
+    getData(...args: unknown[]): Promise<unknown> // permission: platform:read
+    getDistribution(...args: unknown[]): Promise<unknown> // permission: platform:read
+    getStats(...args: unknown[]): Promise<unknown> // permission: platform:read
+    listEnabled(...args: unknown[]): Promise<unknown> // permission: platform:read
+    registerPlatform(...args: unknown[]): Promise<unknown> // permission: platform:register
+  }
+  report: {
+    create(...args: unknown[]): Promise<unknown> // permission: report:write
+    delete(...args: unknown[]): Promise<unknown> // permission: report:write
+    get(...args: unknown[]): Promise<unknown> // permission: report:read
+    getPlatformReport(...args: unknown[]): Promise<unknown> // permission: report:read
+    getReport(...args: unknown[]): Promise<unknown> // permission: report:read
+    list(...args: unknown[]): Promise<unknown> // permission: report:read
+    listReports(...args: unknown[]): Promise<unknown> // permission: report:read
+    update(...args: unknown[]): Promise<unknown> // permission: report:write
+  }
+  shortcut: {
+    list(...args: unknown[]): Promise<unknown>
+    register(...args: unknown[]): Promise<unknown> // permission: shortcut:register
+    unregister(...args: unknown[]): Promise<unknown> // permission: shortcut:register
+  }
+  speech: {
+    asr(...args: unknown[]): Promise<unknown> // permission: speech:asr
+    getStatus(...args: unknown[]): Promise<unknown> // permission: speech:tts
+    getVoices(...args: unknown[]): Promise<unknown> // permission: speech:tts
+    tts(...args: unknown[]): Promise<unknown> // permission: speech:tts
+  }
+  tappList: {
+    export(...args: unknown[]): Promise<unknown> // permission: tappList:manage
+    get(...args: unknown[]): Promise<unknown> // permission: tappList:read
+    getInstallPackage(...args: unknown[]): Promise<unknown> // permission: tappList:read
+    getRecent(...args: unknown[]): Promise<unknown> // permission: tappList:read
+    install(...args: unknown[]): Promise<unknown> // permission: tappList:manage
+    list(...args: unknown[]): Promise<unknown> // permission: tappList:read
+    resolveStoreSource(...args: unknown[]): Promise<unknown> // permission: tappList:read
+    start(...args: unknown[]): Promise<unknown> // permission: tappList:manage
+    stop(...args: unknown[]): Promise<unknown> // permission: tappList:manage
+    uninstall(...args: unknown[]): Promise<unknown> // permission: tappList:manage
+  }
+  user: {
+    canUsePermissionLevel(...args: unknown[]): Promise<unknown>
+    getAllowedPermissionLevels(...args: unknown[]): Promise<unknown>
+    getRole(...args: unknown[]): Promise<unknown>
+    isAdmin(...args: unknown[]): Promise<unknown>
+    isGuest(...args: unknown[]): Promise<unknown>
+    isLoggedIn(...args: unknown[]): Promise<unknown>
+  }
+  widget: {
+    invalidate(...args: unknown[]): Promise<unknown>
+    listRegistered(...args: unknown[]): Promise<unknown> // permission: widget:register
+    register(...args: unknown[]): Promise<unknown> // permission: widget:register
+    unregister(...args: unknown[]): Promise<unknown> // permission: widget:register
+    updateConfig(...args: unknown[]): Promise<unknown> // permission: widget:register
+    instanceSettings: {
+      update(...args: unknown[]): Promise<unknown>
+    }
+  }
+}
+
+declare const Tapp: TappSdk
+
+interface Window {
+  Tapp: TappSdk
+}
+
+export {}

--- a/tapp-cli/src/package-layout.mjs
+++ b/tapp-cli/src/package-layout.mjs
@@ -1,0 +1,80 @@
+/**
+ * Package path layout shared with Playground export / direct-install.
+ * Mirrors frontend/src/tapp/utils/playgroundPackageFiles.ts path rules for
+ * disk-based CLI projects (content still comes from the filesystem).
+ */
+
+export const PACKAGE_MARKERS = {
+  widget: '// ========== Widget Code ==========',
+  page: '// ========== Page Code ==========',
+}
+
+export function assetPackagePath(path) {
+  return path.startsWith('assets/') ? path : `assets/${path.replace(/^\/+/, '')}`
+}
+
+/**
+ * Normalize Manifest defaults the same way Playground packaging does when
+ * only on-disk files are available (no in-memory code structure).
+ */
+export function normalizeManifestPaths(manifest) {
+  const next = { ...manifest }
+  if (!next.main || !String(next.main).trim()) next.main = 'main.js'
+  if (!next.cssMode) next.cssMode = 'unified'
+  if (next.hasPage === true && !next.pageTemplate && !(next.pageModules && next.pageModules.length)) {
+    next.pageTemplate = 'page.html'
+  }
+  if (Array.isArray(next.pageModules) && next.pageModules.length > 0) {
+    next.hasPage = true
+  }
+  return next
+}
+
+/**
+ * Expected relative package paths for a disk project after validation.
+ * @param {object} options
+ * @param {object} options.manifest
+ * @param {string[]} [options.extraPaths] existing files already collected
+ */
+export function expectedPackagePaths({ manifest, extraPaths = [] }) {
+  const normalized = normalizeManifestPaths(manifest)
+  const paths = new Set(['manifest.json', normalized.main || 'main.js'])
+
+  if (normalized.styles) paths.add(normalized.styles)
+  if (normalized.widgetStyles) paths.add(normalized.widgetStyles)
+  if (normalized.pageStyles) paths.add(normalized.pageStyles)
+  if (normalized.pageTemplate) paths.add(normalized.pageTemplate)
+
+  for (const module of normalized.pageModules || []) {
+    paths.add(`page/${module}`)
+  }
+  for (const asset of normalized.assets || []) {
+    paths.add(assetPackagePath(asset))
+  }
+  for (const widget of normalized.widgets || []) {
+    for (const template of Object.values(widget.templates || {})) {
+      if (template) paths.add(template)
+    }
+  }
+  for (const path of extraPaths) paths.add(path)
+  return [...paths].sort()
+}
+
+/**
+ * Compose main.js the same way Playground does for structured code.
+ * Disk projects usually already ship a composed main.js; this is for build.
+ */
+export function buildMainJs({ core = '', widget = '', page = '', pageModules } = {}) {
+  const hasPageModules = pageModules && Object.keys(pageModules).length > 0
+  if (hasPageModules) {
+    return [
+      core || '',
+      widget ? `\n${PACKAGE_MARKERS.widget}\n${widget}` : '',
+    ].join('')
+  }
+  return [
+    core || '',
+    widget ? `\n${PACKAGE_MARKERS.widget}\n${widget}` : '',
+    page ? `\n${PACKAGE_MARKERS.page}\n${page}` : '',
+  ].join('')
+}

--- a/tapp-cli/src/project.mjs
+++ b/tapp-cli/src/project.mjs
@@ -1,0 +1,1122 @@
+import {
+  access,
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import {
+  dirname,
+  extname,
+  join,
+  resolve,
+} from 'node:path'
+import {
+  expectedPackagePaths,
+  normalizeManifestPaths,
+  PACKAGE_MARKERS,
+} from './package-layout.mjs'
+import { writeZip, zipSize } from './zip.mjs'
+import { createStarterTemplate } from './starter-template.mjs'
+import { analyzeProjectCode } from './source-analyzer.mjs'
+import { validateProjectResources } from './resource-validator.mjs'
+
+const contract = JSON.parse(
+  await readFile(new URL('./generated/contract.json', import.meta.url), 'utf8'),
+)
+const catalog = contract.permissions
+const schemaDefinitions = contract.schema.$defs
+const schemaFields = (name) => Object.keys(schemaDefinitions[name].properties)
+const schemaEnum = (name) => schemaDefinitions[name].enum
+
+const TOP_LEVEL_FIELDS = new Set(Object.keys(contract.schema.properties))
+const CATEGORIES = new Set([
+  ...schemaEnum('TappCategory'),
+  ...contract.rules.tappCategoryAliases,
+])
+const WIDGET_SIZES = new Set(contract.rules.widgetSizes)
+const BACKGROUND_REQUIREMENTS = new Set(contract.rules.backgroundRequirements)
+const WIDGET_CATEGORIES = new Set([
+  ...schemaEnum('TappWidgetCategory'),
+  ...contract.rules.widgetCategoryAliases,
+])
+const WIDGET_REFRESH_MODES = new Set(schemaEnum('TappWidgetRefreshMode'))
+const SETTING_TYPES = new Set(contract.rules.settingTypes)
+const AI_OPERATIONS = new Set(schemaEnum('TappAiOperation'))
+const AI_MODEL_TIERS = new Set(schemaEnum('TappAiModelTier'))
+const AI_CONTEXT_SOURCES = new Set(schemaEnum('TappAiContextSource'))
+const AI_OUTPUT_FORMATS = new Set(schemaEnum('TappAiOutputFormat'))
+const API_ACCESS_LEVELS = new Set(schemaEnum('TappApiAccess'))
+const API_PUBLIC_ACCESS = schemaEnum('TappApiAccess').find((value) => value === 'public')
+const API_BUILTINS = new Set(contract.rules.apiBuiltins)
+const API_TYPES = new Set(contract.rules.apiTypes)
+const CSS_MODES = new Set(contract.rules.cssModes)
+const AGENT_INTENTS = new Set(contract.rules.agentIntents)
+const SETTING_FIELD_TYPES = contract.rules.settingFieldTypes
+const SETTING_DEFAULT_KINDS = contract.rules.settingDefaultKinds
+const EVENT_DIRECTIONS = Object.keys(contract.rules.eventPermissionRules)
+const DATA_EXCHANGE_DIRECTIONS = contract.rules.dataExchangeDirections
+const API_BUILTIN_AI_OPERATIONS = contract.rules.apiBuiltinAiOperations
+const API_BUILTIN_PERMISSIONS = contract.rules.apiBuiltinPermissions
+const MANIFEST_RESOURCE_FIELDS = contract.rules.manifestResourceFields
+const URL_FIELDS = contract.rules.urlFields
+const DEFAULT_API_TYPE = contract.rules.defaultApiType
+const HTTP_API_TYPE = contract.rules.httpApiType
+const BUILTIN_API_TYPE = contract.rules.builtinApiType
+const DEFAULT_HTTP_METHOD = contract.rules.defaultHttpMethod
+const WIDGET_REFRESH_EVENT_MODE = contract.rules.widgetRefreshModes.event
+const WIDGET_REFRESH_INTERVAL_MODE = contract.rules.widgetRefreshModes.interval
+
+const SAFE_COMPONENT = new RegExp(contract.patterns.safeComponent)
+const LOCALE_TAG = new RegExp(contract.patterns.localeTag)
+const SEMVER = new RegExp(contract.patterns.semver)
+const NAMED_VALUE = new RegExp(contract.patterns.namedValue)
+const STORAGE_KEY = new RegExp(contract.patterns.storageKey)
+const THEME_COLOR = new RegExp(contract.patterns.themeColor)
+// Fixed allow-list enforced identically by the backend installer.
+const HTTP_METHODS = new Set(contract.rules.httpMethods)
+const REQUIRED_MANIFEST_FIELDS = new Set([
+  ...contract.schema.required,
+  ...contract.rules.requiredManifestFields,
+])
+const MAX_ARCHIVE_FILES = contract.limits.archiveFiles
+const MAX_ARCHIVE_BYTES = contract.limits.archiveBytes
+const MAX_UNCOMPRESSED_BYTES = contract.limits.archiveUncompressedBytes
+
+function diagnostic(severity, code, message, file = 'manifest.json', line, column) {
+  return { severity, code, message, file, line, column }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function validateFields(value, allowed, path, diagnostics) {
+  if (!isObject(value)) return false
+  for (const field of Object.keys(value)) {
+    if (!allowed.includes(field)) {
+      diagnostics.push(
+        diagnostic('error', 'unknown-manifest-field', `Unknown manifest field: ${path}.${field}`),
+      )
+    }
+  }
+  return true
+}
+
+function hasDuplicates(values) {
+  return new Set(values).size !== values.length
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function formatBytes(bytes) {
+  for (const [unitBytes, unit] of [
+    [1024 ** 3, 'GiB'],
+    [1024 ** 2, 'MiB'],
+    [1024, 'KiB'],
+  ]) {
+    if (bytes >= unitBytes && bytes % unitBytes === 0) {
+      return `${bytes / unitBytes} ${unit}`
+    }
+  }
+  return `${bytes} bytes`
+}
+
+function isNamedValue(value) {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= contract.limits.tappIdLength &&
+    !value.startsWith('.') &&
+    !value.endsWith('.') &&
+    !value.includes('..') &&
+    NAMED_VALUE.test(value)
+  )
+}
+
+function isDataExchangeId(value) {
+  return typeof value === 'string' && value.length > 0 && value.length <= contract.limits.dataExchangeIdLength && NAMED_VALUE.test(value)
+}
+
+function validateHttpUrl(value) {
+  if (typeof value !== 'string' || value.length > contract.limits.httpUrlLength) return false
+  try {
+    return contract.rules.httpUrlSchemes.includes(new URL(value).protocol.replace(/:$/, ''))
+  } catch {
+    return false
+  }
+}
+
+function validateStorageKey(value) {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= contract.limits.storageKeyLength &&
+    !value.startsWith('.') &&
+    !value.endsWith('.') &&
+    !value.includes('..') &&
+    STORAGE_KEY.test(value)
+  )
+}
+
+function validateInlineSchema(schema) {
+  if (!isObject(schema) || Buffer.byteLength(JSON.stringify(schema)) > contract.limits.dataExchangeSchemaBytes) return false
+  if (!contract.rules.inlineSchemaRootKeys.some((field) => field in schema)) return false
+  const visit = (value, depth) => {
+    if (depth > contract.limits.inlineSchemaDepth) return false
+    if (Array.isArray(value)) return value.every((child) => visit(child, depth + 1))
+    if (!isObject(value)) return true
+    if ('$ref' in value) return false
+    return Object.values(value).every((child) => visit(child, depth + 1))
+  }
+  return visit(schema, 0)
+}
+
+function validateSettings(settings, path, diagnostics) {
+  if (!Array.isArray(settings)) {
+    diagnostics.push(diagnostic('error', 'invalid-settings', `${path} must be an array`))
+    return
+  }
+  if (settings.length > contract.limits.tappSettings) {
+    diagnostics.push(diagnostic('error', 'invalid-settings', `${path} accepts at most ${contract.limits.tappSettings} entries`))
+  }
+  const keys = new Set()
+  for (const [index, setting] of settings.entries()) {
+    const settingPath = `${path}[${index}]`
+    if (
+      !validateFields(
+        setting,
+        schemaFields('TappSettingDef'),
+        settingPath,
+        diagnostics,
+      )
+    ) {
+      diagnostics.push(diagnostic('error', 'invalid-setting', `${settingPath} must be an object`))
+      continue
+    }
+    if (
+      !validateStorageKey(setting.key) ||
+      keys.has(setting.key) ||
+      typeof setting.label !== 'string' ||
+      !setting.label ||
+      setting.label.length > contract.limits.settingLabelLength ||
+      !SETTING_TYPES.has(setting.type)
+    ) {
+      diagnostics.push(diagnostic('error', 'invalid-setting', `${settingPath} is invalid or duplicated`))
+    }
+    keys.add(setting.key)
+    const optionType = SETTING_FIELD_TYPES.options
+    if (setting.type === optionType) {
+      if (!Array.isArray(setting.options) || setting.options.length === 0 || setting.options.length > contract.limits.settingOptions) {
+        diagnostics.push(diagnostic('error', 'invalid-setting-options', `${settingPath}.options must contain 1-${contract.limits.settingOptions} entries`))
+      }
+    } else if (setting.options !== undefined) {
+      diagnostics.push(diagnostic('error', 'invalid-setting-options', `${settingPath}.options is only valid for select settings`))
+    }
+    if (Array.isArray(setting.options)) {
+      const values = new Set()
+      for (const [optionIndex, option] of setting.options.entries()) {
+        const optionPath = `${settingPath}.options[${optionIndex}]`
+        validateFields(option, schemaFields('TappSettingOption'), optionPath, diagnostics)
+        if (
+          !isObject(option) ||
+          typeof option.value !== 'string' ||
+          !option.value ||
+          option.value.length > contract.limits.settingOptionValueLength ||
+          values.has(option.value) ||
+          typeof option.label !== 'string' ||
+          !option.label ||
+          option.label.length > contract.limits.settingLabelLength
+        ) {
+          diagnostics.push(diagnostic('error', 'invalid-setting-option', `${optionPath} is invalid or duplicated`))
+        }
+        values.add(option?.value)
+      }
+    }
+    for (const [field, expectedType] of Object.entries(SETTING_FIELD_TYPES)) {
+      if (setting[field] !== undefined && setting.type !== expectedType) {
+        diagnostics.push(diagnostic('error', 'invalid-setting', `${settingPath}.${field} requires type ${expectedType}`))
+      }
+    }
+    if (
+      (setting.min !== undefined && typeof setting.min !== 'number') ||
+      (setting.max !== undefined && typeof setting.max !== 'number') ||
+      (setting.step !== undefined && (typeof setting.step !== 'number' || setting.step <= 0)) ||
+      (typeof setting.min === 'number' && typeof setting.max === 'number' && setting.min > setting.max)
+    ) {
+      diagnostics.push(diagnostic('error', 'invalid-setting-range', `${settingPath} has an invalid numeric range`))
+    }
+    if (setting.defaultValue !== undefined) {
+      const defaultKind = SETTING_DEFAULT_KINDS[setting.type]
+      const validDefault =
+        (defaultKind === 'boolean' && typeof setting.defaultValue === 'boolean') ||
+        (defaultKind === 'string' && typeof setting.defaultValue === 'string') ||
+        (defaultKind === 'option' && Array.isArray(setting.options) && setting.options.some((option) => option.value === setting.defaultValue)) ||
+        (defaultKind === 'number' &&
+          typeof setting.defaultValue === 'number' &&
+          Number.isFinite(setting.defaultValue) &&
+          (setting.min === undefined || setting.defaultValue >= setting.min) &&
+          (setting.max === undefined || setting.defaultValue <= setting.max))
+      if (!validDefault) {
+        diagnostics.push(diagnostic('error', 'invalid-setting-default', `${settingPath}.defaultValue is invalid`))
+      }
+    }
+  }
+}
+
+function validateResourcePath(value) {
+  if (typeof value !== 'string' || !value || value.length > contract.limits.resourcePathLength || value.includes('\\')) {
+    return false
+  }
+  if (value.startsWith('/') || /^[A-Za-z]:/.test(value)) return false
+  const components = value.split('/')
+  return components.every(
+    (component) =>
+      component.length <= contract.limits.tappIdLength &&
+      component !== '.' &&
+      component !== '..' &&
+      SAFE_COMPONENT.test(component),
+  )
+}
+
+function validateStringField(manifest, field, diagnostics, { required = false } = {}) {
+  const value = manifest[field]
+  if (value === undefined && !required) return
+  if (typeof value !== 'string' || !value.trim()) {
+    diagnostics.push(
+      diagnostic('error', 'manifest-field-type', `${field} must be a non-empty string`),
+    )
+  }
+}
+
+function inferredSurfaces(manifest) {
+  const widgets = arrayValue(manifest.widgets)
+  const pageModules = arrayValue(manifest.pageModules)
+  const backgroundRequirements = arrayValue(manifest.backgroundRequirements)
+  const page =
+    manifest.hasPage === true ||
+    typeof manifest.pageTemplate === 'string' ||
+    pageModules.length > 0
+  const widget = widgets.length > 0
+  const headless = backgroundRequirements.length > 0
+  return { page, widget, headless, headlessOnly: headless && !page && !widget }
+}
+
+function validateModeConsistency(manifest, diagnostics, requiredPermissions) {
+  const surfaces = inferredSurfaces(manifest)
+  const widgets = arrayValue(manifest.widgets)
+
+  if (widgets.length > 0) {
+    addRequiredPermission(
+      requiredPermissions,
+      contract.rules.widgetManifestPermission,
+      'manifest declares widgets',
+    )
+  }
+
+  if (manifest.hasPage === true) {
+    const hasPageResource =
+      typeof manifest.pageTemplate === 'string' ||
+      arrayValue(manifest.pageModules).length > 0
+    if (!hasPageResource) {
+      diagnostics.push(
+        diagnostic(
+          'error',
+          'missing-page-resource',
+          'hasPage requires pageTemplate or pageModules',
+        ),
+      )
+    }
+  }
+
+  if (!surfaces.page && !surfaces.widget && !surfaces.headless) {
+    diagnostics.push(
+      diagnostic(
+        'warning',
+        'empty-runtime-surface',
+        'Manifest declares neither Page, Widget, nor backgroundRequirements; only shared core can run',
+      ),
+    )
+  }
+
+  return surfaces
+}
+
+function addRequiredPermission(required, permission, reason, file = 'manifest.json') {
+  if (!permission || permission === API_PUBLIC_ACCESS) return
+  const entry = required.get(permission) || { permission, reasons: [], locations: [] }
+  if (!entry.reasons.includes(reason)) entry.reasons.push(reason)
+  if (!entry.locations.includes(file)) entry.locations.push(file)
+  required.set(permission, entry)
+}
+
+function validateDataExchange(value, diagnostics) {
+  if (!validateFields(value, schemaFields('TappDataExchangeManifest'), 'dataExchange', diagnostics)) {
+    diagnostics.push(diagnostic('error', 'invalid-data-exchange', 'dataExchange must be an object'))
+    return
+  }
+  for (const direction of Object.keys(DATA_EXCHANGE_DIRECTIONS)) {
+    if (value[direction] !== undefined && !Array.isArray(value[direction])) {
+      diagnostics.push(diagnostic('error', 'invalid-data-exchange', `dataExchange.${direction} must be an array`))
+    } else if ((value[direction]?.length || 0) > contract.limits.dataExchangeDeclarations) {
+      diagnostics.push(diagnostic('error', 'invalid-data-exchange', `dataExchange.${direction} accepts at most ${contract.limits.dataExchangeDeclarations} entries`))
+    }
+  }
+  const exportDirection = Object.entries(DATA_EXCHANGE_DIRECTIONS).find(([, kind]) => kind === 'export')?.[0]
+  const importDirection = Object.entries(DATA_EXCHANGE_DIRECTIONS).find(([, kind]) => kind === 'import')?.[0]
+  const exportIds = new Set()
+  for (const [index, entry] of arrayValue(value[exportDirection]).entries()) {
+    const path = `dataExchange.${exportDirection}[${index}]`
+    if (!validateFields(entry, schemaFields('TappDataExport'), path, diagnostics)) {
+      diagnostics.push(diagnostic('error', 'invalid-data-export', `${path} must be an object`))
+      continue
+    }
+    if (!isDataExchangeId(entry.id) || exportIds.has(entry.id)) {
+      diagnostics.push(diagnostic('error', 'invalid-data-export', `${path}.id is invalid or duplicated`))
+    }
+    exportIds.add(entry.id)
+    if (!validateInlineSchema(entry.schema)) {
+      diagnostics.push(diagnostic('error', 'invalid-data-schema', `${path}.schema is not a supported inline JSON Schema`))
+    }
+    if (!Number.isInteger(entry.maxBytes) || entry.maxBytes < 1 || entry.maxBytes > contract.limits.dataExchangeResponseBytes) {
+      diagnostics.push(diagnostic('error', 'invalid-data-export', `${path}.maxBytes must be between 1 and ${contract.limits.dataExchangeResponseBytes}`))
+    }
+    if (entry.maxRecords !== undefined && (!Number.isInteger(entry.maxRecords) || entry.maxRecords < 1 || entry.maxRecords > contract.limits.dataExchangeRecords)) {
+      diagnostics.push(diagnostic('error', 'invalid-data-export', `${path}.maxRecords must be between 1 and ${contract.limits.dataExchangeRecords}`))
+    }
+    if (entry.description !== undefined && (typeof entry.description !== 'string' || entry.description.length > contract.limits.dataExchangeDescriptionLength)) {
+      diagnostics.push(diagnostic('error', 'invalid-data-export', `${path}.description exceeds ${contract.limits.dataExchangeDescriptionLength} characters`))
+    }
+  }
+  const imports = new Set()
+  for (const [index, entry] of arrayValue(value[importDirection]).entries()) {
+    const path = `dataExchange.${importDirection}[${index}]`
+    if (!validateFields(entry, schemaFields('TappDataImport'), path, diagnostics)) {
+      diagnostics.push(diagnostic('error', 'invalid-data-import', `${path} must be an object`))
+      continue
+    }
+    const key = `${entry.tappId}\0${entry.exportId}`
+    if (!isNamedValue(entry.tappId) || !isDataExchangeId(entry.exportId) || imports.has(key)) {
+      diagnostics.push(diagnostic('error', 'invalid-data-import', `${path} is invalid or duplicated`))
+    }
+    imports.add(key)
+  }
+}
+
+function validateAi(value, diagnostics, requiredPermissions) {
+  if (!validateFields(value, schemaFields('TappAiManifest'), 'ai', diagnostics)) {
+    diagnostics.push(diagnostic('error', 'invalid-ai', 'ai must be an object'))
+    return
+  }
+  if (value.protocolVersion !== contract.rules.protocolVersion) {
+    diagnostics.push(diagnostic('error', 'invalid-ai', `ai.protocolVersion must be ${contract.rules.protocolVersion}`))
+  }
+  if (!Array.isArray(value.operations) || value.operations.length < 1 || value.operations.length > contract.limits.aiOperations || value.operations.some((item) => !AI_OPERATIONS.has(item)) || hasDuplicates(value.operations)) {
+    diagnostics.push(diagnostic('error', 'invalid-ai', `ai.operations must contain 1-${contract.limits.aiOperations} unique supported operations`))
+  } else {
+    for (const operation of value.operations) {
+      addRequiredPermission(requiredPermissions, contract.rules.aiOperationPermissions[operation], `manifest.ai uses ${operation}`)
+    }
+  }
+  if (!AI_MODEL_TIERS.has(value.modelTier)) {
+    diagnostics.push(diagnostic('error', 'invalid-ai', 'ai.modelTier must be standard or pro'))
+  }
+  const contextSources = value.contextSources ?? []
+  if (!Array.isArray(contextSources) || contextSources.length > contract.limits.aiContextSources || contextSources.some((item) => !AI_CONTEXT_SOURCES.has(item)) || hasDuplicates(contextSources)) {
+    diagnostics.push(diagnostic('error', 'invalid-ai', 'ai.contextSources must contain unique supported values'))
+  } else {
+    for (const [source, permission] of Object.entries(contract.rules.aiContextPermissionRules)) {
+      if (contextSources.includes(source)) addRequiredPermission(requiredPermissions, permission, `manifest.ai uses ${source} context`)
+    }
+  }
+  if (!Array.isArray(value.outputFormats) || value.outputFormats.length < 1 || value.outputFormats.length > contract.limits.aiOutputFormats || value.outputFormats.some((item) => !AI_OUTPUT_FORMATS.has(item)) || hasDuplicates(value.outputFormats)) {
+    diagnostics.push(diagnostic('error', 'invalid-ai', `ai.outputFormats must contain 1-${contract.limits.aiOutputFormats} unique supported values`))
+  } else {
+    for (const [operation, format] of Object.entries(contract.rules.aiOperationOutputRules)) {
+      if (value.operations?.includes(operation) && !value.outputFormats.includes(format)) {
+        diagnostics.push(diagnostic('error', 'invalid-ai', `ai ${operation} operation requires ${format} output format`))
+      }
+    }
+  }
+}
+
+function validateEvents(value, manifest, diagnostics, requiredPermissions) {
+  if (!validateFields(value, schemaFields('TappEventsManifest'), 'events', diagnostics)) {
+    diagnostics.push(diagnostic('error', 'invalid-events', 'events must be an object'))
+    return
+  }
+  for (const direction of EVENT_DIRECTIONS) {
+    const topics = value[direction] ?? []
+    if (!Array.isArray(topics) || topics.length > contract.limits.eventTopics || hasDuplicates(topics)) {
+      diagnostics.push(diagnostic('error', 'invalid-events', `events.${direction} must contain at most ${contract.limits.eventTopics} unique topics`))
+      continue
+    }
+    for (const topic of topics) {
+      const prefixes = contract.rules.eventTopicPrefixes[direction].map((prefix) =>
+        prefix.replace('{id}', manifest.id),
+      )
+      const valid = isNamedValue(topic) && prefixes.some((prefix) => topic.startsWith(prefix))
+      if (!valid) diagnostics.push(diagnostic('error', 'invalid-event-topic', `Invalid events.${direction} topic: ${String(topic)}`))
+    }
+    if (topics.length) addRequiredPermission(requiredPermissions, contract.rules.eventPermissionRules[direction], `manifest declares event ${direction} topics`)
+  }
+}
+
+function validateAgent(value, diagnostics) {
+  if (!validateFields(value, schemaFields('TappAgentManifest'), 'agent', diagnostics)) {
+    diagnostics.push(diagnostic('error', 'invalid-agent', 'agent must be an object'))
+    return
+  }
+  if (value.protocolVersion !== contract.rules.protocolVersion) {
+    diagnostics.push(diagnostic('error', 'invalid-agent', `agent.protocolVersion must be ${contract.rules.protocolVersion}`))
+  }
+  if (!Array.isArray(value.interactions) || value.interactions.length < 1 || value.interactions.length > contract.limits.agentInteractions) {
+    diagnostics.push(diagnostic('error', 'invalid-agent', `agent.interactions must contain 1-${contract.limits.agentInteractions} entries`))
+  } else {
+    const types = new Set()
+    for (const [index, interaction] of value.interactions.entries()) {
+      const path = `agent.interactions[${index}]`
+      if (!validateFields(interaction, schemaFields('TappAgentInteractionDef'), path, diagnostics)) {
+        diagnostics.push(diagnostic('error', 'invalid-agent-interaction', `${path} must be an object`))
+        continue
+      }
+      if (!isNamedValue(interaction.type) || types.has(interaction.type)) {
+        diagnostics.push(diagnostic('error', 'invalid-agent-interaction', `${path}.type is invalid or duplicated`))
+      }
+      types.add(interaction.type)
+      for (const field of contract.rules.agentSchemaFields) {
+        if (interaction[field] !== undefined && (!validateResourcePath(interaction[field]) || extname(interaction[field]) !== contract.rules.resourceExtensions.agentSchema)) {
+          diagnostics.push(diagnostic('error', 'invalid-agent-schema', `${path}.${field} must be a safe .json resource path`))
+        }
+      }
+    }
+  }
+  const intents = value.intents ?? []
+  if (!Array.isArray(intents) || intents.length > contract.limits.agentIntents || intents.some((intent) => !AGENT_INTENTS.has(intent)) || hasDuplicates(intents)) {
+    diagnostics.push(diagnostic('error', 'invalid-agent', `agent.intents must contain at most ${contract.limits.agentIntents} unique supported intents`))
+  }
+}
+
+function validateManifest(manifest, diagnostics, requiredPermissions) {
+  for (const field of Object.keys(manifest)) {
+    if (!TOP_LEVEL_FIELDS.has(field)) {
+      diagnostics.push(
+        diagnostic('error', 'unknown-manifest-field', `Unknown manifest field: ${field}`),
+      )
+    }
+  }
+
+  for (const field of REQUIRED_MANIFEST_FIELDS) {
+    validateStringField(manifest, field, diagnostics, { required: true })
+  }
+
+  if (typeof manifest.id === 'string' && !SAFE_COMPONENT.test(manifest.id)) {
+    diagnostics.push(
+      diagnostic(
+        'error',
+        'invalid-tapp-id',
+        `id must use 1-${contract.limits.tappIdLength} ASCII letters, numbers, dots, underscores, or hyphens`,
+      ),
+    )
+  }
+  if (typeof manifest.id === 'string' && manifest.id.length > contract.limits.tappIdLength) {
+    diagnostics.push(diagnostic('error', 'invalid-tapp-id', `id exceeds ${contract.limits.tappIdLength} characters`))
+  }
+  if (typeof manifest.version === 'string' && !SEMVER.test(manifest.version)) {
+    diagnostics.push(
+      diagnostic('error', 'invalid-version', 'version must be a semantic version'),
+    )
+  }
+  if (manifest.name !== undefined && (typeof manifest.name !== 'string' || !manifest.name.trim() || manifest.name.length > contract.limits.tappNameLength)) {
+    diagnostics.push(diagnostic('error', 'invalid-name', `name must contain 1-${contract.limits.tappNameLength} characters`))
+  }
+  if (manifest.description !== undefined && (typeof manifest.description !== 'string' || manifest.description.length > contract.limits.tappDescriptionLength)) {
+    diagnostics.push(diagnostic('error', 'invalid-description', `description must not exceed ${contract.limits.tappDescriptionLength} characters`))
+  }
+  if (typeof manifest.category === 'string' && !CATEGORIES.has(manifest.category)) {
+    diagnostics.push(
+      diagnostic(
+        'error',
+        'invalid-category',
+        `category must be one of: ${[...CATEGORIES].join(', ')}`,
+      ),
+    )
+  }
+  for (const [field, extensionKey] of Object.entries(MANIFEST_RESOURCE_FIELDS)) {
+    const extension = contract.rules.resourceExtensions[extensionKey]
+    if (manifest[field] !== undefined && (!validateResourcePath(manifest[field]) || extname(manifest[field]) !== extension)) {
+      diagnostics.push(diagnostic('error', field === 'main' ? 'invalid-main' : 'invalid-resource-path', `${field} must be a safe relative ${extension} path`))
+    }
+  }
+  const normalizedSystemVersion = typeof manifest.minSystemVersion === 'string'
+    ? contract.rules.semverPrefixes.reduce(
+        (value, prefix) => value.startsWith(prefix) ? value.slice(prefix.length) : value,
+        manifest.minSystemVersion,
+      )
+    : manifest.minSystemVersion
+  if (manifest.minSystemVersion !== undefined && (typeof manifest.minSystemVersion !== 'string' || !SEMVER.test(normalizedSystemVersion))) {
+    diagnostics.push(diagnostic('error', 'invalid-system-version', 'minSystemVersion must be a semantic version'))
+  }
+  if (manifest.icon !== undefined && (typeof manifest.icon !== 'string' || manifest.icon.length > contract.limits.tappIconLength)) {
+    diagnostics.push(diagnostic('error', 'invalid-icon', `icon must not exceed ${contract.limits.tappIconLength} characters`))
+  }
+  if (manifest.iconSvg !== undefined && (typeof manifest.iconSvg !== 'string' || Buffer.byteLength(manifest.iconSvg) > contract.limits.tappIconSvgBytes)) {
+    diagnostics.push(diagnostic('error', 'invalid-icon', `iconSvg must not exceed ${formatBytes(contract.limits.tappIconSvgBytes)}`))
+  }
+
+  if (manifest.permissions !== undefined && !Array.isArray(manifest.permissions)) {
+    diagnostics.push(
+      diagnostic('error', 'invalid-permissions', 'permissions must be an array'),
+    )
+  } else if (manifest.permissions) {
+    if (manifest.permissions.length > contract.limits.tappPermissions) {
+      diagnostics.push(
+        diagnostic('error', 'invalid-permissions', `permissions accepts at most ${contract.limits.tappPermissions} entries`),
+      )
+    }
+    const seen = new Set()
+    for (const permission of manifest.permissions) {
+      if (typeof permission !== 'string' || !(permission in catalog.permissionLevels)) {
+        diagnostics.push(
+          diagnostic('error', 'unknown-permission', `Unknown permission: ${String(permission)}`),
+        )
+      } else if (seen.has(permission)) {
+        diagnostics.push(
+          diagnostic('error', 'duplicate-permission', `Duplicate permission: ${permission}`),
+        )
+      }
+      seen.add(permission)
+    }
+  }
+
+  if (manifest.author !== undefined) {
+    validateFields(manifest.author, schemaFields('TappAuthor'), 'author', diagnostics)
+    if (!isObject(manifest.author) || typeof manifest.author.name !== 'string' || !manifest.author.name.trim() || manifest.author.name.length > contract.limits.tappNameLength) {
+      diagnostics.push(
+        diagnostic('error', 'invalid-author', 'author must contain a string name'),
+      )
+    }
+    if (manifest.author?.email !== undefined && (typeof manifest.author.email !== 'string' || manifest.author.email.length > contract.limits.authorEmailLength || /\s/.test(manifest.author.email) || !manifest.author.email.includes('@'))) {
+      diagnostics.push(diagnostic('error', 'invalid-author', 'author.email is invalid'))
+    }
+    if (manifest.author?.url !== undefined && !validateHttpUrl(manifest.author.url)) {
+      diagnostics.push(diagnostic('error', 'invalid-author', 'author.url must be an HTTP(S) URL'))
+    }
+  }
+  if (
+    manifest.themeColor !== undefined &&
+    (typeof manifest.themeColor !== 'string' || !THEME_COLOR.test(manifest.themeColor))
+  ) {
+    diagnostics.push(
+      diagnostic('error', 'invalid-theme-color', 'themeColor must use #RRGGBB'),
+    )
+  }
+  for (const field of URL_FIELDS) {
+    if (manifest[field] === undefined) continue
+    try {
+      if (!validateHttpUrl(manifest[field])) throw new Error('invalid URL')
+    } catch {
+      diagnostics.push(
+        diagnostic('error', 'invalid-url', `${field} must be an HTTP(S) URL`),
+      )
+    }
+  }
+
+  if (manifest.locales !== undefined) {
+    if (!isObject(manifest.locales)) {
+      diagnostics.push(diagnostic('error', 'invalid-locales', 'locales must be an object'))
+    } else {
+      const locales = Object.entries(manifest.locales)
+      if (locales.length > contract.limits.tappLocales) {
+        diagnostics.push(
+          diagnostic('error', 'invalid-locales', `locales accepts at most ${contract.limits.tappLocales} languages`),
+        )
+      }
+      for (const [locale, entry] of locales) {
+        if (locale.length > contract.limits.localeTagLength || !LOCALE_TAG.test(locale)) {
+          diagnostics.push(
+            diagnostic('error', 'invalid-locale', `Invalid BCP-47 locale: ${locale}`),
+          )
+        }
+        if (!isObject(entry)) {
+          diagnostics.push(
+            diagnostic('error', 'invalid-locale', `locales.${locale} must be an object`),
+          )
+          continue
+        }
+        validateFields(entry, schemaFields('TappManifestLocaleEntry'), `locales.${locale}`, diagnostics)
+        if (
+          entry.name !== undefined &&
+          (typeof entry.name !== 'string' || !entry.name.trim() || entry.name.length > contract.limits.tappNameLength)
+        ) {
+          diagnostics.push(
+            diagnostic('error', 'invalid-locale', `locales.${locale}.name is invalid`),
+          )
+        }
+        if (
+          entry.description !== undefined &&
+          (typeof entry.description !== 'string' || entry.description.length > contract.limits.tappDescriptionLength)
+        ) {
+          diagnostics.push(
+            diagnostic('error', 'invalid-locale', `locales.${locale}.description is invalid`),
+          )
+        }
+      }
+    }
+  }
+
+  if (manifest.cssMode !== undefined && !CSS_MODES.has(manifest.cssMode)) {
+    diagnostics.push(
+      diagnostic('error', 'invalid-css-mode', 'cssMode must be unified or separated'),
+    )
+  }
+  if (manifest.hasPage !== undefined && typeof manifest.hasPage !== 'boolean') {
+    diagnostics.push(diagnostic('error', 'invalid-has-page', 'hasPage must be boolean'))
+  }
+  if (manifest.backgroundRequirements !== undefined && (
+    !Array.isArray(manifest.backgroundRequirements) ||
+    manifest.backgroundRequirements.length > contract.limits.backgroundRequirements ||
+    manifest.backgroundRequirements.some((value) => !BACKGROUND_REQUIREMENTS.has(value)) ||
+    hasDuplicates(manifest.backgroundRequirements)
+  )) {
+    diagnostics.push(
+      diagnostic(
+        'error',
+        'invalid-background-requirements',
+        'backgroundRequirements contains an unknown value',
+      ),
+    )
+  }
+
+  if (manifest.settings !== undefined) validateSettings(manifest.settings, 'settings', diagnostics)
+
+  if (manifest.pageModules !== undefined) {
+    if (
+      !Array.isArray(manifest.pageModules) ||
+      manifest.pageModules.length > contract.limits.pageModules ||
+      manifest.pageModules.some((module) => typeof module !== 'string' || module.length > contract.limits.tappIdLength || !SAFE_COMPONENT.test(module) || !module.endsWith(contract.rules.resourceExtensions.pageModule)) ||
+      hasDuplicates(manifest.pageModules)
+    ) {
+      diagnostics.push(diagnostic('error', 'invalid-page-modules', `pageModules must contain at most ${contract.limits.pageModules} unique ${contract.rules.resourceExtensions.pageModule} filenames`))
+    }
+  }
+
+  if (manifest.assets !== undefined && (
+    !Array.isArray(manifest.assets) ||
+    manifest.assets.some((asset) => typeof asset !== 'string') ||
+    hasDuplicates(manifest.assets)
+  )) {
+    diagnostics.push(diagnostic('error', 'invalid-assets', 'assets must contain unique resource paths'))
+  }
+
+  if (manifest.widgets !== undefined && !Array.isArray(manifest.widgets)) {
+    diagnostics.push(diagnostic('error', 'invalid-widgets', 'widgets must be an array'))
+  } else if (manifest.widgets?.length) {
+    if (manifest.widgets.length > contract.limits.widgets) {
+      diagnostics.push(diagnostic('error', 'invalid-widgets', `widgets accepts at most ${contract.limits.widgets} entries`))
+    }
+    const ids = new Set()
+    for (const [widgetIndex, widget] of manifest.widgets.entries()) {
+      validateFields(widget, schemaFields('TappWidgetDef'), `widgets[${widgetIndex}]`, diagnostics)
+      if (!isObject(widget) || typeof widget.id !== 'string' || widget.id.length > contract.limits.tappIdLength || !SAFE_COMPONENT.test(widget.id)) {
+        diagnostics.push(diagnostic('error', 'invalid-widget', 'Widget id is invalid'))
+        continue
+      }
+      if (ids.has(widget.id)) {
+        diagnostics.push(
+          diagnostic('error', 'duplicate-widget', `Duplicate Widget id: ${widget.id}`),
+        )
+      }
+      ids.add(widget.id)
+      if (typeof widget.name !== 'string' || !widget.name) {
+        diagnostics.push(
+          diagnostic('error', 'invalid-widget', `Widget ${widget.id} requires a name`),
+        )
+      }
+      if (widget.name?.length > contract.limits.tappNameLength) {
+        diagnostics.push(diagnostic('error', 'invalid-widget', `Widget ${widget.id} name exceeds ${contract.limits.tappNameLength} characters`))
+      }
+      if (widget.category !== undefined && !WIDGET_CATEGORIES.has(widget.category)) {
+        diagnostics.push(diagnostic('error', 'invalid-widget-category', `Widget ${widget.id} category is invalid`))
+      }
+      if (
+        !Array.isArray(widget.sizes) ||
+        widget.sizes.length === 0 ||
+        widget.sizes.length > contract.limits.widgetSizes ||
+        widget.sizes.some((size) => !WIDGET_SIZES.has(size)) ||
+        !widget.sizes.includes(widget.defaultSize)
+      ) {
+        diagnostics.push(
+          diagnostic('error', 'invalid-widget-sizes', `Widget ${widget.id} sizes are invalid`),
+        )
+      }
+      if (widget.templates !== undefined && !isObject(widget.templates)) {
+        diagnostics.push(
+          diagnostic('error', 'invalid-widget-templates', `Widget ${widget.id} templates are invalid`),
+        )
+      } else if (widget.templates) {
+        for (const [size, path] of Object.entries(widget.templates)) {
+          if (!WIDGET_SIZES.has(size) || !widget.sizes?.includes(size) || !validateResourcePath(path) || extname(path) !== contract.rules.resourceExtensions.widgetTemplate) {
+            diagnostics.push(diagnostic('error', 'invalid-widget-template', `Widget ${widget.id} template ${size} is invalid`))
+          }
+        }
+      }
+      if (widget.settings !== undefined) {
+        validateSettings(widget.settings, `widgets[${widgetIndex}].settings`, diagnostics)
+      }
+      if (widget.refreshPolicy !== undefined) {
+        const path = `widgets[${widgetIndex}].refreshPolicy`
+        if (!validateFields(widget.refreshPolicy, schemaFields('TappWidgetRefreshPolicy'), path, diagnostics)) {
+          diagnostics.push(diagnostic('error', 'invalid-widget-refresh', `${path} must be an object`))
+        } else if (
+          !WIDGET_REFRESH_MODES.has(widget.refreshPolicy.mode) ||
+          (widget.refreshPolicy.refreshOnVisible !== undefined && typeof widget.refreshPolicy.refreshOnVisible !== 'boolean') ||
+          (widget.refreshPolicy.mode === WIDGET_REFRESH_EVENT_MODE && widget.refreshPolicy.intervalSeconds !== undefined) ||
+          (widget.refreshPolicy.mode === WIDGET_REFRESH_INTERVAL_MODE && (!Number.isInteger(widget.refreshPolicy.intervalSeconds) || widget.refreshPolicy.intervalSeconds < contract.limits.widgetRefreshIntervalMinSeconds || widget.refreshPolicy.intervalSeconds > contract.limits.widgetRefreshIntervalMaxSeconds))
+        ) {
+          diagnostics.push(diagnostic('error', 'invalid-widget-refresh', `Widget ${widget.id} refreshPolicy is invalid`))
+        }
+      }
+    }
+  }
+
+  if (manifest.apis !== undefined && !isObject(manifest.apis)) {
+    diagnostics.push(diagnostic('error', 'invalid-apis', 'apis must be an object'))
+  } else if (manifest.apis) {
+    if (Object.keys(manifest.apis).length > contract.limits.tappApis) {
+      diagnostics.push(diagnostic('error', 'invalid-apis', `apis accepts at most ${contract.limits.tappApis} entries`))
+    }
+    for (const [name, definition] of Object.entries(manifest.apis)) {
+      if (!isNamedValue(name) || !isObject(definition)) {
+        diagnostics.push(diagnostic('error', 'invalid-api', `API declaration ${name} is invalid`))
+        continue
+      }
+      validateFields(definition, schemaFields('TappApiDef'), `apis.${name}`, diagnostics)
+      if (definition.access !== undefined && !API_ACCESS_LEVELS.has(definition.access)) {
+        diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} access is invalid`))
+      }
+      const method = definition.method || DEFAULT_HTTP_METHOD
+      if (typeof method !== 'string' || !HTTP_METHODS.has(method)) {
+        diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} HTTP method must be one of: ${contract.rules.httpMethods.join(', ')}`))
+      }
+      if (definition.inject !== undefined && !isObject(definition.inject)) {
+        diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} inject must be an object`))
+      } else if (definition.inject) {
+        if (Object.keys(definition.inject).length > contract.limits.apiInjectAliases) {
+          diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} inject accepts at most ${contract.limits.apiInjectAliases} aliases`))
+        }
+        for (const [alias, template] of Object.entries(definition.inject)) {
+          if (!isNamedValue(alias) || contract.rules.apiInjectReservedPrefixes.some((prefix) => alias.startsWith(prefix)) || typeof template !== 'string' || !template || template.length > contract.limits.apiInjectTemplateLength) {
+            diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} inject alias ${alias} is invalid`))
+          }
+        }
+      }
+      if (definition.cacheTtl !== undefined && (!Number.isInteger(definition.cacheTtl) || definition.cacheTtl < 0 || definition.cacheTtl > contract.limits.apiCacheTtlSeconds)) {
+        diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} cacheTtl must be between 0 and ${contract.limits.apiCacheTtlSeconds}`))
+      }
+      if (JSON.stringify(definition).includes('{{secrets.')) {
+        diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} cannot reference host secret templates`))
+      }
+      const type = definition.type || DEFAULT_API_TYPE
+      if (!API_TYPES.has(type)) {
+        diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} type must be one of: ${contract.rules.apiTypes.join(', ')}`))
+        continue
+      }
+      if (type === HTTP_API_TYPE) {
+        addRequiredPermission(
+          requiredPermissions,
+          contract.rules.httpApiPermission,
+          `manifest.apis.${name} uses HTTP`,
+        )
+        if (typeof definition.endpoint !== 'string' || !definition.endpoint) {
+          diagnostics.push(
+            diagnostic('error', 'invalid-api', `HTTP API ${name} requires endpoint`),
+          )
+        }
+        if (definition.builtin !== undefined) {
+          diagnostics.push(diagnostic('error', 'invalid-api', `HTTP API ${name} cannot declare builtin`))
+        }
+      } else if (type === BUILTIN_API_TYPE) {
+        if (!API_BUILTINS.has(definition.builtin)) {
+          diagnostics.push(
+            diagnostic('error', 'invalid-api', `Builtin API ${name} has an unknown builtin`),
+          )
+        }
+        const operation = API_BUILTIN_AI_OPERATIONS[definition.builtin]
+        if (operation) {
+          addRequiredPermission(
+            requiredPermissions,
+            API_BUILTIN_PERMISSIONS[definition.builtin],
+            `manifest.apis.${name} uses ${definition.builtin}`,
+          )
+          if (manifest.ai?.protocolVersion !== contract.rules.protocolVersion || !manifest.ai?.operations?.includes(operation) || !manifest.ai?.outputFormats?.includes(contract.rules.aiBuiltinOutputFormat)) {
+            diagnostics.push(diagnostic('error', 'invalid-api', `Builtin API ${name} requires matching protocolVersion ${contract.rules.protocolVersion} AI operation and ${contract.rules.aiBuiltinOutputFormat} output`))
+          }
+        }
+        if (contract.rules.httpOnlyApiFields.some((field) => definition[field] !== undefined)) {
+          diagnostics.push(diagnostic('error', 'invalid-api', `Builtin API ${name} contains HTTP-only fields`))
+        }
+      } else {
+        diagnostics.push(
+          diagnostic('error', 'invalid-api', `API ${name} type must be one of: ${contract.rules.apiTypes.join(', ')}`),
+        )
+      }
+    }
+  }
+
+  if (manifest.dataExchange !== undefined) validateDataExchange(manifest.dataExchange, diagnostics)
+  if (manifest.ai !== undefined) validateAi(manifest.ai, diagnostics, requiredPermissions)
+  if (manifest.events !== undefined) validateEvents(manifest.events, manifest, diagnostics, requiredPermissions)
+  if (manifest.agent !== undefined) validateAgent(manifest.agent, diagnostics)
+}
+
+async function pathExists(path) {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function inspectProject(projectRoot = '.') {
+  const root = resolve(projectRoot)
+  const diagnostics = []
+  const manifestPath = join(root, 'manifest.json')
+  let manifest
+
+  try {
+    // Check the size before loading the manifest into memory.
+    if ((await stat(manifestPath)).size > contract.limits.manifestBytes) {
+      diagnostics.push(
+        diagnostic('error', 'manifest-too-large', `manifest.json exceeds ${formatBytes(contract.limits.manifestBytes)}`),
+      )
+      return {
+        root,
+        manifest: null,
+        diagnostics,
+        surfaces: { page: false, widget: false, headless: false, headlessOnly: false },
+        permissions: { declared: [], required: [], missing: [], usedActions: [] },
+        packageFiles: [],
+      }
+    }
+    manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+  } catch (error) {
+    diagnostics.push(
+      diagnostic(
+        'error',
+        'invalid-manifest',
+        error.code === 'ENOENT' ? 'manifest.json was not found' : 'manifest.json is not valid JSON',
+      ),
+    )
+    return {
+      root,
+      manifest: null,
+      diagnostics,
+      surfaces: { page: false, widget: false, headless: false, headlessOnly: false },
+      permissions: { declared: [], required: [], missing: [], usedActions: [] },
+      packageFiles: [],
+    }
+  }
+
+  if (!isObject(manifest)) {
+    diagnostics.push(diagnostic('error', 'invalid-manifest', 'manifest.json must contain an object'))
+    return {
+      root,
+      manifest: null,
+      diagnostics,
+      surfaces: { page: false, widget: false, headless: false, headlessOnly: false },
+      permissions: { declared: [], required: [], missing: [], usedActions: [] },
+      packageFiles: [],
+    }
+  }
+
+  const requiredPermissions = new Map()
+  validateManifest(manifest, diagnostics, requiredPermissions)
+  const surfaces = validateModeConsistency(manifest, diagnostics, requiredPermissions)
+  const resources = await validateProjectResources(root, manifest)
+  const analysis = await analyzeProjectCode({ root, manifest, surfaces })
+  diagnostics.push(...resources.diagnostics, ...analysis.diagnostics)
+  for (const entry of analysis.requiredPermissions.values()) {
+    for (const reason of entry.reasons) {
+      for (const file of entry.locations) addRequiredPermission(requiredPermissions, entry.permission, reason, file)
+    }
+  }
+
+  const declared = Array.isArray(manifest.permissions) ? manifest.permissions : []
+  const missing = [...requiredPermissions.values()].filter(
+    ({ permission }) => !declared.includes(permission),
+  )
+  for (const entry of missing) {
+    diagnostics.push(
+      diagnostic(
+        'error',
+        'missing-permission',
+        `Missing permission ${entry.permission}: ${entry.reasons.join('; ')}`,
+      ),
+    )
+  }
+
+  return {
+    root,
+    manifest,
+    diagnostics,
+    surfaces,
+    permissions: {
+      declared: declared.map((permission) => ({
+        permission,
+        level: catalog.permissionLevels[permission],
+      })),
+      required: [...requiredPermissions.values()].map((entry) => ({
+        ...entry,
+        level: catalog.permissionLevels[entry.permission],
+      })),
+      missing,
+      usedActions: analysis.usedActions,
+    },
+    packageFiles: resources.packageFiles,
+  }
+}
+
+export async function createProject(directory, options = {}) {
+  const root = resolve(directory)
+  if (await pathExists(root)) {
+    if (!(await lstat(root)).isDirectory()) {
+      throw new Error(`Target path is not a directory: ${root}`)
+    }
+    const existing = await readdir(root)
+    if (existing.length > 0 && !options.force) {
+      throw new Error(`Target directory is not empty: ${root}`)
+    }
+  }
+  await mkdir(root, { recursive: true })
+
+  const { type, hasPage, hasWidget, manifest, source } = createStarterTemplate(root, options)
+  await writeFile(join(root, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+  const typedSource = `/// <reference path="./types/tapp-sdk.d.ts" />\n${source}`
+  await writeFile(join(root, 'main.js'), typedSource)
+  await mkdir(join(root, 'types'), { recursive: true })
+  const sdkDts = await readFile(
+    new URL('./generated/tapp-sdk.d.ts', import.meta.url),
+    'utf8',
+  )
+  await writeFile(join(root, 'types/tapp-sdk.d.ts'), sdkDts)
+  await writeFile(
+    join(root, 'jsconfig.json'),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          checkJs: true,
+          noEmit: true,
+          lib: ['ES2022', 'DOM'],
+          maxNodeModuleJsDepth: 0,
+        },
+        include: ['*.js', '**/*.js', 'types/**/*.d.ts'],
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  await writeFile(
+    join(root, 'styles.css'),
+    `:root { color-scheme: light dark; }
+body { margin: 0; font: 14px/1.5 system-ui, sans-serif; }
+.page, .widget { box-sizing: border-box; display: grid; gap: 12px; padding: 16px; }
+.widget { height: 100%; align-content: center; }
+button { width: fit-content; padding: 8px 12px; }
+`,
+  )
+  if (hasPage) {
+    await writeFile(
+      join(root, 'page.html'),
+      `<main id="tapp-root" class="page">
+  <h1>${manifest.name}</h1>
+  <button type="button" data-action="notify">Show notification</button>
+</main>
+`,
+    )
+  }
+  if (hasWidget) {
+    await mkdir(join(root, 'templates'), { recursive: true })
+    const template = `<div data-widget-root="true" class="widget"></div>\n`
+    await writeFile(join(root, 'templates/widget-2x2.html'), template)
+    await writeFile(join(root, 'templates/widget-4x2.html'), template)
+  }
+  return { root, type, manifest }
+}
+
+export async function packProject(projectRoot = '.', outputPath) {
+  const report = await inspectProject(projectRoot)
+  if (report.diagnostics.some(({ severity }) => severity === 'error')) {
+    const error = new Error('Project validation failed')
+    error.report = report
+    throw error
+  }
+
+  const entries = []
+  let uncompressedBytes = 0
+  // Pack only installable package files (not local editor helpers like types/).
+  const packagePaths = new Set(
+    expectedPackagePaths({
+      manifest: report.manifest,
+      extraPaths: report.packageFiles,
+    }),
+  )
+  // Drop only the starter's editor scaffolding; any other path under types/
+  // is a legitimately declared resource and must stay in the package.
+  packagePaths.delete('jsconfig.json')
+  packagePaths.delete('types/tapp-sdk.d.ts')
+
+  const normalizedManifest = normalizeManifestPaths(report.manifest)
+  for (const path of [...packagePaths].sort()) {
+    let data
+    if (path === 'manifest.json') {
+      data = Buffer.from(`${JSON.stringify(normalizedManifest, null, 2)}\n`)
+      if (data.length > contract.limits.manifestBytes) {
+        throw new Error(`manifest.json exceeds ${formatBytes(contract.limits.manifestBytes)}`)
+      }
+    } else {
+      const absolute = join(report.root, path)
+      try {
+        data = await readFile(absolute)
+      } catch (error) {
+        if (error.code === 'ENOENT') {
+          throw new Error(`Package entry disappeared during packing: ${path}`, { cause: error })
+        }
+        throw error
+      }
+      if (data.length > contract.limits.resourceBytes) {
+        throw new Error(`Package entry exceeds ${formatBytes(contract.limits.resourceBytes)}: ${path}`)
+      }
+    }
+    uncompressedBytes += data.length
+    entries.push({ path, data })
+  }
+  if (entries.length > MAX_ARCHIVE_FILES) throw new Error(`Package exceeds ${MAX_ARCHIVE_FILES} entries`)
+  if (uncompressedBytes > MAX_UNCOMPRESSED_BYTES) {
+    throw new Error(`Package exceeds ${formatBytes(MAX_UNCOMPRESSED_BYTES)} uncompressed`)
+  }
+
+  const target = resolve(
+    outputPath || join(report.root, 'dist', `${report.manifest.id}.tapp`),
+  )
+  if (zipSize(entries) > MAX_ARCHIVE_BYTES) {
+    throw new Error(`Package exceeds ${formatBytes(MAX_ARCHIVE_BYTES)}`)
+  }
+  const result = await writeZip(target, entries)
+  return { ...result, report }
+}
+
+export function permissionCatalog() {
+  return catalog
+}
+
+export function generatedContract() {
+  return contract
+}
+
+export { expectedPackagePaths, normalizeManifestPaths, PACKAGE_MARKERS }

--- a/tapp-cli/src/resource-validator.mjs
+++ b/tapp-cli/src/resource-validator.mjs
@@ -1,0 +1,212 @@
+import { access, lstat, realpath, readdir, readFile, stat } from 'node:fs/promises'
+import { extname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+const contract = JSON.parse(
+  await readFile(new URL('./generated/contract.json', import.meta.url), 'utf8'),
+)
+const MANIFEST_RESOURCE_FIELDS = contract.rules.manifestResourceFields
+const AGENT_SCHEMA_FIELDS = new Set(contract.rules.agentSchemaFields)
+const PACKAGE_RESOURCE_EXTENSIONS = contract.rules.packageResourceExtensions
+const PACKAGE_JSON_OBJECT_DIRECTORIES = new Set(contract.rules.packageJsonObjectDirectories)
+const PACKAGE_RESOURCE_FILE_LIMITS = contract.rules.packageResourceFileLimits
+const PACKAGE_RESOURCE_BYTE_LIMITS = contract.rules.packageResourceByteLimits
+const ASSET_DIRECTORY = contract.rules.assetDirectory
+const PAGE_MODULE_DIRECTORY = contract.rules.pageModuleDirectory
+const SAFE_COMPONENT = new RegExp(contract.patterns.safeComponent)
+
+function diagnostic(severity, code, message, file = 'manifest.json', line, column) {
+  return { severity, code, message, file, line, column }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function formatBytes(bytes) {
+  for (const [unitBytes, unit] of [[1024 ** 3, 'GiB'], [1024 ** 2, 'MiB'], [1024, 'KiB']]) {
+    if (bytes >= unitBytes && bytes % unitBytes === 0) return `${bytes / unitBytes} ${unit}`
+  }
+  return `${bytes} bytes`
+}
+
+function validateInlineSchema(schema) {
+  if (!isObject(schema) || Buffer.byteLength(JSON.stringify(schema)) > contract.limits.dataExchangeSchemaBytes) return false
+  if (!contract.rules.inlineSchemaRootKeys.some((field) => field in schema)) return false
+  const visit = (value, depth) => {
+    if (depth > contract.limits.inlineSchemaDepth) return false
+    if (Array.isArray(value)) return value.every((child) => visit(child, depth + 1))
+    if (!isObject(value)) return true
+    if ('$ref' in value) return false
+    return Object.values(value).every((child) => visit(child, depth + 1))
+  }
+  return visit(schema, 0)
+}
+
+function validateResourcePath(value) {
+  if (typeof value !== 'string' || !value || value.length > contract.limits.resourcePathLength || value.includes('\\')) return false
+  if (value.startsWith('/') || /^[A-Za-z]:/.test(value)) return false
+  return value.split('/').every((component) => component.length <= contract.limits.tappIdLength && component !== '.' && component !== '..' && SAFE_COMPONENT.test(component))
+}
+
+function isPathWithin(root, target) {
+  const path = relative(root, target)
+  return path !== '' && path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path)
+}
+
+async function pathExists(path) {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function resourceDeclarations(manifest) {
+  const declarations = new Map()
+  const add = (path, kind, extension) => {
+    if (typeof path === 'string' && path) declarations.set(path, { kind, extension })
+  }
+  for (const [field, extensionKey] of Object.entries(MANIFEST_RESOURCE_FIELDS)) {
+    add(manifest[field], field, contract.rules.resourceExtensions[extensionKey])
+  }
+  for (const module of arrayValue(manifest.pageModules)) add(`${PAGE_MODULE_DIRECTORY}/${module}`, 'pageModule', contract.rules.resourceExtensions.pageModule)
+  for (const asset of arrayValue(manifest.assets)) add(asset, 'asset')
+  for (const widget of arrayValue(manifest.widgets)) {
+    if (!isObject(widget)) continue
+    for (const path of Object.values(widget.templates || {})) add(path, `widgetTemplate:${widget.id}`, contract.rules.resourceExtensions.widgetTemplate)
+  }
+  for (const interaction of arrayValue(manifest.agent?.interactions)) {
+    for (const field of AGENT_SCHEMA_FIELDS) add(interaction?.[field], 'agentSchema', contract.rules.resourceExtensions.agentSchema)
+  }
+  return declarations
+}
+
+export async function validateProjectResources(root, manifest) {
+  const diagnostics = []
+  const declarations = resourceDeclarations(manifest)
+  const packagePaths = new Set(['manifest.json'])
+  const canonicalRoot = await realpath(root)
+  let assetBytes = 0
+
+  for (const [path, metadata] of declarations) {
+    if (!validateResourcePath(path)) {
+      diagnostics.push(diagnostic('error', 'invalid-resource-path', `Invalid ${metadata.kind} path: ${path}`))
+      continue
+    }
+    if (metadata.extension && extname(path) !== metadata.extension) {
+      diagnostics.push(diagnostic('error', 'invalid-resource-extension', `${metadata.kind} must use ${metadata.extension}: ${path}`))
+    }
+    const absolute = resolve(root, path)
+    if (!isPathWithin(root, absolute)) {
+      diagnostics.push(diagnostic('error', 'invalid-resource-path', `Resource escapes the project root: ${path}`))
+      continue
+    }
+    if (!(await pathExists(absolute))) {
+      diagnostics.push(diagnostic('error', 'missing-resource', `Declared resource not found: ${path}`))
+      continue
+    }
+    const info = await lstat(absolute)
+    if (!info.isFile()) {
+      diagnostics.push(diagnostic('error', 'invalid-resource', `Resource is not a file: ${path}`))
+      continue
+    }
+    if (!isPathWithin(canonicalRoot, await realpath(absolute))) {
+      diagnostics.push(diagnostic('error', 'invalid-resource', `Resource escapes the project root: ${path}`))
+      continue
+    }
+    packagePaths.add(path)
+    if (info.size > contract.limits.resourceBytes) {
+      diagnostics.push(diagnostic('error', 'resource-too-large', `${path} exceeds ${formatBytes(contract.limits.resourceBytes)}`))
+    }
+    if (metadata.kind === 'asset') {
+      assetBytes += info.size
+      if (!path.startsWith(`${ASSET_DIRECTORY}/`) || contract.rules.assetForbiddenExtensions.includes(extname(path))) {
+        diagnostics.push(diagnostic('error', 'invalid-asset', `Asset must be under ${ASSET_DIRECTORY}/ and cannot be JS/HTML: ${path}`))
+      }
+      if (info.size > contract.limits.assetBytes) diagnostics.push(diagnostic('error', 'asset-too-large', `Asset exceeds ${formatBytes(contract.limits.assetBytes)}: ${path}`))
+    }
+    if (metadata.kind === 'agentSchema') {
+      if (info.size > contract.limits.agentSchemaBytes) diagnostics.push(diagnostic('error', 'agent-schema-too-large', `${path} exceeds ${formatBytes(contract.limits.agentSchemaBytes)}`))
+      try {
+        const schema = JSON.parse(await readFile(absolute, 'utf8'))
+        if (!validateInlineSchema(schema)) throw new Error('unsupported schema')
+      } catch {
+        diagnostics.push(diagnostic('error', 'invalid-agent-schema', `${path} is not a supported inline JSON Schema`))
+      }
+    }
+  }
+
+  if (arrayValue(manifest.assets).length > contract.limits.assets) diagnostics.push(diagnostic('error', 'too-many-assets', `assets accepts at most ${contract.limits.assets} entries`))
+  if (assetBytes > contract.limits.assetsTotalBytes) diagnostics.push(diagnostic('error', 'assets-too-large', `Declared assets exceed ${formatBytes(contract.limits.assetsTotalBytes)} total`))
+
+  for (const [directory, extension] of Object.entries(PACKAGE_RESOURCE_EXTENSIONS)) {
+    const absoluteDirectory = join(root, directory)
+    let directoryInfo
+    try {
+      directoryInfo = await lstat(absoluteDirectory)
+    } catch (error) {
+      if (error.code === 'ENOENT') continue
+      diagnostics.push(diagnostic('error', `invalid-${directory}`, `${directory} directory cannot be read`))
+      continue
+    }
+    // Reject symlinked directories so packed files cannot escape the project root.
+    if (!directoryInfo.isDirectory()) {
+      diagnostics.push(diagnostic('error', `invalid-${directory}`, `${directory} must be a regular directory inside the project`))
+      continue
+    }
+    let directoryEntries
+    try {
+      directoryEntries = await readdir(absoluteDirectory, { withFileTypes: true })
+    } catch {
+      diagnostics.push(diagnostic('error', `invalid-${directory}`, `${directory} directory cannot be read`))
+      continue
+    }
+    const fileLimitKey = PACKAGE_RESOURCE_FILE_LIMITS[directory]
+    if (fileLimitKey && directoryEntries.length > contract.limits[fileLimitKey]) diagnostics.push(diagnostic('error', `too-many-${directory}-files`, `${directory} accepts at most ${contract.limits[fileLimitKey]} files`))
+    for (const entry of directoryEntries) {
+      if (PACKAGE_JSON_OBJECT_DIRECTORIES.has(directory) && (!entry.isFile() || extname(entry.name) !== extension)) {
+        diagnostics.push(diagnostic('error', `invalid-${directory}`, `${directory}/${entry.name} must be a regular JSON file`))
+        continue
+      }
+      if (!entry.isFile()) continue
+      if (!PACKAGE_JSON_OBJECT_DIRECTORIES.has(directory) && extname(entry.name) !== extension) continue
+      const path = `${directory}/${entry.name}`
+      if (!validateResourcePath(path)) {
+        diagnostics.push(diagnostic('error', 'invalid-resource-path', `Invalid path: ${path}`))
+        continue
+      }
+      // Dirent.isFile() uses lstat semantics and the parent directory is a
+      // verified non-symlink, so entries here cannot escape the project root.
+      const absoluteEntry = join(absoluteDirectory, entry.name)
+      let info
+      try {
+        info = await stat(absoluteEntry)
+      } catch {
+        diagnostics.push(diagnostic('error', `invalid-${directory}`, `${path} cannot be read`))
+        continue
+      }
+      const byteLimitKey = PACKAGE_RESOURCE_BYTE_LIMITS[directory]
+      const directoryLimit = byteLimitKey ? contract.limits[byteLimitKey] : Number.POSITIVE_INFINITY
+      const byteLimit = Math.min(directoryLimit, contract.limits.resourceBytes)
+      if (info.size > byteLimit) {
+        const code = byteLimit === directoryLimit ? `${directory}-too-large` : 'resource-too-large'
+        diagnostics.push(diagnostic('error', code, `${path} exceeds ${formatBytes(byteLimit)}`))
+      }
+      if (PACKAGE_JSON_OBJECT_DIRECTORIES.has(directory)) {
+        try {
+          const value = JSON.parse(await readFile(absoluteEntry, 'utf8'))
+          if (!isObject(value)) throw new Error('resource must be an object')
+        } catch {
+          diagnostics.push(diagnostic('error', `invalid-${directory}`, `${path} must contain a JSON object`))
+        }
+      }
+      packagePaths.add(path)
+    }
+  }
+  return { diagnostics, packageFiles: [...packagePaths].sort() }
+}

--- a/tapp-cli/src/source-analyzer.mjs
+++ b/tapp-cli/src/source-analyzer.mjs
@@ -1,0 +1,193 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { extname, join, relative, sep } from 'node:path'
+import ts from 'typescript'
+
+const contract = JSON.parse(
+  await readFile(new URL('./generated/contract.json', import.meta.url), 'utf8'),
+)
+const ACTIONS = contract.permissions.actions
+const HEADLESS_DENIED_ACTIONS = new Set(contract.capabilities?.headlessDeniedActions || [])
+const CODE_EXTENSIONS = new Set(contract.rules.sourceCodeExtensions)
+const SKIP_DIRECTORIES = new Set(contract.rules.sourceScanSkipDirectories)
+const ASSET_LITERAL_METHODS = new Set(contract.rules.assetLiteralMethods)
+const ASSET_DIRECTORY = contract.rules.assetDirectory
+const API_PUBLIC_ACCESS = contract.schema.$defs.TappApiAccess.enum.find(
+  (value) => value === 'public',
+)
+
+function diagnostic(severity, code, message, file, line, column) {
+  return { severity, code, message, file, line, column }
+}
+
+function addRequiredPermission(required, permission, reason, file) {
+  if (!permission || permission === API_PUBLIC_ACCESS) return
+  const entry = required.get(permission) || { permission, reasons: [], locations: [] }
+  if (!entry.reasons.includes(reason)) entry.reasons.push(reason)
+  if (!entry.locations.includes(file)) entry.locations.push(file)
+  required.set(permission, entry)
+}
+
+function scriptKind(file) {
+  if (file.endsWith('.tsx')) return ts.ScriptKind.TSX
+  if (file.endsWith('.jsx')) return ts.ScriptKind.JSX
+  if (file.endsWith('.ts')) return ts.ScriptKind.TS
+  return ts.ScriptKind.JS
+}
+
+function unwrapExpression(node) {
+  while (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    node = node.expression
+  }
+  return node
+}
+
+function staticMemberName(node) {
+  if (ts.isPropertyAccessExpression(node)) return node.name.text
+  if (ts.isElementAccessExpression(node)) {
+    const argument = unwrapExpression(node.argumentExpression)
+    if (ts.isStringLiteralLike(argument)) return argument.text
+  }
+  return undefined
+}
+
+function tappCallPath(expression) {
+  const path = []
+  let current = unwrapExpression(expression)
+  while (ts.isPropertyAccessExpression(current) || ts.isElementAccessExpression(current)) {
+    const name = staticMemberName(current)
+    if (name === undefined) return undefined
+    path.unshift(name)
+    current = unwrapExpression(current.expression)
+  }
+  return ts.isIdentifier(current) && current.text === 'Tapp' ? path : undefined
+}
+
+function resolveAction(path) {
+  for (let end = path.length; end >= 2; end -= 1) {
+    const action = path.slice(0, end).join('.')
+    if (Object.hasOwn(ACTIONS, action)) return action
+  }
+  return undefined
+}
+
+function literalString(node) {
+  const value = node && unwrapExpression(node)
+  return value && ts.isStringLiteralLike(value) ? value.text : undefined
+}
+
+function inspectCode(source, file, manifest, diagnostics, requiredPermissions, usedActions, surfaces) {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind(file),
+  )
+
+  for (const parseDiagnostic of sourceFile.parseDiagnostics) {
+    const location = sourceFile.getLineAndCharacterOfPosition(parseDiagnostic.start || 0)
+    diagnostics.push(
+      diagnostic(
+        'error',
+        'invalid-source-syntax',
+        ts.flattenDiagnosticMessageText(parseDiagnostic.messageText, '\n'),
+        file,
+        location.line + 1,
+        location.character + 1,
+      ),
+    )
+  }
+
+  function visit(node) {
+    if (!ts.isCallExpression(node)) {
+      ts.forEachChild(node, visit)
+      return
+    }
+
+    const path = tappCallPath(node.expression)
+    if (!path) {
+      ts.forEachChild(node, visit)
+      return
+    }
+    const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+    const location = { line: position.line + 1, column: position.character + 1 }
+
+    const action = resolveAction(path)
+    if (action) {
+      const permission = ACTIONS[action]
+      usedActions.push({ action, permission, file, ...location })
+      addRequiredPermission(requiredPermissions, permission, `code calls ${action}`, file)
+      if (HEADLESS_DENIED_ACTIONS.has(action)) {
+        if (surfaces?.headlessOnly) {
+          diagnostics.push(diagnostic('error', 'headless-denied-action', `${action} is unavailable in headless-only Tapps`, file, location.line, location.column))
+        } else if (surfaces?.headless) {
+          diagnostics.push(diagnostic('warning', 'headless-unavailable-action', `${action} is unavailable in headless core; keep it in Page/Widget code paths`, file, location.line, location.column))
+        }
+      }
+    }
+
+    if (path.length === 1 && path[0] === 'api') {
+      const name = literalString(node.arguments[0])
+      if (name === undefined) {
+        diagnostics.push(diagnostic('warning', 'dynamic-api-name', 'A dynamic Tapp.api name cannot be checked statically', file, location.line, location.column))
+      } else if (!manifest.apis || !Object.hasOwn(manifest.apis, name)) {
+        diagnostics.push(diagnostic('error', 'undeclared-api', `Tapp.api('${name}') is not declared in manifest.apis`, file, location.line, location.column))
+      }
+    }
+
+    if (path.length === 2 && path[0] === 'assets' && ASSET_LITERAL_METHODS.has(path[1])) {
+      const assetPath = literalString(node.arguments[0])
+      if (assetPath !== undefined) {
+        const normalized = assetPath.startsWith(`${ASSET_DIRECTORY}/`)
+          ? assetPath
+          : `${ASSET_DIRECTORY}/${assetPath}`
+        const declaredAssets = new Set(Array.isArray(manifest.assets) ? manifest.assets : [])
+        if (!declaredAssets.has(normalized)) {
+          diagnostics.push(diagnostic('error', 'undeclared-asset', `${normalized} is not declared in manifest.assets`, file, location.line, location.column))
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+}
+
+async function walkCodeFiles(root, current = root) {
+  const files = []
+  for (const entry of await readdir(current, { withFileTypes: true })) {
+    if (entry.isDirectory() && (SKIP_DIRECTORIES.has(entry.name) || entry.name === 'types')) continue
+    const absolute = join(current, entry.name)
+    if (entry.isDirectory()) files.push(...(await walkCodeFiles(root, absolute)))
+    else if (entry.isFile() && CODE_EXTENSIONS.has(extname(entry.name)) && !entry.name.endsWith('.d.ts')) {
+      files.push(absolute)
+    }
+  }
+  return files
+}
+
+export async function analyzeProjectCode({ root, manifest, surfaces }) {
+  const diagnostics = []
+  const requiredPermissions = new Map()
+  const usedActions = []
+  for (const absolute of await walkCodeFiles(root)) {
+    const file = relative(root, absolute).split(sep).join('/')
+    inspectCode(
+      await readFile(absolute, 'utf8'),
+      file,
+      manifest,
+      diagnostics,
+      requiredPermissions,
+      usedActions,
+      surfaces,
+    )
+  }
+  return { diagnostics, requiredPermissions, usedActions }
+}

--- a/tapp-cli/src/starter-template.mjs
+++ b/tapp-cli/src/starter-template.mjs
@@ -1,0 +1,56 @@
+import { basename, resolve } from 'node:path'
+
+function starterId(directory) {
+  const slug = basename(resolve(directory))
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^[^a-z0-9]+/, '')
+    .replace(/[^a-z0-9]+$/, '')
+  return `com.example.${slug || 'my-tapp'}`
+}
+
+function starterName(directory) {
+  return basename(resolve(directory))
+    .split(/[-_.\s]+/)
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(' ') || 'My Tapp'
+}
+
+export function createStarterTemplate(directory, options = {}) {
+  const type = options.type || 'page'
+  if (!['page', 'widget', 'both'].includes(type)) {
+    throw new Error('type must be page, widget, or both')
+  }
+  const hasPage = type === 'page' || type === 'both'
+  const hasWidget = type === 'widget' || type === 'both'
+  const manifest = {
+    id: options.id || starterId(directory),
+    name: options.name || starterName(directory),
+    version: '0.1.0',
+    description: 'A Myriad Tapp',
+    category: 'utility',
+    main: 'main.js',
+    author: { name: options.author || 'Tapp Developer' },
+    permissions: [
+      ...(hasPage ? ['ui:notification'] : []),
+      ...(hasWidget ? ['widget:register'] : []),
+    ],
+    ...(hasPage ? { hasPage: true, pageTemplate: 'page.html' } : {}),
+    ...(hasWidget ? { widgets: [{ id: 'starter', name: 'Starter Widget', defaultSize: '2x2', sizes: ['2x2', '4x2'], templates: { '2x2': 'templates/widget-2x2.html', '4x2': 'templates/widget-4x2.html' } }] } : {}),
+    styles: 'styles.css',
+    cssMode: 'unified',
+  }
+  const page = `// ========== Page Code ==========
+Tapp.lifecycle.onReady(async function () {
+  var root = document.getElementById('tapp-root');
+  root.querySelector('[data-action="notify"]').addEventListener('click', function () {
+    Tapp.ui.showNotification({ title: 'My Tapp', message: 'The Page is running.', type: 'success' });
+  });
+});
+`
+  const widget = `// ========== Widget Code ==========
+Tapp.widgets['starter'] = { render: function (container, props) { container.innerHTML = '<section class="widget"><strong>My Tapp</strong><span>' + props.size + '</span></section>'; } };
+`
+  return { type, hasPage, hasWidget, manifest, source: `${hasWidget ? widget : ''}${hasWidget && hasPage ? '\n' : ''}${hasPage ? page : ''}` }
+}

--- a/tapp-cli/src/zip.mjs
+++ b/tapp-cli/src/zip.mjs
@@ -1,0 +1,119 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+const CRC_TABLE = new Uint32Array(256)
+for (let index = 0; index < 256; index += 1) {
+  let value = index
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+  }
+  CRC_TABLE[index] = value >>> 0
+}
+
+function crc32(buffer) {
+  let value = 0xffffffff
+  for (const byte of buffer) {
+    value = CRC_TABLE[(value ^ byte) & 0xff] ^ (value >>> 8)
+  }
+  return (value ^ 0xffffffff) >>> 0
+}
+
+function dosTimestamp(date) {
+  const year = Math.max(1980, date.getFullYear())
+  const time =
+    (date.getHours() << 11) | (date.getMinutes() << 5) | (date.getSeconds() >> 1)
+  const day = ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate()
+  return { time, day }
+}
+
+export function createZip(entries, timestamp = new Date()) {
+  if (entries.length > 0xffff) throw new Error('ZIP64 is not supported')
+
+  const localParts = []
+  const centralParts = []
+  const { time, day } = dosTimestamp(timestamp)
+  let offset = 0
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.path, 'utf8')
+    const data = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data)
+    const checksum = crc32(data)
+
+    const local = Buffer.alloc(30)
+    local.writeUInt32LE(0x04034b50, 0)
+    local.writeUInt16LE(20, 4)
+    local.writeUInt16LE(0x0800, 6)
+    local.writeUInt16LE(0, 8)
+    local.writeUInt16LE(time, 10)
+    local.writeUInt16LE(day, 12)
+    local.writeUInt32LE(checksum, 14)
+    local.writeUInt32LE(data.length, 18)
+    local.writeUInt32LE(data.length, 22)
+    local.writeUInt16LE(name.length, 26)
+    local.writeUInt16LE(0, 28)
+    localParts.push(local, name, data)
+
+    const central = Buffer.alloc(46)
+    central.writeUInt32LE(0x02014b50, 0)
+    central.writeUInt16LE(0x0314, 4)
+    central.writeUInt16LE(20, 6)
+    central.writeUInt16LE(0x0800, 8)
+    central.writeUInt16LE(0, 10)
+    central.writeUInt16LE(time, 12)
+    central.writeUInt16LE(day, 14)
+    central.writeUInt32LE(checksum, 16)
+    central.writeUInt32LE(data.length, 20)
+    central.writeUInt32LE(data.length, 24)
+    central.writeUInt16LE(name.length, 28)
+    central.writeUInt16LE(0, 30)
+    central.writeUInt16LE(0, 32)
+    central.writeUInt16LE(0, 34)
+    central.writeUInt16LE(0, 36)
+    central.writeUInt32LE(0, 38)
+    central.writeUInt32LE(offset, 42)
+    centralParts.push(central, name)
+
+    offset += local.length + name.length + data.length
+  }
+
+  const centralDirectory = Buffer.concat(centralParts)
+  const end = Buffer.alloc(22)
+  end.writeUInt32LE(0x06054b50, 0)
+  end.writeUInt16LE(0, 4)
+  end.writeUInt16LE(0, 6)
+  end.writeUInt16LE(entries.length, 8)
+  end.writeUInt16LE(entries.length, 10)
+  end.writeUInt32LE(centralDirectory.length, 12)
+  end.writeUInt32LE(offset, 16)
+  end.writeUInt16LE(0, 20)
+
+  return Buffer.concat([...localParts, centralDirectory, end])
+}
+
+export function zipSize(entries) {
+  return entries.reduce(
+    (size, entry) => size + 76 + Buffer.byteLength(entry.path, 'utf8') * 2 + entry.data.length,
+    22,
+  )
+}
+
+export async function writeZip(outputPath, entries) {
+  const archive = createZip(entries)
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, archive)
+  return { outputPath, sizeBytes: archive.length, entries: entries.length }
+}
+
+export function listZipEntries(archive) {
+  const entries = []
+  let offset = 0
+  while (offset + 4 <= archive.length && archive.readUInt32LE(offset) === 0x04034b50) {
+    const nameLength = archive.readUInt16LE(offset + 26)
+    const extraLength = archive.readUInt16LE(offset + 28)
+    const size = archive.readUInt32LE(offset + 18)
+    const nameStart = offset + 30
+    entries.push(archive.subarray(nameStart, nameStart + nameLength).toString('utf8'))
+    offset = nameStart + nameLength + extraLength + size
+  }
+  return entries
+}

--- a/tapp-cli/test/cli.test.mjs
+++ b/tapp-cli/test/cli.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { after, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const bin = join(packageRoot, 'bin/myriad-tapp.mjs')
+const root = await mkdtemp(join(tmpdir(), 'myriad-tapp-cli-'))
+const project = join(root, 'starter')
+
+after(async () => {
+  await rm(root, { recursive: true })
+})
+
+function run(args) {
+  return spawnSync(process.execPath, [bin, ...args], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+  })
+}
+
+describe('CLI adapter', () => {
+  it('exposes an npx-inferable package binary', async () => {
+    const packageJson = JSON.parse(
+      await readFile(join(packageRoot, 'package.json'), 'utf8'),
+    )
+    assert.equal(packageJson.bin['tapp-cli'], 'bin/myriad-tapp.mjs')
+    assert.deepEqual(packageJson.files, ['bin', 'src', 'README.md'])
+    assert.equal(packageJson.publishConfig.access, 'public')
+  })
+
+  it('supports global help and version flags', () => {
+    const help = run(['--help'])
+    assert.equal(help.status, 0)
+    assert.match(help.stdout, /Myriad Tapp CLI/)
+
+    const version = run(['--version'])
+    assert.equal(version.status, 0)
+    assert.equal(version.stdout.trim(), '0.1.0')
+  })
+
+  it('documents each command for agents and rejects unsupported options', () => {
+    const initHelp = run(['init', '--help'])
+    assert.equal(initHelp.status, 0)
+    assert.match(initHelp.stdout, /Usage:\n  myriad-tapp init/)
+    assert.match(initHelp.stdout, /--type <page\|widget\|both>/)
+    assert.doesNotMatch(initHelp.stdout, /--out <path>/)
+
+    const checkHelp = run(['check', '--help'])
+    assert.equal(checkHelp.status, 0)
+    assert.match(checkHelp.stdout, /Exit status:\n  0  Validation succeeded/)
+    assert.match(checkHelp.stdout, /--json.*stdout is a single JSON object/)
+
+    const invalid = run(['check', '.', '--type', 'page'])
+    assert.equal(invalid.status, 2)
+    assert.match(invalid.stderr, /--type is only valid with init/)
+  })
+
+  it('emits a structured JSON error when a JSON command cannot run', () => {
+    const failed = run(['init', packageRoot, '--json'])
+    assert.equal(failed.status, 1)
+    assert.equal(failed.stderr, '')
+    assert.deepEqual(JSON.parse(failed.stdout), {
+      error: {
+        code: 'execution-error',
+        message: `Target directory is not empty: ${packageRoot}`,
+      },
+      exitCode: 1,
+    })
+  })
+
+  it('emits a structured JSON usage error for an unknown command', () => {
+    const failed = run(['unknown', '--json'])
+    assert.equal(failed.status, 2)
+    assert.equal(failed.stderr, '')
+    assert.deepEqual(JSON.parse(failed.stdout), {
+      error: {
+        code: 'usage-error',
+        message: 'Unknown command: unknown',
+      },
+      exitCode: 2,
+    })
+  })
+
+  it('reports an existing file as an invalid init target', async () => {
+    const target = join(root, 'not-a-directory')
+    await writeFile(target, 'existing file\n')
+
+    const failed = run(['init', target, '--json'])
+    assert.equal(failed.status, 1)
+    assert.equal(failed.stderr, '')
+    assert.deepEqual(JSON.parse(failed.stdout), {
+      error: {
+        code: 'execution-error',
+        message: `Target path is not a directory: ${target}`,
+      },
+      exitCode: 1,
+    })
+  })
+
+  it('runs init, check, permissions and pack end to end', () => {
+    const initialized = run(['init', project, '--type', 'both', '--id', 'com.example.cli'])
+    assert.equal(initialized.status, 0, initialized.stderr || initialized.stdout)
+    assert.match(initialized.stdout, /Created both Tapp/)
+
+    const checked = run(['check', project, '--json'])
+    assert.equal(checked.status, 0, checked.stderr || checked.stdout)
+    const report = JSON.parse(checked.stdout)
+    assert.equal(report.manifest.id, 'com.example.cli')
+    assert.deepEqual(report.permissions.missing, [])
+
+    const permissions = run(['permissions', project])
+    assert.equal(permissions.status, 0, permissions.stderr || permissions.stdout)
+    assert.match(permissions.stdout, /ui:notification/)
+    assert.match(permissions.stdout, /widget:register/)
+
+    const packed = run(['pack', project, '--json'])
+    assert.equal(packed.status, 0, packed.stderr || packed.stdout)
+    const archive = JSON.parse(packed.stdout)
+    assert.equal(archive.entries, 6)
+    assert.match(archive.outputPath, /com\.example\.cli\.tapp$/)
+  })
+})

--- a/tapp-cli/test/project.test.mjs
+++ b/tapp-cli/test/project.test.mjs
@@ -1,0 +1,600 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { access, mkdir, mkdtemp, readFile, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { afterEach, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import {
+  createProject,
+  generatedContract,
+  inspectProject,
+  packProject,
+  permissionCatalog,
+} from '../src/project.mjs'
+import { listZipEntries } from '../src/zip.mjs'
+import { parseCapabilitySource } from '../scripts/capability-source.mjs'
+import { parsePermissionSource } from '../scripts/permission-source.mjs'
+
+const directories = []
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const execFileAsync = promisify(execFile)
+
+async function temporaryDirectory(name) {
+  const root = await mkdtemp(join(tmpdir(), `myriad-tapp-${name}-`))
+  directories.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((root) => rm(root, { recursive: true })))
+})
+
+describe('Tapp project core', () => {
+  it('ships a generated permission catalog', () => {
+    const catalog = permissionCatalog()
+    assert.ok(Object.keys(catalog.actions).length > 200)
+    assert.ok(Object.keys(catalog.permissionLevels).length > 30)
+  })
+
+  it('keeps the generated contract aligned with the backend exporter', async () => {
+    const manifestPath = resolve(packageRoot, '../tapp-contract-export/Cargo.toml')
+    const { stdout } = await execFileAsync(
+      'cargo',
+      ['run', '--quiet', '--locked', '--manifest-path', manifestPath],
+      { maxBuffer: 4 * 1024 * 1024 },
+    )
+    const backendContract = JSON.parse(stdout)
+    const current = generatedContract()
+    assert.deepEqual(current.schema, backendContract.schema)
+    assert.deepEqual(current.limits, backendContract.limits)
+    assert.deepEqual(current.rules, backendContract.rules)
+    assert.deepEqual(current.patterns, backendContract.patterns)
+  })
+
+  it('keeps the generated catalog aligned with permissionConfig', async () => {
+    const source = await readFile(
+      resolve(packageRoot, '../../frontend/src/tapp/runtime/permissionConfig.ts'),
+      'utf8',
+    )
+    const { permissionLevels, actions } = parsePermissionSource(source)
+    assert.deepEqual(permissionCatalog().permissionLevels, permissionLevels)
+    assert.deepEqual(permissionCatalog().actions, actions)
+  })
+
+  it('keeps capability profiles aligned with capabilityProfiles.ts', async () => {
+    const source = await readFile(
+      resolve(
+        packageRoot,
+        '../../frontend/src/tapp/runtime/sandbox/capabilityProfiles.ts',
+      ),
+      'utf8',
+    )
+    const expected = parseCapabilitySource(source)
+    const current = generatedContract().capabilities
+    assert.deepEqual(current, expected)
+    assert.ok(current.headlessDeniedActions.includes('ui.confirm'))
+    await access(resolve(packageRoot, 'src/generated/manifest.schema.json'))
+    await access(resolve(packageRoot, 'src/generated/capability-profiles.json'))
+    const sdkDts = await readFile(
+      resolve(packageRoot, 'src/generated/tapp-sdk.d.ts'),
+      'utf8',
+    )
+    assert.match(sdkDts, /export interface TappSdk/)
+    assert.match(sdkDts, /declare const Tapp: TappSdk/)
+    assert.match(sdkDts, /showNotification/)
+    assert.match(sdkDts, /federation/)
+  })
+
+  it('keeps generated manifest schema metadata for CLI consumers', async () => {
+    const schema = JSON.parse(
+      await readFile(resolve(packageRoot, 'src/generated/manifest.schema.json'), 'utf8'),
+    )
+    assert.equal(schema.title, 'Myriad Tapp Manifest')
+    assert.equal(
+      schema.description,
+      'Generated from backend TappManifest schema. Semantic limits and permission rules live in contract.json.',
+    )
+  })
+
+  it('parses contract sources independently of quote style', async () => {
+    const permissionSource = await readFile(
+      resolve(packageRoot, '../../frontend/src/tapp/runtime/permissionConfig.ts'),
+      'utf8',
+    )
+    const capabilitySource = await readFile(
+      resolve(
+        packageRoot,
+        '../../frontend/src/tapp/runtime/sandbox/capabilityProfiles.ts',
+      ),
+      'utf8',
+    )
+
+    const quotedPermissionSource = permissionSource.replace(
+      /\['lifecycle\.ready', 'public'\]/,
+      '["lifecycle.ready", "public"]',
+    )
+    const quotedCapabilitySource = capabilitySource.replace(
+      "'ui.showNotification'",
+      '"ui.showNotification"',
+    )
+
+    assert.deepEqual(
+      parsePermissionSource(quotedPermissionSource),
+      parsePermissionSource(permissionSource),
+    )
+    assert.deepEqual(
+      parseCapabilitySource(quotedCapabilitySource),
+      parseCapabilitySource(capabilitySource),
+    )
+  })
+
+  it('rejects contract sources with syntax errors', async () => {
+    const permissionSource = await readFile(
+      resolve(packageRoot, '../../frontend/src/tapp/runtime/permissionConfig.ts'),
+      'utf8',
+    )
+    const capabilitySource = await readFile(
+      resolve(
+        packageRoot,
+        '../../frontend/src/tapp/runtime/sandbox/capabilityProfiles.ts',
+      ),
+      'utf8',
+    )
+
+    assert.throws(() => parsePermissionSource(`${permissionSource}\nconst =`))
+    assert.throws(() => parseCapabilitySource(`${capabilitySource}\nconst =`))
+  })
+
+  for (const type of ['page', 'widget', 'both']) {
+    it(`creates a valid ${type} starter`, async () => {
+      const root = await temporaryDirectory(type)
+      await createProject(root, { type, id: `com.example.${type}` })
+      const report = await inspectProject(root)
+      assert.deepEqual(
+        report.diagnostics.filter(({ severity }) => severity === 'error'),
+        [],
+      )
+      await access(join(root, 'types/tapp-sdk.d.ts'))
+      await access(join(root, 'jsconfig.json'))
+      const main = await readFile(join(root, 'main.js'), 'utf8')
+      assert.match(main, /reference path="\.\/types\/tapp-sdk\.d\.ts"/)
+    })
+  }
+
+  it('reports strict fields, undeclared APIs and missing permissions', async () => {
+    const root = await temporaryDirectory('invalid')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.permissions = []
+    manifest.typoField = true
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(
+      join(root, 'main.js'),
+      `Tapp.storage.set('key', 'value');\nTapp.api('missing', {});\n`,
+    )
+
+    const report = await inspectProject(root)
+    const codes = new Set(report.diagnostics.map(({ code }) => code))
+    assert.ok(codes.has('unknown-manifest-field'))
+    assert.ok(codes.has('undeclared-api'))
+    assert.ok(codes.has('missing-permission'))
+    assert.ok(report.permissions.missing.some(({ permission }) => permission === 'storage'))
+  })
+
+  it('uses the TypeScript AST for calls without matching comments or strings', async () => {
+    const root = await temporaryDirectory('ast-analysis')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.permissions = ['storage']
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(
+      join(root, 'main.js'),
+      `// Tapp.ui.confirm('not a call')
+const example = "Tapp.api('not-real')"
+const apiName = 'dynamic'
+Tapp?.storage?.get('key')
+Tapp.api(apiName)
+`,
+    )
+
+    const report = await inspectProject(root)
+    assert.deepEqual(report.permissions.usedActions.map(({ action }) => action), ['storage.get'])
+    assert.equal(report.diagnostics.filter(({ code }) => code === 'dynamic-api-name').length, 1)
+    assert.equal(report.diagnostics.some(({ code }) => code === 'undeclared-api'), false)
+    assert.equal(report.permissions.required.some(({ permission }) => permission === 'ui:confirm'), false)
+  })
+
+  it('reports generated actions with three or more path segments', async () => {
+    const root = await temporaryDirectory('nested-action')
+    await createProject(root, { type: 'page' })
+    await writeFile(
+      join(root, 'main.js'),
+      `Tapp.ai.tasks.create({})
+Tapp.ui.confirm.call(null, 'ok')
+`,
+    )
+
+    const report = await inspectProject(root)
+    assert.ok(
+      report.permissions.usedActions.some(
+        ({ action, permission, file }) =>
+          action === 'ai.tasks.create' && permission === 'public' && file === 'main.js',
+      ),
+    )
+    assert.ok(report.permissions.missing.some(({ permission }) => permission === 'ui:confirm'))
+  })
+
+  it('parses TypeScript and reports source syntax errors with locations', async () => {
+    const root = await temporaryDirectory('typescript-analysis')
+    await createProject(root, { type: 'page' })
+    await writeFile(
+      join(root, 'helper.ts'),
+      `const key: string = 'key'
+Tapp.storage.get(key)
+`,
+    )
+    await writeFile(join(root, 'broken.ts'), 'const value: = 1\n')
+
+    const report = await inspectProject(root)
+    assert.ok(report.permissions.usedActions.some(({ action, file }) => action === 'storage.get' && file === 'helper.ts'))
+    const syntax = report.diagnostics.find(({ code }) => code === 'invalid-source-syntax')
+    assert.equal(syntax.file, 'broken.ts')
+    assert.equal(syntax.line, 1)
+    assert.ok(syntax.column > 0)
+  })
+
+  it('returns diagnostics instead of crashing on malformed collection fields', async () => {
+    const root = await temporaryDirectory('malformed-collections')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.assets = { invalid: true }
+    manifest.widgets = { invalid: true }
+    manifest.dataExchange = { exports: { invalid: true }, imports: 'invalid' }
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    const report = await inspectProject(root)
+    const codes = new Set(report.diagnostics.map(({ code }) => code))
+    assert.ok(codes.has('invalid-assets'))
+    assert.ok(codes.has('invalid-widgets'))
+    assert.ok(codes.has('invalid-data-exchange'))
+  })
+
+  it('accepts omitted permissions when no capability requires one', async () => {
+    const root = await temporaryDirectory('optional-permissions')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    delete manifest.permissions
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(join(root, 'main.js'), '// no privileged capabilities\n')
+
+    const report = await inspectProject(root)
+    assert.deepEqual(
+      report.diagnostics.filter(({ severity }) => severity === 'error'),
+      [],
+    )
+  })
+
+  it('validates and packages Agent interaction schemas', async () => {
+    const root = await temporaryDirectory('agent')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.permissions.push('ai:chat')
+    manifest.ai = {
+      protocolVersion: 2,
+      operations: ['chat'],
+      modelTier: 'standard',
+      outputFormats: ['text'],
+    }
+    manifest.agent = {
+      protocolVersion: 2,
+      interactions: [
+        {
+          type: 'report.create',
+          inputSchema: 'schemas/report-input.json',
+          resultSchema: 'schemas/report-result.json',
+        },
+      ],
+      intents: ['report.create'],
+    }
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await mkdir(join(root, 'schemas'))
+    await writeFile(join(root, 'schemas/report-input.json'), '{"type":"object"}\n')
+    await writeFile(join(root, 'schemas/report-result.json'), '{"type":"object"}\n')
+
+    const report = await inspectProject(root)
+    assert.deepEqual(
+      report.diagnostics.filter(({ severity }) => severity === 'error'),
+      [],
+    )
+    assert.ok(report.packageFiles.includes('schemas/report-input.json'))
+    assert.ok(report.packageFiles.includes('schemas/report-result.json'))
+  })
+
+  it('rejects declared resources that are symbolic links', async () => {
+    const root = await temporaryDirectory('symlink-resource')
+    const targetRoot = await temporaryDirectory('symlink-target')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.assets = ['assets/linked.txt']
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await mkdir(join(root, 'assets'))
+    const target = join(targetRoot, 'outside.txt')
+    await writeFile(target, 'outside project')
+    await symlink(target, join(root, 'assets/linked.txt'))
+
+    const report = await inspectProject(root)
+    assert.ok(report.diagnostics.some(({ code }) => code === 'invalid-resource'))
+    await assert.rejects(packProject(root), /Project validation failed/)
+  })
+
+  it('rejects declared resources that escape through a symbolic-link directory', async () => {
+    const root = await temporaryDirectory('symlink-directory-resource')
+    const targetRoot = await temporaryDirectory('symlink-directory-target')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.main = 'linked/outside.js'
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(join(targetRoot, 'outside.js'), 'Tapp.lifecycle.ready()\n')
+    await symlink(targetRoot, join(root, 'linked'))
+
+    const report = await inspectProject(root)
+    assert.ok(report.diagnostics.some(({ code }) => code === 'invalid-resource'))
+    await assert.rejects(packProject(root), /Project validation failed/)
+  })
+
+  it('rejects package resource directories that are symbolic links', async () => {
+    const root = await temporaryDirectory('symlink-package-directory')
+    const targetRoot = await temporaryDirectory('symlink-package-directory-target')
+    await createProject(root, { type: 'page' })
+    await writeFile(join(targetRoot, 'en-US.json'), '{"hello": "world"}\n')
+    await symlink(targetRoot, join(root, 'i18n'))
+
+    const report = await inspectProject(root)
+    assert.ok(report.diagnostics.some(({ code }) => code === 'invalid-i18n'))
+    assert.equal(report.packageFiles.some((path) => path.startsWith('i18n/')), false)
+    await assert.rejects(packProject(root), /Project validation failed/)
+  })
+
+  it('reports a diagnostic when a package resource path is not a directory', async () => {
+    const root = await temporaryDirectory('package-directory-file')
+    await createProject(root, { type: 'page' })
+    await writeFile(join(root, 'i18n'), 'not a directory\n')
+
+    const report = await inspectProject(root)
+    assert.ok(report.diagnostics.some(({ code }) => code === 'invalid-i18n'))
+    await assert.rejects(packProject(root), /Project validation failed/)
+  })
+
+  it('rejects HTTP methods outside the fixed allow-list', async () => {
+    const root = await temporaryDirectory('http-method')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.permissions.push('network:fetch')
+    manifest.apis = {
+      allowed: { type: 'http', endpoint: 'https://example.com', method: 'POST' },
+      rejected: { type: 'http', endpoint: 'https://example.com', method: 'FETCH' },
+    }
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    const report = await inspectProject(root)
+    const invalidApis = report.diagnostics.filter(({ code }) => code === 'invalid-api')
+    assert.equal(invalidApis.length, 1)
+    assert.match(invalidApis[0].message, /API rejected HTTP method/)
+  })
+
+  it('rejects manifests over the manifest byte limit', async () => {
+    const root = await temporaryDirectory('oversized-manifest')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const raw = await readFile(manifestPath, 'utf8')
+    await writeFile(manifestPath, raw + ' '.repeat(generatedContract().limits.manifestBytes))
+
+    const report = await inspectProject(root)
+    assert.ok(report.diagnostics.some(({ code }) => code === 'manifest-too-large'))
+  })
+
+  it('rejects directory-walk package files over the resource byte limit', async () => {
+    const root = await temporaryDirectory('oversized-walk')
+    await createProject(root, { type: 'page' })
+    await mkdir(join(root, 'schemas'))
+    // A sparse file is enough: the walk only checks the reported size.
+    await writeFile(join(root, 'schemas/big.json'), '')
+    await truncate(join(root, 'schemas/big.json'), generatedContract().limits.resourceBytes + 1)
+
+    const report = await inspectProject(root)
+    assert.ok(
+      report.diagnostics.some(
+        ({ code, message }) => code === 'resource-too-large' && message.includes('schemas/big.json'),
+      ),
+    )
+  })
+
+  it('rejects unsupported nested fields and invalid i18n resources', async () => {
+    const root = await temporaryDirectory('nested')
+    await createProject(root, { type: 'widget' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.widgets[0].refreshPolicy = { mode: 'interval', intervalSeconds: 10, typo: true }
+    manifest.ai = {
+      protocolVersion: 1,
+      operations: ['image'],
+      modelTier: 'unknown',
+      contextSources: [],
+      outputFormats: ['text'],
+    }
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await mkdir(join(root, 'i18n'))
+    await writeFile(join(root, 'i18n/en-US.json'), '["not-an-object"]\n')
+    await writeFile(join(root, 'i18n/README.txt'), 'unsupported\n')
+
+    const report = await inspectProject(root)
+    const codes = new Set(report.diagnostics.map(({ code }) => code))
+    assert.ok(codes.has('unknown-manifest-field'))
+    assert.ok(codes.has('invalid-widget-refresh'))
+    assert.ok(codes.has('invalid-ai'))
+    assert.ok(codes.has('invalid-i18n'))
+  })
+
+  it('packs a valid installable file layout', async () => {
+    const root = await temporaryDirectory('pack')
+    await createProject(root, { type: 'both', id: 'com.example.pack' })
+    const result = await packProject(root)
+    const archive = await readFile(result.outputPath)
+    assert.deepEqual(listZipEntries(archive), [
+      'main.js',
+      'manifest.json',
+      'page.html',
+      'styles.css',
+      'templates/widget-2x2.html',
+      'templates/widget-4x2.html',
+    ])
+    assert.equal(
+      listZipEntries(archive).some((path) => path.startsWith('types/')),
+      false,
+    )
+    assert.ok(archive.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04])))
+  })
+
+  it('packs declared resources under types/ while dropping editor scaffolding', async () => {
+    const root = await temporaryDirectory('types-resource')
+    await createProject(root, { type: 'page', id: 'com.example.types' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.main = 'types/main.js'
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(
+      join(root, 'types/main.js'),
+      await readFile(join(root, 'main.js'), 'utf8'),
+    )
+
+    const result = await packProject(root)
+    const entries = listZipEntries(await readFile(result.outputPath))
+    assert.ok(entries.includes('types/main.js'))
+    assert.equal(entries.includes('types/tapp-sdk.d.ts'), false)
+    assert.equal(entries.includes('jsconfig.json'), false)
+  })
+
+  it('matches Playground main.js composition markers', async () => {
+    const { buildMainJs, PACKAGE_MARKERS } = await import('../src/package-layout.mjs')
+    const composed = buildMainJs({
+      core: 'const shared = 1;',
+      widget: 'Tapp.widgets.a = { render() {} };',
+      page: 'Tapp.lifecycle.onReady(() => {});',
+    })
+    assert.ok(composed.includes(PACKAGE_MARKERS.widget))
+    assert.ok(composed.includes(PACKAGE_MARKERS.page))
+    assert.ok(composed.indexOf('const shared') < composed.indexOf(PACKAGE_MARKERS.widget))
+    assert.ok(composed.indexOf(PACKAGE_MARKERS.widget) < composed.indexOf(PACKAGE_MARKERS.page))
+  })
+
+  it('rejects declared resources over the general resource byte limit', async () => {
+    const root = await temporaryDirectory('oversized-resource')
+    await createProject(root, { type: 'page' })
+    await writeFile(
+      join(root, 'main.js'),
+      Buffer.alloc(generatedContract().limits.resourceBytes + 1, 0x20),
+    )
+
+    const report = await inspectProject(root)
+    assert.ok(
+      report.diagnostics.some(
+        ({ code, message }) => code === 'resource-too-large' && message.includes('main.js'),
+      ),
+    )
+  })
+
+  it('does not leave an archive behind when the stored ZIP exceeds 25 MiB', async () => {
+    const root = await temporaryDirectory('oversized')
+    await createProject(root, { type: 'page' })
+    await writeFile(join(root, 'main.js'), Buffer.alloc(25 * 1024 * 1024, 0x20))
+    const outputPath = join(root, 'oversized.tapp')
+
+    await assert.rejects(packProject(root, outputPath), /Package exceeds 25 MiB/)
+    await assert.rejects(access(outputPath), { code: 'ENOENT' })
+  })
+
+  it('requires page resources when hasPage is true', async () => {
+    const root = await temporaryDirectory('missing-page')
+    await createProject(root, { type: 'widget', id: 'com.example.missing-page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.hasPage = true
+    delete manifest.pageTemplate
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    const report = await inspectProject(root)
+    assert.ok(report.diagnostics.some(({ code }) => code === 'missing-page-resource'))
+    assert.equal(report.surfaces.page, true)
+  })
+
+  it('errors on headless-denied actions in headless-only projects', async () => {
+    const root = await temporaryDirectory('headless-only')
+    await createProject(root, { type: 'page', id: 'com.example.headless-only' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    delete manifest.hasPage
+    delete manifest.pageTemplate
+    delete manifest.widgets
+    manifest.backgroundRequirements = ['sync']
+    manifest.permissions = []
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(
+      join(root, 'main.js'),
+      `Tapp.ui.confirm('ok');
+`,
+    )
+    await rm(join(root, 'page.html'), { force: true })
+
+    const report = await inspectProject(root)
+    assert.equal(report.surfaces.headlessOnly, true)
+    assert.ok(
+      report.diagnostics.some(
+        ({ code, severity }) => code === 'headless-denied-action' && severity === 'error',
+      ),
+    )
+    assert.ok(report.permissions.missing.some(({ permission }) => permission === 'ui:confirm'))
+  })
+
+  it('warns when headless-denied actions appear in mixed surface projects', async () => {
+    const root = await temporaryDirectory('headless-mixed')
+    await createProject(root, { type: 'page', id: 'com.example.headless-mixed' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.backgroundRequirements = ['scheduler']
+    if (!manifest.permissions.includes('ui:confirm')) {
+      manifest.permissions.push('ui:confirm')
+    }
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+    await writeFile(
+      join(root, 'main.js'),
+      `Tapp.lifecycle.onReady(async function () {
+  await Tapp.ui.confirm('ok');
+});
+`,
+    )
+
+    const report = await inspectProject(root)
+    assert.equal(report.surfaces.headless, true)
+    assert.equal(report.surfaces.headlessOnly, false)
+    assert.ok(
+      report.diagnostics.some(
+        ({ code, severity }) =>
+          code === 'headless-unavailable-action' && severity === 'warning',
+      ),
+    )
+    assert.equal(
+      report.diagnostics.some(({ code }) => code === 'headless-denied-action'),
+      false,
+    )
+  })
+})


### PR DESCRIPTION
## 概述

将 `@myriad/tapp-cli` 从 [Myriad 主仓库](https://github.com/Myriad-You/Myriad/tree/preview/tools/tapp-cli) 合入本仓库 `tapp-cli/` 目录。

## CLI 能力

| 命令 | 作用 |
|------|------|
| `init` | 创建 Tapp 项目骨架（page/widget/both） |
| `check` | 离线校验 Manifest、权限、资源、API 声明 |
| `permissions` | 列出已声明 + 静态推断权限 |
| `pack` | 校验后打包为 `.tapp` 归档 |

## 包含内容

- `bin/` — CLI 入口
- `src/` — 核心逻辑（校验、打包、源码分析、模板生成）
- `src/generated/` — contract.json、manifest.schema.json、tapp-sdk.d.ts 等生成文件
- `scripts/` — contract 同步脚本
- `test/` — 测试用例
- `package.json` / `package-lock.json` — npm 包配置
- `README.md` — 完整使用文档

## 来源

- 源仓库: https://github.com/Myriad-You/Myriad/tree/preview/tools/tapp-cli
- 版本: v0.1.0