### PR TITLE
feat(edge): Cloudflare Workers install stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,18 @@ tapp-store/
 │   ├── sync-index.mjs      # manifest + catalog.json → index
 │   ├── validate-app.mjs    # category / 敏感权限 / catalog
 │   └── validate-previews.mjs
+├── edge/                   # Cloudflare Workers：全网安装统计（可选部署）
 └── development/            # 贡献者文档镜像（见下）
 ```
+
+## 安装统计（边缘，可选）
+
+全网安装次数由 **Cloudflare Workers + KV** 服务维护，**不**写回本仓库 `index.json`（`downloads` 字段仅 schema 占位）。
+
+- 代码与部署说明：[`edge/README.md`](./edge/README.md)
+- API：`POST /v1/hit`（安装成功打点）、`GET /v1/stats?apps=…` / `?top=N`
+- 默认可部署到 `*.workers.dev`，**不强制自有域名**
+- 面向 ~1 万应用：禁止全量 dump、批量 ≤100、top 用维护索引
 
 ## `index.json` 协议（摘要）
 

--- a/development/tapp/STORE.md
+++ b/development/tapp/STORE.md
@@ -528,6 +528,25 @@ REST 商店安装仍是 body `source: "store"` + `storeSource: catalogRef`（源
 
 ---
 
+## 安装统计（边缘服务）
+
+官方全网安装次数由独立边缘服务维护（**Cloudflare Workers + KV**），与静态 Git 目录解耦：
+
+| 项 | 说明 |
+| -- | ---- |
+| 代码 | 商店仓库 [`edge/`](https://github.com/Myriad-You/tapp-store/tree/main/edge) |
+| 计什么 | **安装成功**（`event=install`）；`update` 单独计数；不计 preview / 浏览 |
+| 真值 | `GET /v1/stats`；**不**由 Catalog Sync 写回 `index.json` |
+| `index.json` `downloads` | 仅占位/降级；UI 优先 edge overlay |
+| 部署 | `wrangler deploy` → `*.workers.dev` 即可；自定义域名可选 |
+| 万级应用 | stats 必须 `apps=` / `app=` / `top=`；禁止无参全量 dump |
+
+Myriad 接入（后续）：后端/前端在安装成功路径 fire-and-forget `POST /v1/hit`；商店 UI 批量拉 stats 展示。失败不影响安装。
+
+详细部署与 API 见商店仓库 `edge/README.md`。
+
+---
+
 ## 变更时同步项
 
 修改商店协议或拉包逻辑时至少核对：
@@ -537,4 +556,5 @@ REST 商店安装仍是 body `source: "store"` + `storeSource: catalogRef`（源
 3. `store_package.rs` 与客户端 `downloadAppPackage` 对必填资源/assets 行为一致；
 4. `TappInstallationApi.installFromStore` 回退条件与大包阈值；
 5. 本文、[REST_API](REST_API.md)、[MANIFEST](MANIFEST.md) 分类与路径规则；
-6. 后端商店/安装定向测试与前端相关单测（`storePackagePaths`、`tappInstallProgress` 等）。
+6. 后端商店/安装定向测试与前端相关单测（`storePackagePaths`、`tappInstallProgress` 等）；
+7. 边缘统计 `edge/` 契约（若改 hit/stats 协议）。

--- a/edge/.gitignore
+++ b/edge/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.wrangler/
+.dev.vars
+dist/
+*.log
+.DS_Store

--- a/edge/.npmrc
+++ b/edge/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/edge/README.md
+++ b/edge/README.md
@@ -1,0 +1,186 @@
+# tapp-store-stats（Cloudflare Workers）
+
+官方 Tapp 商店的 **安装次数** 统计边缘服务。可独立部署到 Cloudflare，不依赖 Myriad Postgres，也不改写仓库里的 `index.json`。
+
+| 项 | 值 |
+| -- | -- |
+| 运行时 | Cloudflare Workers |
+| 存储 | Workers KV（计数 + 去重 + 限流 + catalog 白名单） |
+| 默认入口 | `https://tapp-store-stats.<account>.workers.dev`（**不需要自有域名**） |
+| 可选正式域名 | `store-stats.myriad.you` 等（CF 托管 zone 后绑 route） |
+
+## API
+
+### `GET /health`
+
+```json
+{ "ok": true, "service": "tapp-store-stats", "version": "1" }
+```
+
+### `POST /v1/hit`
+
+安装/更新 **成功后** 由 Myriad 后端或浏览器 fallback 调用（失败不影响安装）。
+
+```json
+{
+  "app_id": "com.myriad.music-player",
+  "version": "1.0.0",
+  "event": "install",
+  "idempotency_key": "unique-per-install-session",
+  "client": "myriad-backend"
+}
+```
+
+响应：
+
+```json
+{ "ok": true, "counted": true, "downloads": 1, "installs": 1, "updates": 0 }
+```
+
+- `downloads` ≡ `installs`（与 `index.json` 字段名对齐）
+- 同一 `idempotency_key` 在 48h 内只计一次（`counted: false`）
+- 默认只接受 **官方 catalog 白名单** 中的 `app_id`（定时从 `CATALOG_URL` 拉取）
+
+### `GET /v1/stats`（10k 规模友好）
+
+**禁止** 无参全量 dump（万级应用时响应过大）。必须：
+
+| 查询 | 含义 | 上限 |
+|------|------|------|
+| `?apps=id1,id2` | 批量 | 默认 100 |
+| `?app=id` | 单应用 | — |
+| `?top=20` | 安装量排行（维护中的 top 索引，不扫全库） | 默认 100 |
+
+```bash
+curl 'https://tapp-store-stats.example.workers.dev/v1/stats?apps=com.myriad.music-player'
+curl 'https://tapp-store-stats.example.workers.dev/v1/stats?top=10'
+```
+
+```json
+{
+  "updated_at": "2026-08-05T12:00:00.000Z",
+  "apps": {
+    "com.myriad.music-player": {
+      "installs": 42,
+      "updates": 3,
+      "downloads": 42
+    }
+  }
+}
+```
+
+`Cache-Control: public, max-age=60`。
+
+## 为何能扛 ~1 万应用
+
+| 路径 | 复杂度 |
+|------|--------|
+| 单次 hit | O(1) KV 读/写（计数键 + 去重键） |
+| stats 批量 | O(batch)，batch ≤ 100，并行 get |
+| stats top | O(top)，单 KV 维护 top 列表，**不** list 全部 key |
+| catalog 白名单 | 整表 JSON 数组缓存在一个 KV value（1 万 id ≈ 数百 KB） |
+| 写回 Git | **不做** — 避免 Catalog Sync 与 commit 风暴 |
+
+安装 QPS 是瓶颈，不是「应用个数」。万级 catalog + 中等安装量在 Workers 免费/付费档都足够。
+
+## 本地开发
+
+```bash
+cd edge
+npm install
+npm test
+npm run dev
+# 另开终端
+curl -s http://127.0.0.1:8787/health
+curl -s -X POST http://127.0.0.1:8787/v1/hit \
+  -H 'content-type: application/json' \
+  -d '{"app_id":"com.myriad.music-player","event":"install","idempotency_key":"local-test-001"}'
+curl -s 'http://127.0.0.1:8787/v1/stats?app=com.myriad.music-player'
+```
+
+本地 `wrangler dev` 使用模拟 KV。若白名单拉不到 GitHub，可临时：
+
+```toml
+# wrangler.toml [vars]
+ALLOW_UNKNOWN_APPS = "true"
+```
+
+## 部署到 Cloudflare
+
+### 1. 登录与创建 KV
+
+```bash
+cd edge
+npm install
+npx wrangler login
+npx wrangler kv namespace create tapp-store-stats
+npx wrangler kv namespace create tapp-store-stats --preview
+```
+
+把输出的 id 填进 `wrangler.toml`：
+
+```toml
+[[kv_namespaces]]
+binding = "STATS"
+id = "<production id>"
+preview_id = "<preview id>"
+```
+
+### 2. 部署
+
+```bash
+npm run deploy
+```
+
+成功后会打印 `workers.dev` URL，例如：
+
+```text
+https://tapp-store-stats.<subdomain>.workers.dev
+```
+
+**此时不需要自己的域名** 即可给 Myriad 配置：
+
+```bash
+# Myriad backend（后续接入）
+TAPP_STORE_STATS_URL=https://tapp-store-stats.<subdomain>.workers.dev
+
+# 前端（后续接入）
+VITE_TAPP_STORE_STATS_URL=https://tapp-store-stats.<subdomain>.workers.dev
+```
+
+### 3.（可选）自定义域名
+
+在 Cloudflare 仪表盘 → Workers → tapp-store-stats → Triggers → Custom Domains，添加例如 `store-stats.myriad.you`（zone 需已接入 CF）。
+
+## 配置（`[vars]`）
+
+| 变量 | 默认 | 说明 |
+|------|------|------|
+| `CATALOG_URL` | GitHub raw `index.json` | 白名单来源 |
+| `ALLOW_UNKNOWN_APPS` | `false` | `true` 时不校验白名单（仅调试） |
+| `HIT_RATE_LIMIT_PER_MIN` | `60` | 每 IP 每分钟 hit 上限 |
+| `STATS_MAX_BATCH` | `100` | `apps=` 最大个数 |
+| `STATS_TOP_MAX` | `100` | `top=` 最大 |
+| `CATALOG_IDS_TTL_SEC` | `600` | 白名单缓存秒数 |
+
+## 安全说明（v1）
+
+- 匿名公开写 + 限流 + idempotency + catalog 白名单
+- 不存 IP / 用户身份；`CF-Connecting-IP` 仅用于限流键哈希
+- **不是** 审计级防刷；展示文案用「安装次数」即可
+- Stats 宕机不得影响 Myriad 安装（客户端 fire-and-forget）
+
+## 与商店协议的关系
+
+- Git `index.json` 的 `downloads` 字段继续由 Catalog Sync **保留**，但不作为真值写入
+- 真值在本边缘服务；Myriad UI 用 `/v1/stats` overlay（见主仓 `docs/development/tapp/STORE.md`）
+
+## 目录
+
+```text
+edge/
+  src/           Worker 源码
+  test/          纯逻辑单测（不依赖 CF 账号）
+  wrangler.toml  部署配置
+  package.json
+```

