### PR TITLE
feat(config-generator): add backend extra network + custom subnet names

### DIFF
--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -303,7 +303,7 @@ services:
     volumes:
       - backend_cache:/app/cache
       - backend_data:/app/data
-    networks: [myriad-net, myriad-admin-net]
+    networks: [myriad-net, myriad-admin-net{{BACKEND_EXTRA_NETWORK_REF}}]
     restart: unless-stopped
     security_opt: [no-new-privileges:true]
     read_only: false
@@ -480,7 +480,7 @@ networks:
     name: \${MYRIAD_DOCKER_GUARD_NETWORK:-myriad-docker-guard-net}
     driver: bridge
     internal: true
-`;
+{{EXTRA_NETWORK_DECL}}`;
 
 var ENV_TEMPLATE = `# Myriad .env — chmod 600，勿提交 Git
 # 禁止 :latest
@@ -494,9 +494,10 @@ FRONTEND_IMAGE=docker.io/somekawahitomi/myriad-frontend
 # PROXY_IMAGE=docker.io/somekawahitomi/myriad-proxy
 # UPDATER_IMAGE=docker.io/somekawahitomi/myriad-updater
 COMPOSE_PROJECT_NAME=myriad
-# MYRIAD_DOCKER_NETWORK=myriad-net
-# MYRIAD_ADMIN_NETWORK=myriad-admin-net
-# MYRIAD_DOCKER_GUARD_NETWORK=myriad-docker-guard-net
+MYRIAD_DOCKER_NETWORK={{MYRIAD_DOCKER_NETWORK}}
+MYRIAD_ADMIN_NETWORK={{MYRIAD_ADMIN_NETWORK}}
+MYRIAD_DOCKER_GUARD_NETWORK={{MYRIAD_DOCKER_GUARD_NETWORK}}
+{{BACKEND_EXTRA_NETWORK_LINE}}
 
 UPDATE_TOKEN={{UPDATE_TOKEN}}
 UPDATER_GATEWAY_SECRET={{UPDATER_GATEWAY_SECRET}}
@@ -1625,7 +1626,11 @@ var state = {
   backendCpuLimit: '2.0',
   backendMemLimit: '4G',
   frontendCpuLimit: '2.0',
-  frontendMemLimit: '2G'
+  frontendMemLimit: '2G',
+  netMyriad: 'myriad-net',
+  netAdmin: 'myriad-admin-net',
+  netGuard: 'myriad-docker-guard-net',
+  dbExtraNetwork: ''
 };
 
 // ========================================
@@ -1695,6 +1700,10 @@ function initPage() {
   var backendMemLimitInput = document.getElementById('backend-mem-limit');
   var frontendCpuLimitInput = document.getElementById('frontend-cpu-limit');
   var frontendMemLimitInput = document.getElementById('frontend-mem-limit');
+  var netMyriadInput = document.getElementById('net-myriad');
+  var netAdminInput = document.getElementById('net-admin');
+  var netGuardInput = document.getElementById('net-guard');
+  var dbExtraNetworkInput = document.getElementById('db-extra-network');
   var refreshTagsBtn = document.getElementById('btn-refresh-tags');
 
   var tagInputs = {
@@ -1893,6 +1902,14 @@ function initPage() {
           if (dbSslmodeSelect) dbSslmodeSelect.focus();
           return;
         }
+        // 附加外部子网可选：非空时须为合法 Docker 网络名
+        var dbExtraNetwork = (dbExtraNetworkInput && dbExtraNetworkInput.value.trim()) || '';
+        if (dbExtraNetwork && !/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(dbExtraNetwork)) {
+          showNotification('附加子网不是合法 Docker 网络名', 'error');
+          if (dbExtraNetworkInput) dbExtraNetworkInput.focus();
+          return;
+        }
+        state.dbExtraNetwork = dbExtraNetwork;
         // External: keep user password as-is (URL-encoded when building DATABASE_URL)
         if (!dbPassword) {
           showNotification('请填写外置数据库密码', 'error');
@@ -1948,6 +1965,7 @@ function initPage() {
       state.dbHost = dbHost;
       state.dbPort = dbPort;
       state.dbSslmode = dbSslmode;
+      if (!isExternal) state.dbExtraNetwork = '';
 
       state.httpBindAddress = httpBindAddressSelect.value || '127.0.0.1';
       if (state.httpBindAddress !== '127.0.0.1' && state.httpBindAddress !== '0.0.0.0') {
@@ -2048,6 +2066,33 @@ function initPage() {
       if (myriadTagInput) myriadTagInput.value = myriadRef.raw;
       if (proxyTagInput) proxyTagInput.value = proxyRef.raw;
       if (updaterTagInput) updaterTagInput.value = updaterRef.raw;
+
+      var netMyriad = (netMyriadInput && netMyriadInput.value.trim()) || state.netMyriad || 'myriad-net';
+      var netAdmin = (netAdminInput && netAdminInput.value.trim()) || state.netAdmin || 'myriad-admin-net';
+      var netGuard = (netGuardInput && netGuardInput.value.trim()) || state.netGuard || 'myriad-docker-guard-net';
+      var netEntries = [
+        { key: 'MYRIAD_DOCKER_NETWORK', value: netMyriad },
+        { key: 'MYRIAD_ADMIN_NETWORK', value: netAdmin },
+        { key: 'MYRIAD_DOCKER_GUARD_NETWORK', value: netGuard }
+      ];
+      var netNameRe = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+      for (var netIdx = 0; netIdx < netEntries.length; netIdx++) {
+        var netEntry = netEntries[netIdx];
+        if (!netEntry.value) {
+          showNotification(netEntry.key + ' 不能为空', 'error');
+          return;
+        }
+        if (!netNameRe.test(netEntry.value)) {
+          showNotification(
+            netEntry.key + ' 不是合法 Docker 网络名',
+            'error'
+          );
+          return;
+        }
+      }
+      state.netMyriad = netMyriad;
+      state.netAdmin = netAdmin;
+      state.netGuard = netGuard;
 
       try {
         generateConfigs();
@@ -2318,6 +2363,15 @@ function generateConfigs() {
       '# POSTGRES_USER=' + state.dbUser + '\n';
   }
 
+  var extraNetworkName = isExternal ? (state.dbExtraNetwork || '').trim() : '';
+  var backendExtraNetworkRef = extraNetworkName ? ', myriad-backend-ext' : '';
+  var extraNetworkDecl = extraNetworkName
+    ? '  myriad-backend-ext:\n    external: true\n    name: ${MYRIAD_BACKEND_EXTRA_NETWORK}\n'
+    : '';
+  var backendExtraNetworkLine = extraNetworkName
+    ? 'MYRIAD_BACKEND_EXTRA_NETWORK=' + extraNetworkName + '\n'
+    : '';
+
   var map = {
     MYRIAD_DB_MODE: isExternal ? 'external' : 'bundled',
     COMPOSE_START_HINT: composeStartHint,
@@ -2348,6 +2402,12 @@ function generateConfigs() {
     CORS_ORIGINS: corsOrigins,
     HTTP_BIND_ADDRESS: state.httpBindAddress,
     HTTP_PORT: String(state.httpPort),
+    MYRIAD_DOCKER_NETWORK: state.netMyriad || 'myriad-net',
+    MYRIAD_ADMIN_NETWORK: state.netAdmin || 'myriad-admin-net',
+    MYRIAD_DOCKER_GUARD_NETWORK: state.netGuard || 'myriad-docker-guard-net',
+    BACKEND_EXTRA_NETWORK_REF: backendExtraNetworkRef,
+    EXTRA_NETWORK_DECL: extraNetworkDecl,
+    BACKEND_EXTRA_NETWORK_LINE: backendExtraNetworkLine,
     MYRIAD_TAG: state.myriadTag,
     PROXY_TAG: state.proxyTag,
     UPDATER_TAG: state.updaterTag,

--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -2090,6 +2090,30 @@ function initPage() {
           return;
         }
       }
+      // 互斥校验：三个内部子网名两两不同；附加外部子网不得与之撞名
+      var extraNetName = (state.dbExtraNetwork || '').trim();
+      var seen = {};
+      for (var exclIdx = 0; exclIdx < netEntries.length; exclIdx++) {
+        var entry = netEntries[exclIdx];
+        var prevKey = seen[entry.value];
+        if (prevKey) {
+          showNotification(
+            prevKey + ' 与 ' + entry.key + ' 使用了相同的 Docker 网络名「' + entry.value + '」' +
+            '，请改为互不相同',
+            'error'
+          );
+          return;
+        }
+        seen[entry.value] = entry.key;
+        if (extraNetName && extraNetName === entry.value) {
+          showNotification(
+            entry.key + ' 与「为 backend 附加 docker 子网」使用了相同的网络名「' + extraNetName + '」' +
+            '，两者必须不同',
+            'error'
+          );
+          return;
+        }
+      }
       state.netMyriad = netMyriad;
       state.netAdmin = netAdmin;
       state.netGuard = netGuard;

--- a/apps/com.myriad.config-generator/manifest.json
+++ b/apps/com.myriad.config-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.config-generator",
   "name": "Myriad 安装配置生成",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minSystemVersion": "0.2.1",
   "description": "生成 Compose、.env 与 Nginx 部署配置（1Panel / 宝塔 / CLI · 整站反代 + 联邦）",
   "locales": {

--- a/apps/com.myriad.config-generator/page.html
+++ b/apps/com.myriad.config-generator/page.html
@@ -154,7 +154,7 @@
           <div class="form-group">
             <label for="db-extra-network">为 backend 附加 docker 子网（可选）</label>
             <input type="text" id="db-extra-network" class="form-input" placeholder="1panel-network" autocomplete="off">
-            <span class="form-hint">如果你的数据库同为容器但是与 myriad 不在同一个子网，你可能需要这个选项。对于 1Panel 部署，它通常为 <code>1panel-network</code>。</span>
+            <span class="form-hint">如果你的数据库同为容器但是与 myriad 不在同一个子网，你可能需要这个选项。对于 1Panel 部署，它通常为 <code>1panel-network</code>。这可能会增加后端容器的安全风险。</span>
           </div>
         </div>
 

--- a/apps/com.myriad.config-generator/page.html
+++ b/apps/com.myriad.config-generator/page.html
@@ -151,6 +151,11 @@
             </select>
           </div>
           <span class="form-hint form-hint-block">容器访问宿主机上的库：常用 <code>host.docker.internal</code>（Docker Desktop）、宿主 IP，或 docker bridge 网关（如 <code>172.17.0.1</code>）。托管库填公网/VPC 主机名即可。</span>
+          <div class="form-group">
+            <label for="db-extra-network">为 backend 附加 docker 子网（可选）</label>
+            <input type="text" id="db-extra-network" class="form-input" placeholder="1panel-network" autocomplete="off">
+            <span class="form-hint">如果你的数据库同为容器但是与 myriad 不在同一个子网，你可能需要这个选项。对于 1Panel 部署，它通常为 <code>1panel-network</code>。</span>
+          </div>
         </div>
 
         <div class="form-row">
@@ -261,6 +266,37 @@
           <div class="form-group form-group-third">
             <label for="updater-tag">UPDATER_TAG</label>
             <input type="text" id="updater-tag" class="form-input" value="" placeholder="自动获取…" autocomplete="off">
+          </div>
+        </div>
+      </section>
+
+      <section class="form-section">
+        <h2 class="section-title">
+          <span class="section-icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="2" y="7" width="20" height="10" rx="2"/>
+              <circle cx="12" cy="12" r="3"/>
+              <path d="M5 7V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v2"/>
+            </svg>
+          </span>
+          网络
+        </h2>
+        <p class="section-desc">自定义 compose 子网名</p>
+        <div class="form-row">
+          <div class="form-group form-group-third">
+            <label for="net-myriad">MYRIAD_DOCKER_NETWORK</label>
+            <input type="text" id="net-myriad" class="form-input" value="myriad-net" placeholder="myriad-net" autocomplete="off">
+            <span class="form-hint">myriad-net</span>
+          </div>
+          <div class="form-group form-group-third">
+            <label for="net-admin">MYRIAD_ADMIN_NETWORK</label>
+            <input type="text" id="net-admin" class="form-input" value="myriad-admin-net" placeholder="myriad-admin-net" autocomplete="off">
+            <span class="form-hint">myriad-admin-net</span>
+          </div>
+          <div class="form-group form-group-third">
+            <label for="net-guard">MYRIAD_DOCKER_GUARD_NETWORK</label>
+            <input type="text" id="net-guard" class="form-input" value="myriad-docker-guard-net" placeholder="myriad-docker-guard-net" autocomplete="off">
+            <span class="form-hint">myriad-docker-guard-net(internal)</span>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## 变更说明

为 config-generator 增加 compose 子网定制能力：
- 新增 网络 区块，可自定义 `MYRIAD_DOCKER_NETWORK` / `MYRIAD_ADMIN_NETWORK` / `MYRIAD_DOCKER_GUARD_NETWORK` 三个子网名
- 数据库（外置模式）新增“为 backend 附加 docker 子网”，当外置库容器位于其他子网（如 1Panel 的 `1panel-network`）时，backend 以 `external: true` 网络加入，可直连该库
- version 1.0.0 → 1.0.1

## 类型

- [ ] 新应用（`apps/<id>/`）
- [x] 更新已有应用（版本 / 功能 / 修复）
- [ ] 文档或脚本 / CI
- [ ] 其他

## 检查清单

- [x] **一次 PR 只改一个 app**（`apps/<id>/`；多 app 请拆 PR）
- [x] **没有修改** 根目录 `index.json`
- [x] 非 README 类改动已 **bump `manifest.version`**（semver 升高）1.0.0 → 1.0.1
- [x] `manifest.id` 与文件夹名一致
- [x] `category` 为稳定 ID：`developer`
- [ ] 商店展示文案（如需）写在 `apps/<id>/catalog.json`，不在 index
- [x] 敏感权限（federation / platform / tappList:manage 等）已审阅（`com.myriad.*` 官方应用豁免）
- [x] 本地：

```bash
node scripts/check-pr-scope.mjs
node scripts/validate-app.mjs --app <id>
node tapp-cli/bin/myriad-tapp.mjs check apps/<id> --json
node scripts/validate-previews.mjs --app <id>
```

## 对齐说明

安装字段以 **`manifest.json` 为准**；合并后 bot 会重写 `index.json` 的 version / category / permissions / download / size 等。  
展示字段以 **`catalog.json`**（可选）为准，否则保留原 index 条目或用 description 引导。
