### PR TITLE
feat: Aro store locales (en-US / ja-JP)

### DIFF
--- a/apps/com.myriad.aro/catalog.json
+++ b/apps/com.myriad.aro/catalog.json
@@ -1,0 +1,47 @@
+{
+  "long_description": "Aro 是 Myriad 官方社交中心，把联邦私信与群聊、时间线、环网和个人资料收在同一处。信使支持 Channel / Room、端到端加密、群共享与本机贴纸包、表情、附件（图片、文件、Tapp、Brew、资料库与报告）、@ 提及、置顶与转发，以及后台轮询新消息通知。时间线可发帖、引用转发、收藏与关注；环网用于实例目录、Brew 推荐、资料交换和 Tapp 商店等节点协作。设置页可查看出站投递队列（取消 / 重试）并轮换联邦签名密钥。聊天记录可在本机导出或导入 JSON 备份。界面支持中英日与宿主明暗主题。",
+  "tags": ["社交", "消息", "联邦", "时间线", "环网", "官方"],
+  "featured": true,
+  "verified": true,
+  "license": "MIT",
+  "homepage": "https://github.com/Myriad-You/tapp-store/tree/main/apps/com.myriad.aro",
+  "repository": "https://github.com/Myriad-You/tapp-store",
+  "preview": {
+    "version": 1,
+    "type": "snapshot",
+    "html": "preview.html",
+    "styles": ["page.css", "preview.css"],
+    "viewport": { "width": 1440, "height": 900 },
+    "fit": "cover",
+    "focus": { "x": 0.5, "y": 0.5 },
+    "theme": "dark"
+  },
+  "locales": {
+    "en-US": {
+      "long_description": "Aro is the official Myriad social hub: federated direct messages and group rooms, a timeline, the ring network, and your profile in one place. Messenger covers Channel / Room chats, end-to-end encryption, shared and personal sticker packs, emoji, attachments (images, files, Tapps, Brew, library, and reports), @mentions, pins, forwards, and background new-message notifications. The timeline supports posts, quote-reposts, bookmarks, and follows; rings connect instance directories, Brew picks, library exchange, and Tapp store peers. Settings show the outbound delivery queue (cancel / retry) and can rotate federation signing keys. Chat history can be exported or imported as a local JSON backup. The UI follows Chinese, English, and Japanese, plus the host light/dark theme.",
+      "preview": {
+        "version": 1,
+        "type": "snapshot",
+        "html": "preview.en-US.html",
+        "styles": ["page.css", "preview.css"],
+        "viewport": { "width": 1440, "height": 900 },
+        "fit": "cover",
+        "focus": { "x": 0.5, "y": 0.5 },
+        "theme": "dark"
+      }
+    },
+    "ja-JP": {
+      "long_description": "Aro は Myriad 公式のソーシャルハブです。連邦のダイレクトメッセージとグループ、タイムライン、リングネット、プロフィールをひとつにまとめます。メッセンジャーは Channel / Room、エンドツーエンド暗号化、グループ共有と端末内のステッカーパック、絵文字、添付（画像・ファイル・Tapp・Brew・ライブラリ・レポート）、@メンション、ピン留め、転送、バックグラウンドの新着通知に対応します。タイムラインでは投稿、引用リポスト、ブックマーク、フォローができ、リングはインスタンス一覧、Brew おすすめ、資料交換、Tapp ストアなどのノード連携に使います。設定では送信キューの確認（キャンセル / 再試行）と連邦署名鍵のローテーションができます。チャット履歴は端末上の JSON バックアップとして書き出し・読み込みできます。UI は中・英・日とホストのライト / ダークテーマに追従します。",
+      "preview": {
+        "version": 1,
+        "type": "snapshot",
+        "html": "preview.ja-JP.html",
+        "styles": ["page.css", "preview.css"],
+        "viewport": { "width": 1440, "height": 900 },
+        "fit": "cover",
+        "focus": { "x": 0.5, "y": 0.5 },
+        "theme": "dark"
+      }
+    }
+  }
+}