--- a/edge/package-lock.json
+++ b/edge/package-lock.json
@@ -1,0 +1,1613 @@
+{
+  "name": "tapp-store-stats",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tapp-store-stats",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250803.0",
+        "typescript": "^5.9.2",
+        "wrangler": "^4.28.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
+      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
+      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
+      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.23",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.23.tgz",
+      "integrity": "sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260730.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
+      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.28.0",
+        "workerd": "1.20260730.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
+      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260730.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
+        "@cloudflare/workerd-linux-64": "1.20260730.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
+        "@cloudflare/workerd-windows-64": "1.20260730.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.118.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.118.0.tgz",
+      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260730.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260730.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260730.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/edge/package.json
+++ b/edge/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "tapp-store-stats",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Edge download/install stats for the Myriad official Tapp store (Cloudflare Workers + KV)",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "node --experimental-strip-types --test test/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "cf-typegen": "wrangler types"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250803.0",
+    "typescript": "^5.9.2",
+    "wrangler": "^4.28.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/edge/src/catalog.ts
+++ b/edge/src/catalog.ts
@@ -1,0 +1,91 @@
+/** Official catalog allowlist — cached in KV for ~10k app ids. */
+
+import {
+  META_CATALOG_IDS,
+  META_CATALOG_TS,
+  type Env,
+} from './types.ts'
+import { parsePositiveInt } from './validate.ts'
+
+export async function isAppAllowed(
+  env: Env,
+  appId: string,
+  allowUnknown: boolean,
+): Promise<boolean> {
+  if (allowUnknown) return true
+  const ids = await getCatalogIds(env)
+  // Empty allowlist (first boot / fetch failure): fail open only if we have never
+  // successfully stored a list; otherwise fail closed.
+  if (ids === null) return true
+  return ids.has(appId)
+}
+
+/**
+ * Returns Set of allowed app ids, or null if no cached list exists yet
+ * (caller may fail-open). On stale cache, refreshes in background when possible.
+ */
+export async function getCatalogIds(env: Env): Promise<Set<string> | null> {
+  const ttlSec = parsePositiveInt(env.CATALOG_IDS_TTL_SEC, 600)
+  const tsRaw = await env.STATS.get(META_CATALOG_TS)
+  const ts = tsRaw ? Number.parseInt(tsRaw, 10) : 0
+  const ageMs = Date.now() - (Number.isFinite(ts) ? ts : 0)
+  const cached = await env.STATS.get(META_CATALOG_IDS)
+
+  if (cached && ageMs < ttlSec * 1000) {
+    return parseIdSet(cached)
+  }
+
+  // Stale or missing: try refresh (await so first hit after deploy gets list).
+  const fresh = await refreshCatalogIds(env)
+  if (fresh) return fresh
+  if (cached) return parseIdSet(cached)
+  return null
+}
+
+export async function refreshCatalogIds(
+  env: Env,
+): Promise<Set<string> | null> {
+  const url = env.CATALOG_URL?.trim()
+  if (!url) return null
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'tapp-store-stats/1',
+      },
+      cf: { cacheTtl: 300, cacheEverything: true },
+    } as RequestInit)
+    if (!res.ok) return null
+    const data = (await res.json()) as { apps?: Array<{ id?: string }> }
+    const ids = new Set<string>()
+    if (Array.isArray(data.apps)) {
+      for (const app of data.apps) {
+        if (app && typeof app.id === 'string' && app.id.trim()) {
+          ids.add(app.id.trim())
+        }
+      }
+    }
+    // Cap defensive size (10k apps is fine; 100k would be abuse of catalog)
+    if (ids.size > 50_000) {
+      return null
+    }
+    const arr = [...ids]
+    await env.STATS.put(META_CATALOG_IDS, JSON.stringify(arr))
+    await env.STATS.put(META_CATALOG_TS, String(Date.now()))
+    return ids
+  } catch {
+    return null
+  }
+}
+
+function parseIdSet(raw: string): Set<string> {
+  try {
+    const arr = JSON.parse(raw) as unknown
+    if (!Array.isArray(arr)) return new Set()
+    return new Set(
+      arr.filter((x): x is string => typeof x === 'string' && x.length > 0),
+    )
+  } catch {
+    return new Set()
+  }
+}

