### PR TITLE
[APP]添加类GeoGebra的函数计算器

### DIFF
--- a/index.json
+++ b/index.json
@@ -4,7 +4,7 @@
   "version": "1.11.0",
   "api_version": "2",
   "base_url": "https://raw.githubusercontent.com/Myriad-You/tapp-store/main",
-  "updated_at": "2026-08-04T05:52:10Z",
+  "updated_at": "2026-08-04T07:12:00Z",
   "maintainer": {
     "name": "Myriad Team",
     "email": "tapp@myriad.you",
@@ -795,7 +795,61 @@
       "verified": false,
       "created_at": "2026-08-04T05:52:10Z",
       "updated_at": "2026-08-04T05:52:10Z"
+    },
+    {
+      "id": "org.smcresearchhk.math",
+      "name": "函数图形计算器",
+      "version": "1.0.0",
+      "description": "类似 GeoGebra 的函数绘图与交互式计算器，支持多函数叠加、坐标系缩放平移、常用函数库与表达式求值",
+      "long_description": "交互式函数绘图计算器，风格接近 GeoGebra：多函数叠加、安全表达式解析（无 eval）、坐标系缩放/平移、网格与坐标轴、悬停轨迹、侧栏求值与常用函数预设。支持中英日界面与明暗主题，函数列表与视图范围持久化到本地 storage。",
+      "locales": {
+        "en-US": {
+          "name": "Function Graph Calculator",
+          "description": "GeoGebra-like function graphing and interactive calculator with multi-function overlay, zoom/pan, and expression evaluation"
+        },
+        "ja-JP": {
+          "name": "関数グラフ計算機",
+          "description": "GeoGebra風の関数グラフ描画と対話型計算機。複数関数の重ね描き、ズーム・パン、式評価に対応"
+        }
+      },
+      "author": {
+        "name": "WKSYweb",
+        "url": "https://github.com/WKSYweb"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/Myriad-You/tapp-store/tree/main/apps/org.smcresearchhk.math",
+      "repository": "https://github.com/Myriad-You/tapp-store",
+      "category": "utility",
+      "tags": [
+        "函数",
+        "图形",
+        "计算器",
+        "GeoGebra",
+        "数学",
+        "绘图"
+      ],
+      "permissions": [
+        "storage",
+        "ui:theme"
+      ],
+      "icon_svg": "<svg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M3 12h18M12 3v18' stroke='currentColor' stroke-width='1.5' stroke-linecap='round'/><path d='M4 16c2-4 4-6 6-6s4 4 6 6 4 2 6 0' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' fill='none'/><circle cx='12' cy='10' r='1.5' fill='currentColor'/></svg>",
+      "theme_color": "#0EA5E9",
+      "screenshots": [],
+      "download": {
+        "manifest": "apps/org.smcresearchhk.math/manifest.json",
+        "code": "apps/org.smcresearchhk.math/main.js",
+        "readme": "apps/org.smcresearchhk.math/README.md",
+        "page_styles": "apps/org.smcresearchhk.math/page.css",
+        "page_template": "apps/org.smcresearchhk.math/page.html"
+      },
+      "size": 58058,
+      "downloads": 0,
+      "rating": 0,
+      "featured": false,
+      "verified": false,
+      "created_at": "2026-08-04T00:00:00Z",
+      "updated_at": "2026-08-04T07:12:00Z"
     }
   ],
-  "last_updated": "2026-08-04T05:52:10Z"
+  "last_updated": "2026-08-04T07:12:00Z"
 }


### PR DESCRIPTION
# 函数图形计算器 (Function Graph Calculator)

类似 GeoGebra 的交互式函数绘图 Tapp，面向 Myriad 平台。

**包 ID：** `org.smcresearchhk.math`  
**作者：** [WKSYweb](https://github.com/WKSYweb)

## 功能

- **多函数叠加**：同时绘制多条曲线，可单独显示/隐藏、换色、删除
- **安全表达式解析**：自实现递归下降解析器，支持 `sin/cos/tan`、`exp/ln/sqrt/abs`、幂运算、隐式乘法等，**不使用 `eval`**
- **坐标系交互**：滚轮以指针为中心缩放、拖拽平移、网格与坐标轴开关、重置视图
- **轨迹提示**：鼠标悬停显示坐标与函数值
- **求值面板**：对表达式求数值结果
- **常用预设**：一键添加 `sin(x)`、`x^2`、`exp(-x^2)`、`sin(x)/x` 等
- **状态持久化**：函数列表与视图范围写入 `Tapp.storage`
- **明暗主题**：跟随宿主深色模式
- **中 / 英 / 日** 界面文案

## 文件结构

```
org.smcresearchhk.math/
├── manifest.json
├── main.js
├── page.html
├── page.css
└── README.md
```

## 权限

| 权限 | 用途 |
|------|------|
| `storage` | 保存函数列表与视图 |
| `ui:theme` | 适配明暗主题 |

无需网络权限。

## 本地校验与打包

```bash
npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp check ./org.smcresearchhk.math --json
npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp pack ./org.smcresearchhk.math --json
```

## 表达式说明

- 运算：`+ - * / ^`（或 `**`）、括号
- 常量：`pi`、`e`、`tau`
- 函数：`sin cos tan asin acos atan sinh cosh tanh sqrt abs ln log log10 exp floor ceil round sign`
- 隐式乘法：`2x`、`3(x+1)`
- 角度单位为**弧度**

## 许可证

MIT