--- a/apps/com.myriad.aro/manifest.json
+++ b/apps/com.myriad.aro/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.aro",
   "name": "Aro",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "description": "社交中心，统一管理消息、时间线、环网与个人资料",
   "locales": {
     "en-US": {

--- a/apps/com.myriad.aro/manifest.json
+++ b/apps/com.myriad.aro/manifest.json
@@ -5,22 +5,18 @@
   "description": "社交中心，统一管理消息、时间线、环网与个人资料",
   "locales": {
     "en-US": {
-      "name": null,
       "description": "Social hub for messages, timeline, ring network and profile in one place"
     },
     "ja-JP": {
-      "name": null,
       "description": "メッセージ・タイムライン・リングネット・プロフィールをまとめるソーシャルハブ"
     }
   },
   "author": {
     "name": "Myriad Team",
-    "email": null,
     "url": "https://github.com/Myriad-You"
   },
   "main": "index.js",
   "styles": "styles.css",
-  "widgetStyles": null,
   "pageStyles": "page.css",
   "pageTemplate": "page.html",
   "cssMode": "separated",
@@ -41,13 +37,9 @@
     "media:read",
     "network:fetch"
   ],
-  "icon": null,
   "iconSvg": "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\"/><path d=\"M2 12h20\"/><path d=\"M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z\"/></svg>",
   "themeColor": "#6366f1",
-  "homepage": null,
-  "repository": null,
   "minSystemVersion": "0.2.1",
-  "widgets": null,
   "hasPage": true,
   "backgroundRequirements": [
     "notification"
@@ -57,25 +49,16 @@
       "key": "pollInterval",
       "label": "轮询间隔 (秒)",
       "type": "number",
-      "description": null,
       "defaultValue": 15,
-      "options": null,
       "min": 5,
       "max": 120,
-      "step": 5,
-      "placeholder": null
+      "step": 5
     },
     {
       "key": "notifyOnMessage",
       "label": "新消息通知",
       "type": "toggle",
-      "description": null,
-      "defaultValue": true,
-      "options": null,
-      "min": null,
-      "max": null,
-      "step": null,
-      "placeholder": null
+      "defaultValue": true
     }
   ],
   "category": "social",
@@ -102,10 +85,5 @@
     "views.js",
     "events.js",
     "index.js"
-  ],
-  "apis": null,
-  "dataExchange": null,
-  "ai": null,
-  "events": null,
-  "agent": null
+  ]
 }