--- a/edge/src/cors.ts
+++ b/edge/src/cors.ts
@@ -1,0 +1,35 @@
+/** CORS helpers — public anonymous stats API. */
+
+const ALLOW_HEADERS = 'content-type'
+const ALLOW_METHODS = 'GET, POST, OPTIONS'
+
+export function corsHeaders(request: Request): HeadersInit {
+  const origin = request.headers.get('Origin')
+  return {
+    'Access-Control-Allow-Origin': origin || '*',
+    'Access-Control-Allow-Methods': ALLOW_METHODS,
+    'Access-Control-Allow-Headers': ALLOW_HEADERS,
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  }
+}
+
+export function withCors(request: Request, response: Response): Response {
+  const headers = new Headers(response.headers)
+  const extra = corsHeaders(request)
+  for (const [k, v] of Object.entries(extra)) {
+    headers.set(k, v)
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+export function preflight(request: Request): Response {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders(request),
+  })
+}

--- a/edge/src/hit.ts
+++ b/edge/src/hit.ts
@@ -1,0 +1,74 @@
+/** POST /v1/hit handler. */
+
+import { isAppAllowed } from './catalog.ts'
+import { checkRateLimit, clientIp, incrementIfNew } from './kv.ts'
+import type { Env, ErrorBody, HitResponse } from './types.ts'
+import { parseBool, parsePositiveInt, validateHitBody } from './validate.ts'
+
+export async function handleHit(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return jsonError(405, 'method not allowed', 'method_not_allowed')
+  }
+
+  const limit = parsePositiveInt(env.HIT_RATE_LIMIT_PER_MIN, 60)
+  const ip = clientIp(request)
+  const allowedRate = await checkRateLimit(env, ip, limit)
+  if (!allowedRate) {
+    return jsonError(429, 'rate limit exceeded', 'rate_limited')
+  }
+
+  let raw: unknown
+  try {
+    raw = await request.json()
+  } catch {
+    return jsonError(400, 'invalid JSON', 'invalid_json')
+  }
+
+  const validated = validateHitBody(raw)
+  if (!validated.ok) {
+    return jsonError(400, validated.error, validated.code)
+  }
+
+  const allowUnknown = parseBool(env.ALLOW_UNKNOWN_APPS, false)
+  const allowed = await isAppAllowed(env, validated.body.app_id, allowUnknown)
+  if (!allowed) {
+    return jsonError(400, 'app_id not in official catalog', 'unknown_app')
+  }
+
+  const { counted, counters } = await incrementIfNew(
+    env,
+    validated.body.app_id,
+    validated.body.event,
+    validated.body.idempotency_key,
+  )
+
+  const body: HitResponse = {
+    ok: true,
+    counted,
+    downloads: counters.installs,
+    installs: counters.installs,
+    updates: counters.updates,
+  }
+
+  return json(200, body, {
+    'Cache-Control': 'no-store',
+  })
+}
+
+function json(status: number, body: unknown, headers?: HeadersInit): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      ...headers,
+    },
+  })
+}
+
+function jsonError(status: number, error: string, code: string): Response {
+  const body: ErrorBody = { ok: false, error, code }
+  return json(status, body, { 'Cache-Control': 'no-store' })
+}

--- a/edge/src/index.ts
+++ b/edge/src/index.ts
@@ -1,0 +1,86 @@
+/**
+ * tapp-store-stats — Cloudflare Worker
+ *
+ * Routes:
+ *   GET  /health
+ *   GET  /v1/stats?apps=a,b | ?app=id | ?top=N
+ *   POST /v1/hit
+ *   OPTIONS *  (CORS preflight)
+ */
+
+import { preflight, withCors } from './cors.ts'
+import { handleHit } from './hit.ts'
+import { handleStats } from './stats.ts'
+import { SERVICE_VERSION, type Env, type ErrorBody } from './types.ts'
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    try {
+      assertEnv(env)
+      const response = await route(request, env)
+      return withCors(request, response)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'internal error'
+      const body: ErrorBody = { ok: false, error: message, code: 'internal' }
+      return withCors(
+        request,
+        new Response(JSON.stringify(body), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        }),
+      )
+    }
+  },
+}
+
+function assertEnv(env: Env): void {
+  if (!env.STATS) {
+    throw new Error('STATS KV binding missing — configure [[kv_namespaces]]')
+  }
+}
+
+async function route(request: Request, env: Env): Promise<Response> {
+  if (request.method === 'OPTIONS') {
+    return preflight(request)
+  }
+
+  const url = new URL(request.url)
+  const path = url.pathname.replace(/\/+$/, '') || '/'
+
+  if (path === '/health' || path === '/') {
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        service: 'tapp-store-stats',
+        version: SERVICE_VERSION,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Cache-Control': 'no-store',
+        },
+      },
+    )
+  }
+
+  if (path === '/v1/hit') {
+    return handleHit(request, env)
+  }
+
+  if (path === '/v1/stats') {
+    return handleStats(request, env)
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      error: 'not found',
+      code: 'not_found',
+    } satisfies ErrorBody),
+    {
+      status: 404,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    },
+  )
+}