--- a/apps/com.myriad.aro/preview.en-US.html
+++ b/apps/com.myriad.aro/preview.en-US.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html class="dark">
+<body class="dark">
+  <div id="tapp-background"><div class="page-bg-base"></div><div class="page-bg-glow page-bg-glow-1"></div><div class="page-bg-glow page-bg-glow-2"></div></div>
+
+  <div id="tapp-content">
+    <nav id="aro-nav" class="aro-nav">
+      <button class="aro-nav-item" type="button"><div class="nav-feed-avatar">H</div><span class="nav-feed-name">Haru</span></button>
+      <button class="aro-nav-item aro-nav-active" type="button">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4 20-7z"/></svg><span>Messages</span>
+      </button>
+      <button class="aro-nav-item" type="button">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M0 15L24 9"/></svg><span>Rings</span>
+      </button>
+    </nav>
+
+    <div id="view-messages" class="aro-view aro-view-active">
+      <div class="messenger-app">
+        <aside class="sidebar">
+          <div class="sidebar-header"><h2 class="sidebar-title">Messages</h2><button class="create-btn" type="button" aria-label="New">+</button></div>
+          <div class="conv-tabs-bar"><div class="conv-tabs" role="tablist"><button class="conv-tab conv-tab-active" type="button">Recent</button><button class="conv-tab" type="button">DMs</button><button class="conv-tab" type="button">Groups</button></div></div>
+          <div class="aro-search-bar"><span class="aro-search-icon"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span><input class="aro-search-input" type="search" placeholder="Search chats…"></div>
+          <div class="conv-list">
+            <button class="conv-item conv-active" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-room preview-avatar-purple">M</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Myriad Design</span><span class="conv-time">21:18</span></div><div class="conv-bottom"><span class="conv-preview">Preview scene is fully synced</span></div></div></button>
+            <button class="conv-item conv-unread" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-channel preview-avatar-coral">N</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Noa</span><span class="conv-time">20:42</span></div><div class="conv-bottom"><span class="conv-preview">The new card layout is really clear</span><span class="conv-badge">2</span></div></div></button>
+            <button class="conv-item" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-room preview-avatar-blue">L</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Lumen Community</span><span class="conv-time">18:05</span></div><div class="conv-bottom"><span class="conv-preview">Mira: See you at the weekend event</span></div></div></button>
+            <button class="conv-item" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-channel preview-avatar-green">A</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Aki</span><span class="conv-time">Yesterday</span></div><div class="conv-bottom"><span class="conv-preview">File received securely</span></div></div></button>
+            <button class="conv-item" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-room preview-avatar-amber">S</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Studio Notes</span><span class="conv-time">Wed</span></div><div class="conv-bottom"><span class="conv-preview">3 new posts</span></div></div></button>
+          </div>
+        </aside>
+
+        <main class="chat-main">
+          <div class="chat-container">
+            <div class="chat-header">
+              <div class="chat-hdr-avatar preview-avatar-purple">M</div>
+              <div class="chat-header-info"><div class="chat-name">Myriad Design</div><div class="chat-meta"><span class="meta-badge badge-public">6 members</span><span class="meta-badge">End-to-end encrypted</span></div></div>
+              <div class="chat-actions"><button class="aro-icon-btn" type="button" aria-label="Search"><svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></button><button class="aro-icon-btn" type="button" aria-label="More">•••</button></div>
+            </div>
+
+            <div class="messages-area">
+              <div class="msg-day-sep"><span class="msg-day-label">Today</span></div>
+              <div class="msg-row msg-remote"><div class="msg-avatar preview-avatar-coral">N</div><div class="msg-bubble bubble-remote"><div class="msg-sender">Noa</div><div class="msg-text">The detail page hierarchy is cleaned up, and the permissions block now matches the settings page.</div><div class="msg-footer"><span class="msg-time">20:54</span></div></div></div>
+              <div class="msg-row msg-remote"><div class="msg-avatar preview-avatar-blue">L</div><div class="msg-bubble bubble-remote"><div class="msg-sender">Lumen</div><div class="msg-text">The desktop preview uses 1440 × 900, so the live page layout and spacing stay intact.</div><div class="msg-footer"><span class="msg-time">21:03</span></div></div></div>
+              <div class="msg-row msg-local"><div class="msg-bubble bubble-local"><div class="msg-text">Let's ship this spec. All static data is sanitized sample copy — no real chats are read.</div><div class="msg-footer"><span class="msg-time">21:12</span></div></div></div>
+              <div class="msg-row msg-remote"><div class="msg-avatar preview-avatar-purple">M</div><div class="msg-bubble bubble-remote"><div class="msg-sender">Mira</div><div class="msg-text">Preview scene is fully synced ✨</div><div class="msg-footer"><span class="msg-time">21:18</span></div></div></div>
+            </div>
+
+            <div class="input-float-wrap"><div class="input-bar"><button class="attach-btn" type="button" aria-label="Attach"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg></button><button class="sticker-btn" type="button" aria-label="Emoji"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M9 10h.01M15 10h.01M8.5 14c1 1.3 2.4 2 3.5 2s2.5-.7 3.5-2"/></svg></button><textarea class="msg-input" rows="1" placeholder="Message…"></textarea><button class="send-btn send-ready" type="button" aria-label="Send"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20V4M5 11l7-7 7 7"/></svg></button></div></div>
+          </div>
+        </main>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/apps/com.myriad.aro/preview.ja-JP.html
+++ b/apps/com.myriad.aro/preview.ja-JP.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html class="dark">
+<body class="dark">
+  <div id="tapp-background"><div class="page-bg-base"></div><div class="page-bg-glow page-bg-glow-1"></div><div class="page-bg-glow page-bg-glow-2"></div></div>
+
+  <div id="tapp-content">
+    <nav id="aro-nav" class="aro-nav">
+      <button class="aro-nav-item" type="button"><div class="nav-feed-avatar">H</div><span class="nav-feed-name">Haru</span></button>
+      <button class="aro-nav-item aro-nav-active" type="button">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4 20-7z"/></svg><span>メッセージ</span>
+      </button>
+      <button class="aro-nav-item" type="button">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M0 15L24 9"/></svg><span>リング</span>
+      </button>
+    </nav>
+
+    <div id="view-messages" class="aro-view aro-view-active">
+      <div class="messenger-app">
+        <aside class="sidebar">
+          <div class="sidebar-header"><h2 class="sidebar-title">メッセージ</h2><button class="create-btn" type="button" aria-label="新規">+</button></div>
+          <div class="conv-tabs-bar"><div class="conv-tabs" role="tablist"><button class="conv-tab conv-tab-active" type="button">最近</button><button class="conv-tab" type="button">DM</button><button class="conv-tab" type="button">グループ</button></div></div>
+          <div class="aro-search-bar"><span class="aro-search-icon"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></span><input class="aro-search-input" type="search" placeholder="チャットを検索…"></div>
+          <div class="conv-list">
+            <button class="conv-item conv-active" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-room preview-avatar-purple">M</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Myriad デザインチーム</span><span class="conv-time">21:18</span></div><div class="conv-bottom"><span class="conv-preview">プレビューシーンの同期が完了しました</span></div></div></button>
+            <button class="conv-item conv-unread" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-channel preview-avatar-coral">N</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Noa</span><span class="conv-time">20:42</span></div><div class="conv-bottom"><span class="conv-preview">新しいカードレイアウトはとても見やすい</span><span class="conv-badge">2</span></div></div></button>
+            <button class="conv-item" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-room preview-avatar-blue">L</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Lumen コミュニティ</span><span class="conv-time">18:05</span></div><div class="conv-bottom"><span class="conv-preview">Mira：週末のイベントで会おう</span></div></div></button>
+            <button class="conv-item" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-channel preview-avatar-green">A</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Aki</span><span class="conv-time">昨日</span></div><div class="conv-bottom"><span class="conv-preview">ファイルを安全に受信しました</span></div></div></button>
+            <button class="conv-item" type="button"><span class="conv-accent"></span><div class="conv-avatar avatar-room preview-avatar-amber">S</div><div class="conv-info"><div class="conv-top"><span class="conv-name">Studio Notes</span><span class="conv-time">水曜</span></div><div class="conv-bottom"><span class="conv-preview">新しい投稿が 3 件</span></div></div></button>
+          </div>
+        </aside>
+
+        <main class="chat-main">
+          <div class="chat-container">
+            <div class="chat-header">
+              <div class="chat-hdr-avatar preview-avatar-purple">M</div>
+              <div class="chat-header-info"><div class="chat-name">Myriad デザインチーム</div><div class="chat-meta"><span class="meta-badge badge-public">6 人のメンバー</span><span class="meta-badge">エンドツーエンド暗号化</span></div></div>
+              <div class="chat-actions"><button class="aro-icon-btn" type="button" aria-label="検索"><svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg></button><button class="aro-icon-btn" type="button" aria-label="その他">•••</button></div>
+            </div>
+
+            <div class="messages-area">
+              <div class="msg-day-sep"><span class="msg-day-label">今日</span></div>
+              <div class="msg-row msg-remote"><div class="msg-avatar preview-avatar-coral">N</div><div class="msg-bubble bubble-remote"><div class="msg-sender">Noa</div><div class="msg-text">詳細ページの情報階層は整理済みで、権限エリアも設定ページと同じスタイルに揃えました。</div><div class="msg-footer"><span class="msg-time">20:54</span></div></div></div>
+              <div class="msg-row msg-remote"><div class="msg-avatar preview-avatar-blue">L</div><div class="msg-bubble bubble-remote"><div class="msg-sender">Lumen</div><div class="msg-text">デスクトッププレビューは 1440 × 900 なので、本番ページのレイアウトと余白をそのまま残せます。</div><div class="msg-footer"><span class="msg-time">21:03</span></div></div></div>
+              <div class="msg-row msg-local"><div class="msg-bubble bubble-local"><div class="msg-text">この仕様でいきましょう。静的データはすべてマスキングしたサンプルで、実際の会話は読み取りません。</div><div class="msg-footer"><span class="msg-time">21:12</span></div></div></div>
+              <div class="msg-row msg-remote"><div class="msg-avatar preview-avatar-purple">M</div><div class="msg-bubble bubble-remote"><div class="msg-sender">Mira</div><div class="msg-text">プレビューシーンの同期が完了しました ✨</div><div class="msg-footer"><span class="msg-time">21:18</span></div></div></div>
+            </div>
+
+            <div class="input-float-wrap"><div class="input-bar"><button class="attach-btn" type="button" aria-label="添付"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg></button><button class="sticker-btn" type="button" aria-label="絵文字"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M9 10h.01M15 10h.01M8.5 14c1 1.3 2.4 2 3.5 2s2.5-.7 3.5-2"/></svg></button><textarea class="msg-input" rows="1" placeholder="メッセージを入力…"></textarea><button class="send-btn send-ready" type="button" aria-label="送信"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20V4M5 11l7-7 7 7"/></svg></button></div></div>
+          </div>
+        </main>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Why

Official merchandising locales for **com.myriad.aro**. Split from #81 because store CI allows at most one `apps/<id>` per PR and forbids editing `index.json`.

## This PR

- `catalog.json` locale overlays (en-US / ja-JP)
- `preview.en-US.html` / `preview.ja-JP.html`
- Manifest version bump

Does **not** touch `index.json` — Catalog Sync regenerates it after merge.

Depends on host locale picking from Myriad #324 (`pickLocaleEntry`).