--- a/edge/src/kv.ts
+++ b/edge/src/kv.ts
@@ -1,0 +1,186 @@
+/** KV counter / dedupe / rate helpers. */
+
+import {
+  COUNTER_KEY_PREFIX,
+  DEDUPE_KEY_PREFIX,
+  DEDUPE_TTL_SEC,
+  META_TOP_INDEX,
+  RATE_KEY_PREFIX,
+  RATE_TTL_SEC,
+  type AppCounters,
+  type Env,
+} from './types.ts'
+
+export function counterKey(appId: string): string {
+  return `${COUNTER_KEY_PREFIX}${appId}`
+}
+
+export function dedupeKey(idempotencyKey: string): string {
+  return `${DEDUPE_KEY_PREFIX}${idempotencyKey}`
+}
+
+export function rateKey(ipHash: string, minuteBucket: number): string {
+  return `${RATE_KEY_PREFIX}${ipHash}:${minuteBucket}`
+}
+
+export function emptyCounters(): AppCounters {
+  return { installs: 0, updates: 0 }
+}
+
+export function parseCounters(raw: string | null): AppCounters {
+  if (!raw) return emptyCounters()
+  try {
+    const o = JSON.parse(raw) as Partial<AppCounters>
+    return {
+      installs: Math.max(0, Math.floor(Number(o.installs) || 0)),
+      updates: Math.max(0, Math.floor(Number(o.updates) || 0)),
+    }
+  } catch {
+    return emptyCounters()
+  }
+}
+
+export async function getCounters(
+  env: Env,
+  appId: string,
+): Promise<AppCounters> {
+  const raw = await env.STATS.get(counterKey(appId))
+  return parseCounters(raw)
+}
+
+export async function getCountersBatch(
+  env: Env,
+  appIds: string[],
+): Promise<Record<string, AppCounters>> {
+  const out: Record<string, AppCounters> = {}
+  // KV has no multi-get in all runtimes; parallel gets scale fine for ≤100.
+  await Promise.all(
+    appIds.map(async (id) => {
+      out[id] = await getCounters(env, id)
+    }),
+  )
+  return out
+}
+
+/**
+ * Increment counters if idempotency key is new.
+ * Returns whether this call counted, and the resulting counters.
+ */
+export async function incrementIfNew(
+  env: Env,
+  appId: string,
+  event: 'install' | 'update',
+  idempotencyKey: string,
+): Promise<{ counted: boolean; counters: AppCounters }> {
+  const dKey = dedupeKey(idempotencyKey)
+  const existing = await env.STATS.get(dKey)
+  if (existing !== null) {
+    const counters = await getCounters(env, appId)
+    return { counted: false, counters }
+  }
+
+  // Mark dedupe first to reduce double-count under race (second writer sees key).
+  await env.STATS.put(dKey, '1', { expirationTtl: DEDUPE_TTL_SEC })
+
+  const counters = await getCounters(env, appId)
+  if (event === 'install') counters.installs += 1
+  else counters.updates += 1
+
+  await env.STATS.put(counterKey(appId), JSON.stringify(counters))
+  // Best-effort maintain a compact top-installs index for /v1/stats?top=
+  void touchTopIndex(env, appId, counters.installs)
+
+  return { counted: true, counters }
+}
+
+/** Soft IP rate limit. Returns false when over limit. */
+export async function checkRateLimit(
+  env: Env,
+  ip: string,
+  limitPerMin: number,
+): Promise<boolean> {
+  if (limitPerMin <= 0) return true
+  const minuteBucket = Math.floor(Date.now() / 60_000)
+  const ipHash = await sha256Hex(ip).then((h) => h.slice(0, 16))
+  const key = rateKey(ipHash, minuteBucket)
+  const raw = await env.STATS.get(key)
+  const count = raw ? Number.parseInt(raw, 10) || 0 : 0
+  if (count >= limitPerMin) return false
+  await env.STATS.put(key, String(count + 1), { expirationTtl: RATE_TTL_SEC })
+  return true
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+interface TopEntry {
+  id: string
+  installs: number
+}
+
+/**
+ * Maintain a small top-N list in one KV value so we never need a full scan
+ * of 10k counter keys for leaderboard reads.
+ */
+async function touchTopIndex(
+  env: Env,
+  appId: string,
+  installs: number,
+): Promise<void> {
+  try {
+    const raw = await env.STATS.get(META_TOP_INDEX)
+    let list: TopEntry[] = []
+    if (raw) {
+      try {
+        list = JSON.parse(raw) as TopEntry[]
+        if (!Array.isArray(list)) list = []
+      } catch {
+        list = []
+      }
+    }
+    const filtered = list.filter((e) => e && e.id !== appId)
+    filtered.push({ id: appId, installs })
+    filtered.sort((a, b) => b.installs - a.installs || a.id.localeCompare(b.id))
+    // Keep headroom above STATS_TOP_MAX for concurrent churn
+    const trimmed = filtered.slice(0, 200)
+    await env.STATS.put(META_TOP_INDEX, JSON.stringify(trimmed))
+  } catch {
+    // non-fatal
+  }
+}
+
+export async function readTopIndex(
+  env: Env,
+  limit: number,
+): Promise<TopEntry[]> {
+  const raw = await env.STATS.get(META_TOP_INDEX)
+  if (!raw) return []
+  try {
+    const list = JSON.parse(raw) as TopEntry[]
+    if (!Array.isArray(list)) return []
+    return list
+      .filter(
+        (e) =>
+          e &&
+          typeof e.id === 'string' &&
+          typeof e.installs === 'number' &&
+          e.installs > 0,
+      )
+      .slice(0, limit)
+  } catch {
+    return []
+  }
+}
+
+export function clientIp(request: Request): string {
+  return (
+    request.headers.get('CF-Connecting-IP') ||
+    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
+    '0.0.0.0'
+  )
+}

--- a/edge/src/stats.ts
+++ b/edge/src/stats.ts
@@ -1,0 +1,102 @@
+/** GET /v1/stats handler — batch / single / top (10k-safe, no full dump). */
+
+import { getCounters, getCountersBatch, readTopIndex } from './kv.ts'
+import type { Env, ErrorBody, StatsAppEntry, StatsResponse } from './types.ts'
+import { parseAppIdList, parsePositiveInt } from './validate.ts'
+
+export async function handleStats(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (request.method !== 'GET') {
+    return jsonError(405, 'method not allowed', 'method_not_allowed')
+  }
+
+  const url = new URL(request.url)
+  const maxBatch = parsePositiveInt(env.STATS_MAX_BATCH, 100, 200)
+  const topMax = parsePositiveInt(env.STATS_TOP_MAX, 100, 200)
+
+  // Leaderboard: never scans all KV keys — uses maintained top index.
+  const topParam = url.searchParams.get('top')
+  if (topParam !== null) {
+    const n = Math.min(
+      topMax,
+      Math.max(1, Number.parseInt(topParam, 10) || 20),
+    )
+    const top = await readTopIndex(env, n)
+    const apps: Record<string, StatsAppEntry> = {}
+    // Re-read live counters so top list stays accurate after concurrent hits.
+    const ids = top.map((e) => e.id)
+    const live = await getCountersBatch(env, ids)
+    for (const id of ids) {
+      const c = live[id] ?? { installs: 0, updates: 0 }
+      apps[id] = toEntry(c.installs, c.updates)
+    }
+    return jsonStats(apps)
+  }
+
+  // Explicit app list (UI overlay path).
+  const single = url.searchParams.get('app')
+  const appsParam = url.searchParams.get('apps')
+  if (single || appsParam || url.searchParams.getAll('app').length > 0) {
+    const parsed = parseAppIdList(url.searchParams, maxBatch)
+    if (!parsed.ok) {
+      return jsonError(400, parsed.error, parsed.code)
+    }
+    const live = await getCountersBatch(env, parsed.ids)
+    const apps: Record<string, StatsAppEntry> = {}
+    for (const id of parsed.ids) {
+      const c = live[id] ?? { installs: 0, updates: 0 }
+      // Only include apps that have ever been counted — keeps payload small
+      // and UI can treat missing as "no data" (do not show 0).
+      if (c.installs > 0 || c.updates > 0) {
+        apps[id] = toEntry(c.installs, c.updates)
+      } else {
+        // Still return zeros when explicitly asked so clients can merge easily;
+        // FE decides not to display 0.
+        apps[id] = toEntry(0, 0)
+      }
+    }
+    return jsonStats(apps)
+  }
+
+  // Unbounded full dump is rejected at 10k scale — force clients to batch.
+  return jsonError(
+    400,
+    'provide apps=id1,id2, app=id, or top=N (full dump disabled for scale)',
+    'query_required',
+  )
+}
+
+function toEntry(installs: number, updates: number): StatsAppEntry {
+  return { installs, updates, downloads: installs }
+}
+
+function jsonStats(apps: Record<string, StatsAppEntry>): Response {
+  const body: StatsResponse = {
+    updated_at: new Date().toISOString(),
+    apps,
+  }
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      // Short CDN/browser cache — counters are near-real-time, not live tick.
+      'Cache-Control': 'public, max-age=60',
+    },
+  })
+}
+
+function jsonError(status: number, error: string, code: string): Response {
+  const body: ErrorBody = { ok: false, error, code }
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+// re-export for tests that want single-app read without HTTP
+export { getCounters }

--- a/edge/src/types.ts
+++ b/edge/src/types.ts
@@ -1,0 +1,67 @@
+/** Shared types for tapp-store-stats edge worker. */
+
+export type HitEvent = 'install' | 'update'
+
+export type HitClient = 'myriad-backend' | 'myriad-browser' | 'other'
+
+export interface Env {
+  STATS: KVNamespace
+  CATALOG_URL: string
+  ALLOW_UNKNOWN_APPS: string
+  HIT_RATE_LIMIT_PER_MIN: string
+  STATS_MAX_BATCH: string
+  STATS_TOP_MAX: string
+  CATALOG_IDS_TTL_SEC: string
+}
+
+export interface AppCounters {
+  installs: number
+  updates: number
+}
+
+export interface HitRequestBody {
+  app_id: string
+  version?: string
+  event: HitEvent
+  source?: string
+  idempotency_key: string
+  client?: HitClient | string
+  myriad_version?: string
+  instance_hash?: string
+}
+
+export interface HitResponse {
+  ok: true
+  counted: boolean
+  downloads: number
+  installs: number
+  updates: number
+}
+
+export interface StatsAppEntry {
+  installs: number
+  updates: number
+  /** Alias of installs — matches index.json field name. */
+  downloads: number
+}
+
+export interface StatsResponse {
+  updated_at: string
+  apps: Record<string, StatsAppEntry>
+}
+
+export interface ErrorBody {
+  ok: false
+  error: string
+  code?: string
+}
+
+export const SERVICE_VERSION = '1'
+export const COUNTER_KEY_PREFIX = 'c:v1:'
+export const DEDUPE_KEY_PREFIX = 'd:v1:'
+export const RATE_KEY_PREFIX = 'rl:v1:'
+export const META_CATALOG_IDS = 'meta:v1:catalog_ids'
+export const META_CATALOG_TS = 'meta:v1:catalog_ids_ts'
+export const META_TOP_INDEX = 'meta:v1:top_installs'
+export const DEDUPE_TTL_SEC = 48 * 60 * 60
+export const RATE_TTL_SEC = 70

--- a/edge/src/validate.ts
+++ b/edge/src/validate.ts
@@ -1,0 +1,149 @@
+/** Pure validation helpers (unit-testable without KV). */
+
+import type { HitEvent, HitRequestBody } from './types.ts'
+
+// Reverse-domain app ids; segments may include hyphens (e.g. music-player).
+const APP_ID_RE = /^[a-z][a-z0-9_-]*(\.[a-z0-9_-]+)+$/i
+const IDEMPOTENCY_RE = /^[A-Za-z0-9._:-]{8,128}$/
+const VERSION_RE = /^[A-Za-z0-9._+-]{1,64}$/
+
+export function parseBool(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === '') return fallback
+  const v = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(v)) return true
+  if (['0', 'false', 'no', 'off'].includes(v)) return false
+  return fallback
+}
+
+export function parsePositiveInt(
+  value: string | undefined,
+  fallback: number,
+  max?: number,
+): number {
+  const n = Number.parseInt(value ?? '', 10)
+  if (!Number.isFinite(n) || n <= 0) return fallback
+  if (max !== undefined && n > max) return max
+  return n
+}
+
+export function isValidAppId(appId: string): boolean {
+  if (!appId || appId.length > 128) return false
+  return APP_ID_RE.test(appId)
+}
+
+export function isValidHitEvent(event: unknown): event is HitEvent {
+  return event === 'install' || event === 'update'
+}
+
+export type HitValidationOk = { ok: true; body: HitRequestBody }
+export type HitValidationErr = { ok: false; error: string; code: string }
+
+export function validateHitBody(raw: unknown): HitValidationOk | HitValidationErr {
+  if (!raw || typeof raw !== 'object') {
+    return { ok: false, error: 'JSON body required', code: 'invalid_body' }
+  }
+  const o = raw as Record<string, unknown>
+
+  const appId = typeof o.app_id === 'string' ? o.app_id.trim() : ''
+  if (!isValidAppId(appId)) {
+    return { ok: false, error: 'invalid app_id', code: 'invalid_app_id' }
+  }
+
+  if (!isValidHitEvent(o.event)) {
+    return {
+      ok: false,
+      error: 'event must be install or update',
+      code: 'invalid_event',
+    }
+  }
+
+  const idem =
+    typeof o.idempotency_key === 'string' ? o.idempotency_key.trim() : ''
+  if (!IDEMPOTENCY_RE.test(idem)) {
+    return {
+      ok: false,
+      error: 'idempotency_key must be 8–128 chars [A-Za-z0-9._:-]',
+      code: 'invalid_idempotency_key',
+    }
+  }
+
+  let version: string | undefined
+  if (o.version !== undefined && o.version !== null) {
+    if (typeof o.version !== 'string' || !VERSION_RE.test(o.version.trim())) {
+      return { ok: false, error: 'invalid version', code: 'invalid_version' }
+    }
+    version = o.version.trim()
+  }
+
+  const body: HitRequestBody = {
+    app_id: appId,
+    event: o.event,
+    idempotency_key: idem,
+    version,
+  }
+
+  if (typeof o.source === 'string' && o.source.length <= 64) {
+    body.source = o.source
+  }
+  if (typeof o.client === 'string' && o.client.length <= 64) {
+    body.client = o.client
+  }
+  if (typeof o.myriad_version === 'string' && o.myriad_version.length <= 32) {
+    body.myriad_version = o.myriad_version
+  }
+  if (
+    typeof o.instance_hash === 'string' &&
+    /^[a-f0-9]{8,64}$/i.test(o.instance_hash)
+  ) {
+    body.instance_hash = o.instance_hash.toLowerCase()
+  }
+
+  return { ok: true, body }
+}
+
+/** Parse apps query: apps=a,b,c or repeated app= / apps=. */
+export function parseAppIdList(
+  searchParams: URLSearchParams,
+  maxBatch: number,
+): { ok: true; ids: string[] } | { ok: false; error: string; code: string } {
+  const collected: string[] = []
+  const appsParam = searchParams.get('apps')
+  if (appsParam) {
+    for (const part of appsParam.split(',')) {
+      const id = part.trim()
+      if (id) collected.push(id)
+    }
+  }
+  for (const id of searchParams.getAll('app')) {
+    const t = id.trim()
+    if (t) collected.push(t)
+  }
+
+  if (collected.length === 0) {
+    return {
+      ok: false,
+      error: 'provide apps=id1,id2 or app=id (max batch size applies)',
+      code: 'missing_apps',
+    }
+  }
+
+  const unique: string[] = []
+  const seen = new Set<string>()
+  for (const id of collected) {
+    if (!isValidAppId(id)) {
+      return { ok: false, error: `invalid app_id: ${id}`, code: 'invalid_app_id' }
+    }
+    if (seen.has(id)) continue
+    seen.add(id)
+    unique.push(id)
+    if (unique.length > maxBatch) {
+      return {
+        ok: false,
+        error: `at most ${maxBatch} app ids per request`,
+        code: 'batch_too_large',
+      }
+    }
+  }
+
+  return { ok: true, ids: unique }
+}

--- a/edge/test/validate.test.ts
+++ b/edge/test/validate.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  isValidAppId,
+  parseAppIdList,
+  parseBool,
+  parsePositiveInt,
+  validateHitBody,
+} from '../src/validate.ts'
+
+describe('isValidAppId', () => {
+  it('accepts reverse-domain ids', () => {
+    assert.equal(isValidAppId('com.myriad.music-player'), true)
+    assert.equal(isValidAppId('cn.wyyzxzyg.minecraft-hub'), true)
+  })
+
+  it('rejects junk', () => {
+    assert.equal(isValidAppId(''), false)
+    assert.equal(isValidAppId('NoDots'), false)
+    assert.equal(isValidAppId('.leading'), false)
+    assert.equal(isValidAppId('a'), false)
+  })
+})
+
+describe('validateHitBody', () => {
+  it('accepts a minimal install hit', () => {
+    const r = validateHitBody({
+      app_id: 'com.myriad.music-player',
+      event: 'install',
+      idempotency_key: 'abc12345-uuid',
+    })
+    assert.equal(r.ok, true)
+    if (r.ok) {
+      assert.equal(r.body.app_id, 'com.myriad.music-player')
+      assert.equal(r.body.event, 'install')
+    }
+  })
+
+  it('rejects bad event and short idempotency', () => {
+    const badEvent = validateHitBody({
+      app_id: 'com.myriad.music-player',
+      event: 'download',
+      idempotency_key: 'longenough',
+    })
+    assert.equal(badEvent.ok, false)
+
+    const shortKey = validateHitBody({
+      app_id: 'com.myriad.music-player',
+      event: 'install',
+      idempotency_key: 'short',
+    })
+    assert.equal(shortKey.ok, false)
+  })
+})
+
+describe('parseAppIdList', () => {
+  it('parses apps= batch and enforces max', () => {
+    const ok = parseAppIdList(
+      new URLSearchParams('apps=com.a.b,com.c.d'),
+      100,
+    )
+    assert.equal(ok.ok, true)
+    if (ok.ok) assert.deepEqual(ok.ids, ['com.a.b', 'com.c.d'])
+
+    const tooMany = parseAppIdList(
+      new URLSearchParams('apps=com.a.b,com.c.d,com.e.f'),
+      2,
+    )
+    assert.equal(tooMany.ok, false)
+    if (!tooMany.ok) assert.equal(tooMany.code, 'batch_too_large')
+  })
+
+  it('requires at least one id', () => {
+    const r = parseAppIdList(new URLSearchParams(''), 100)
+    assert.equal(r.ok, false)
+  })
+})
+
+describe('parse helpers', () => {
+  it('parseBool / parsePositiveInt', () => {
+    assert.equal(parseBool('true', false), true)
+    assert.equal(parseBool('no', true), false)
+    assert.equal(parsePositiveInt('60', 10), 60)
+    assert.equal(parsePositiveInt('999', 10, 100), 100)
+    assert.equal(parsePositiveInt('x', 7), 7)
+  })
+})

--- a/edge/tsconfig.json
+++ b/edge/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["test/**", "node_modules"]
+}

--- a/edge/wrangler.toml
+++ b/edge/wrangler.toml
@@ -1,0 +1,44 @@
+# Cloudflare Workers — Tapp store install stats
+# Deploy: npm i && npx wrangler login && npm run deploy
+# Local:  npm run dev
+#
+# First-time KV:
+#   npx wrangler kv namespace create tapp-store-stats
+#   npx wrangler kv namespace create tapp-store-stats --preview
+# Then paste the ids below into [[kv_namespaces]].
+
+name = "tapp-store-stats"
+main = "src/index.ts"
+compatibility_date = "2025-08-01"
+workers_dev = true
+
+# Public preview URL: https://tapp-store-stats.<account>.workers.dev
+# Optional custom domain (after zone is on CF):
+# routes = [{ pattern = "store-stats.myriad.you/*", zone_name = "myriad.you" }]
+
+[vars]
+# Official catalog used to refresh the app_id allowlist.
+CATALOG_URL = "https://raw.githubusercontent.com/Myriad-You/tapp-store/main/index.json"
+# When false, unknown app_id hits are rejected (recommended in production).
+ALLOW_UNKNOWN_APPS = "false"
+# Soft rate limit: hits per IP per minute.
+HIT_RATE_LIMIT_PER_MIN = "60"
+# Max app ids accepted by GET /v1/stats?apps=
+STATS_MAX_BATCH = "100"
+# Max apps returned by GET /v1/stats?top=
+STATS_TOP_MAX = "100"
+# How long (seconds) to cache the catalog allowlist in KV.
+CATALOG_IDS_TTL_SEC = "600"
+
+# Bind after creating the namespace (replace ids):
+# [[kv_namespaces]]
+# binding = "STATS"
+# id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# preview_id = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+
+# Local/dev without remote KV: wrangler creates a local sim when binding is present.
+# Uncomment and fill before production deploy:
+[[kv_namespaces]]
+binding = "STATS"
+id = "00000000000000000000000000000000"
+preview_id = "00000000000000000000000000000000"


### PR DESCRIPTION
## Summary
- Add `edge/` Cloudflare Worker for official store install stats (KV counters, `/v1/hit`, `/v1/stats`, `/health`).
- 10k-safe stats API (batch / top only; no full dump).
- Docs in README + STORE.md. Deployable to `*.workers.dev` without a custom domain.

## Deploy notes (CF Git)
- Root directory: `edge`
- Build: `npm ci`
- Deploy: `npx wrangler deploy`
- Create a KV namespace and put real `id` / `preview_id` in `wrangler.toml` before production deploy (placeholders will fail).

## Test plan
- [x] `npm test` / typecheck / wrangler dry-run locally
- [ ] CF build on main after merge
- [ ] `GET /health` on workers.dev URL