### PR TITLE
feat: Config Generator store locales (en-US / ja-JP)

### DIFF
--- a/apps/com.myriad.config-generator/catalog.json
+++ b/apps/com.myriad.config-generator/catalog.json
@@ -1,0 +1,47 @@
+{
+  "long_description": "填写域名与数据库参数，按所选面板（1Panel / 宝塔 / 通用 CLI）生成官方生产拓扑的 docker-compose、.env、Nginx 与部署说明。密钥白名单与 .env 再解析防注入；原生表单/通知全自定义；宝塔可粘贴编排或目录部署。",
+  "tags": ["配置", "部署", "Docker", "Nginx", "Updater", "1Panel", "宝塔", "工具", "开发者"],
+  "featured": true,
+  "verified": true,
+  "license": "MIT",
+  "homepage": "https://github.com/Myriad-You/tapp-store/tree/main/apps/com.myriad.config-generator",
+  "repository": "https://github.com/Myriad-You/tapp-store",
+  "preview": {
+    "version": 1,
+    "type": "snapshot",
+    "html": "preview.html",
+    "styles": ["page.css", "preview.css"],
+    "viewport": { "width": 1440, "height": 900 },
+    "fit": "cover",
+    "focus": { "x": 0.5, "y": 0.5 },
+    "theme": "dark"
+  },
+  "locales": {
+    "en-US": {
+      "long_description": "Enter domain and database settings, then generate official production docker-compose, .env, Nginx, and deploy notes for the selected panel (1Panel / Baota / generic CLI). Secrets are allowlisted and the .env is parsed again to block injection; native forms and notifications are fully custom-drawn. On Baota you can paste compose or deploy from a directory.",
+      "preview": {
+        "version": 1,
+        "type": "snapshot",
+        "html": "preview.en-US.html",
+        "styles": ["page.css", "preview.css"],
+        "viewport": { "width": 1440, "height": 900 },
+        "fit": "cover",
+        "focus": { "x": 0.5, "y": 0.5 },
+        "theme": "dark"
+      }
+    },
+    "ja-JP": {
+      "long_description": "ドメインとデータベースのパラメータを入力し、選択したパネル（1Panel / 宝塔 / 汎用 CLI）向けに公式本番トポロジの docker-compose、.env、Nginx、デプロイ手順を生成します。シークレットはホワイトリスト検証し、.env を再パースしてインジェクションを防ぎます。ネイティブのフォームと通知はすべてカスタム描画です。宝塔では編成の貼り付けまたはディレクトリ配置が可能です。",
+      "preview": {
+        "version": 1,
+        "type": "snapshot",
+        "html": "preview.ja-JP.html",
+        "styles": ["page.css", "preview.css"],
+        "viewport": { "width": 1440, "height": 900 },
+        "fit": "cover",
+        "focus": { "x": 0.5, "y": 0.5 },
+        "theme": "dark"
+      }
+    }
+  }
+}

--- a/apps/com.myriad.config-generator/manifest.json
+++ b/apps/com.myriad.config-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.config-generator",
   "name": "Myriad 安装配置生成",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minSystemVersion": "0.2.1",
   "description": "生成 Compose、.env 与 Nginx 部署配置（1Panel / 宝塔 / CLI · 整站反代 + 联邦）",
   "locales": {

--- a/apps/com.myriad.config-generator/preview.en-US.html
+++ b/apps/com.myriad.config-generator/preview.en-US.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html class="dark">
+<body>
+  <div id="tapp-background">
+    <div class="page-bg-base"></div>
+    <div class="page-bg-glow page-bg-glow-1"></div>
+    <div class="page-bg-glow page-bg-glow-2"></div>
+  </div>
+
+  <div id="tapp-content">
+    <div class="page-content">
+      <header class="page-header">
+        <div class="header-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="M12 18v-6M9 15l3 3 3-3"/>
+          </svg>
+        </div>
+        <div class="header-info">
+          <h1 class="header-title">Myriad Install Config Generator</h1>
+          <p class="header-subtitle">Compose · .env · Nginx · Deploy notes</p>
+        </div>
+      </header>
+
+      <div class="section-info">
+        <span class="section-info-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+        </span>
+        <div class="section-info-content"><span class="section-info-title">Notes</span>Generate Compose / .env / Nginx and deploy steps for your panel. Do not commit secrets.</div>
+      </div>
+
+      <div class="config-form">
+        <section class="form-section">
+          <h2 class="section-title">
+            <span class="section-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+            </span>
+            Panel
+          </h2>
+          <div class="form-group">
+            <span class="form-label-text">Deploy panel</span>
+            <div class="panel-mode-toggle" role="radiogroup">
+              <label class="panel-mode-option is-active"><input type="radio" checked><span class="panel-mode-option-title">1Panel</span><span class="panel-mode-option-desc">Paste YAML into compose · env vars box</span></label>
+              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">Baota Panel</span><span class="panel-mode-option-desc">Paste compose · watch pgdata owner</span></label>
+              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">Generic / CLI</span><span class="panel-mode-option-desc">Standard paths · docker compose</span></label>
+            </div>
+            <span class="form-hint">1Panel: docker-compose.yml → “Containers / Compose”; .env → “Environment”. Reverse-proxy the whole site to HTTP_BIND:HTTP_PORT.</span>
+          </div>
+        </section>
+
+        <section class="form-section">
+          <h2 class="section-title">
+            <span class="section-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+            </span>
+            Domain
+          </h2>
+          <div class="form-group"><label>Primary domain</label><input class="form-input" type="text" value="myriad.example.net"><span class="form-hint">Do not include <code>https://</code>. Written to <code>BASE_URL</code> and <code>FRONTEND_URL</code>.</span></div>
+          <div class="form-group"><label>Extra domains (optional)</label><input class="form-input" type="text" value="www.example.net"></div>
+        </section>
+
+        <section class="form-section preview-database-section">
+          <h2 class="section-title">
+            <span class="section-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/><path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3"/></svg>
+            </span>
+            Database
+          </h2>
+          <div class="form-group">
+            <span class="form-label-text">Deploy mode</span>
+            <div class="db-mode-toggle">
+              <label class="db-mode-option is-active"><input type="radio" checked><span class="db-mode-option-title">Bundled Postgres</span><span class="db-mode-option-desc">postgres in compose · default</span></label>
+              <label class="db-mode-option"><input type="radio"><span class="db-mode-option-title">External Postgres</span><span class="db-mode-option-desc">Panel / hosted DB · no postgres service</span></label>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group form-group-half"><label>Database name</label><input class="form-input" type="text" value="myriad"></div>
+            <div class="form-group form-group-half"><label>Username</label><input class="form-input" type="text" value="myriad"></div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/apps/com.myriad.config-generator/preview.ja-JP.html
+++ b/apps/com.myriad.config-generator/preview.ja-JP.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html class="dark">
+<body>
+  <div id="tapp-background">
+    <div class="page-bg-base"></div>
+    <div class="page-bg-glow page-bg-glow-1"></div>
+    <div class="page-bg-glow page-bg-glow-2"></div>
+  </div>
+
+  <div id="tapp-content">
+    <div class="page-content">
+      <header class="page-header">
+        <div class="header-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="M12 18v-6M9 15l3 3 3-3"/>
+          </svg>
+        </div>
+        <div class="header-info">
+          <h1 class="header-title">Myriad インストール設定ジェネレーター</h1>
+          <p class="header-subtitle">Compose · .env · Nginx · デプロイ手順</p>
+        </div>
+      </header>
+
+      <div class="section-info">
+        <span class="section-info-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+        </span>
+        <div class="section-info-content"><span class="section-info-title">説明</span>パネル別に Compose / .env / Nginx とデプロイ手順を生成します。シークレットはコミットしないでください。</div>
+      </div>
+
+      <div class="config-form">
+        <section class="form-section">
+          <h2 class="section-title">
+            <span class="section-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+            </span>
+            パネル
+          </h2>
+          <div class="form-group">
+            <span class="form-label-text">デプロイパネル</span>
+            <div class="panel-mode-toggle" role="radiogroup">
+              <label class="panel-mode-option is-active"><input type="radio" checked><span class="panel-mode-option-title">1Panel</span><span class="panel-mode-option-desc">YAML を編成に貼り付け · 環境変数欄</span></label>
+              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">宝塔パネル</span><span class="panel-mode-option-desc">編成を貼り付け可 · pgdata の所有者に注意</span></label>
+              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">汎用 / CLI</span><span class="panel-mode-option-desc">標準パス · docker compose</span></label>
+            </div>
+            <span class="form-hint">1Panel：docker-compose.yml →「コンテナ / 編成」；.env →「環境変数」。サイト全体を HTTP_BIND:HTTP_PORT にリバースプロキシ。</span>
+          </div>
+        </section>
+
+        <section class="form-section">
+          <h2 class="section-title">
+            <span class="section-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+            </span>
+            ドメイン
+          </h2>
+          <div class="form-group"><label>メインドメイン</label><input class="form-input" type="text" value="myriad.example.net"><span class="form-hint"><code>https://</code> は付けないでください。<code>BASE_URL</code> と <code>FRONTEND_URL</code> に書き込まれます。</span></div>
+          <div class="form-group"><label>追加ドメイン（任意）</label><input class="form-input" type="text" value="www.example.net"></div>
+        </section>
+
+        <section class="form-section preview-database-section">
+          <h2 class="section-title">
+            <span class="section-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/><path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3"/></svg>
+            </span>
+            データベース
+          </h2>
+          <div class="form-group">
+            <span class="form-label-text">デプロイ方式</span>
+            <div class="db-mode-toggle">
+              <label class="db-mode-option is-active"><input type="radio" checked><span class="db-mode-option-title">内蔵 Postgres</span><span class="db-mode-option-desc">compose 内 postgres · デフォルト</span></label>
+              <label class="db-mode-option"><input type="radio"><span class="db-mode-option-title">外部 Postgres</span><span class="db-mode-option-desc">パネル / マネージドDB · postgres サービスなし</span></label>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group form-group-half"><label>データベース名</label><input class="form-input" type="text" value="myriad"></div>
+            <div class="form-group form-group-half"><label>ユーザー名</label><input class="form-input" type="text" value="myriad"></div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/sync-index.mjs
+++ b/scripts/sync-index.mjs
@@ -3,7 +3,7 @@
 //
 // Manifest is the authority for install-critical fields (id/name/version/
 // description/locales/author/category/permissions/icons/theme/download map).
-// Store-only merchandising (long_description, tags, featured, preview, ...) is
+// Store-only merchandising (long_description, tags, featured, preview, locales, ...) is
 // loaded from apps/<id>/catalog.json when present, else preserved from the
 // previous index entry, or bootstrapped for new apps.
 //
@@ -378,6 +378,50 @@ function loadManifest(appId) {
  * Optional per-app merchandising file. Contributors edit this instead of index.json.
  * Paths in preview may be app-relative (preview.html) or repo-relative (apps/id/...).
  */
+function normalizeCatalogPreview(appId, preview) {
+  if (!preview || typeof preview !== 'object' || Array.isArray(preview)) return preview
+  const fix = (path) => {
+    if (typeof path !== 'string') return path
+    if (path.startsWith('apps/')) return path
+    return packageRel(appId, path.replace(/^\.\//, ''))
+  }
+  const next = { ...preview }
+  if (next.html) next.html = fix(next.html)
+  if (Array.isArray(next.styles)) next.styles = next.styles.map(fix)
+  return next
+}
+
+function mergeStoreLocales(manifestLocales, catalogLocales, appId, manifest) {
+  const fromManifest = cleanLocales(manifestLocales) || {}
+  const catalog =
+    catalogLocales && typeof catalogLocales === 'object' && !Array.isArray(catalogLocales)
+      ? catalogLocales
+      : {}
+  const tags = [...Object.keys(fromManifest)]
+  for (const tag of Object.keys(catalog)) {
+    if (!tags.includes(tag)) tags.push(tag)
+  }
+  const out = {}
+  for (const tag of tags) {
+    const entry = { ...(fromManifest[tag] || {}) }
+    const extra = catalog[tag]
+    if (extra && typeof extra === 'object' && !Array.isArray(extra)) {
+      if (typeof extra.long_description === 'string' && extra.long_description.trim()) {
+        entry.long_description = extra.long_description
+      }
+      if (extra.preview) {
+        entry.preview = sanitizePreview(
+          appId,
+          normalizeCatalogPreview(appId, extra.preview),
+          manifest,
+        )
+      }
+    }
+    if (Object.keys(entry).length) out[tag] = entry
+  }
+  return Object.keys(out).length ? out : undefined
+}
+
 function loadCatalogMeta(appId) {
   const path = join(appsDir, appId, 'catalog.json')
   if (!existsSync(path)) return null
@@ -390,17 +434,17 @@ function loadCatalogMeta(appId) {
   delete meta.securityReview
   delete meta.security_review
 
-  if (meta.preview && typeof meta.preview === 'object') {
-    const fix = (p) => {
-      if (typeof p !== 'string') return p
-      if (p.startsWith('apps/')) return p
-      return packageRel(appId, p.replace(/^\.\//, ''))
+  if (meta.preview) meta.preview = normalizeCatalogPreview(appId, meta.preview)
+  if (meta.locales && typeof meta.locales === 'object' && !Array.isArray(meta.locales)) {
+    const locales = {}
+    for (const [tag, entry] of Object.entries(meta.locales)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+      locales[tag] = { ...entry }
+      if (locales[tag].preview) {
+        locales[tag].preview = normalizeCatalogPreview(appId, locales[tag].preview)
+      }
     }
-    meta.preview = { ...meta.preview }
-    if (meta.preview.html) meta.preview.html = fix(meta.preview.html)
-    if (Array.isArray(meta.preview.styles)) {
-      meta.preview.styles = meta.preview.styles.map(fix)
-    }
+    meta.locales = locales
   }
   return meta
 }
@@ -467,10 +511,11 @@ function buildAlignedEntry(appId, previous = null) {
     description: manifest.description || '',
   }
 
-  const locales = cleanLocales(manifest.locales)
-  if (locales) entry.locales = locales
-
   applyMerchandising(entry, previous, catalog, appId, manifest, now)
+
+  const locales = mergeStoreLocales(manifest.locales, catalog?.locales, appId, manifest)
+  if (locales) entry.locales = locales
+  else delete entry.locales
 
   entry.author = cleanAuthor(manifest.author)
   if (manifest.license && !entry.license) entry.license = manifest.license

--- a/scripts/validate-app.mjs
+++ b/scripts/validate-app.mjs
@@ -64,6 +64,7 @@ const CATALOG_ALLOWED_KEYS = new Set([
   'icon_shell',
   'screenshots',
   'preview',
+  'locales',
   'featured',
   'verified',
   'license',
@@ -72,6 +73,11 @@ const CATALOG_ALLOWED_KEYS = new Set([
   'securityReview',
   'security_review',
 ])
+
+const CATALOG_LOCALE_KEYS = new Set(['long_description', 'preview'])
+const LOCALE_TAG = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{1,8})*$/
+const MAX_CATALOG_LOCALES = 32
+const MAX_LONG_DESCRIPTION = 20000
 
 const JUNK_NAME = /^(?:\.DS_Store|Thumbs\.db|\.env.*)$/i
 const MAX_PACKAGE_BYTES = 50 * 1024 * 1024 // 50 MiB hard
@@ -126,6 +132,44 @@ function isOfficial(appId) {
   return appId === 'com.myriad' || appId.startsWith('com.myriad.')
 }
 
+function validateCatalogLocales(appId, locales, errors) {
+  if (!locales || typeof locales !== 'object' || Array.isArray(locales)) {
+    errors.push(`${appId}: catalog.locales must be an object`)
+    return
+  }
+  const tags = Object.keys(locales)
+  if (tags.length > MAX_CATALOG_LOCALES) {
+    errors.push(`${appId}: catalog.locales accepts at most ${MAX_CATALOG_LOCALES} languages`)
+  }
+  for (const [tag, entry] of Object.entries(locales)) {
+    if (!LOCALE_TAG.test(tag)) {
+      errors.push(`${appId}: catalog.locales key "${tag}" must be a BCP-47 tag (e.g. zh-CN)`)
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push(`${appId}: catalog.locales.${tag} must be an object`)
+      continue
+    }
+    for (const key of Object.keys(entry)) {
+      if (!CATALOG_LOCALE_KEYS.has(key)) {
+        errors.push(
+          `${appId}: catalog.locales.${tag} unknown key "${key}" (name/description belong in manifest.locales)`,
+        )
+      }
+    }
+    if (entry.long_description !== undefined && typeof entry.long_description !== 'string') {
+      errors.push(`${appId}: catalog.locales.${tag}.long_description must be a string`)
+    }
+    if (entry.long_description && entry.long_description.length > MAX_LONG_DESCRIPTION) {
+      errors.push(
+        `${appId}: catalog.locales.${tag}.long_description too long (max ${MAX_LONG_DESCRIPTION})`,
+      )
+    }
+    if (entry.preview != null && (typeof entry.preview !== 'object' || Array.isArray(entry.preview))) {
+      errors.push(`${appId}: catalog.locales.${tag}.preview must be an object`)
+    }
+  }
+}
+
 function validateCatalogJson(appId, catalog, errors, warnings) {
   if (!catalog || typeof catalog !== 'object' || Array.isArray(catalog)) {
     errors.push(`${appId}: catalog.json must be a JSON object`)
@@ -146,8 +190,11 @@ function validateCatalogJson(appId, catalog, errors, warnings) {
   if (catalog.long_description !== undefined && typeof catalog.long_description !== 'string') {
     errors.push(`${appId}: catalog.long_description must be a string`)
   }
-  if (catalog.long_description && catalog.long_description.length > 20000) {
-    errors.push(`${appId}: catalog.long_description too long (max 20000)`)
+  if (catalog.long_description && catalog.long_description.length > MAX_LONG_DESCRIPTION) {
+    errors.push(`${appId}: catalog.long_description too long (max ${MAX_LONG_DESCRIPTION})`)
+  }
+  if (catalog.locales !== undefined) {
+    validateCatalogLocales(appId, catalog.locales, errors)
   }
   for (const flag of ['featured', 'verified', 'icon_shell', 'securityReview', 'security_review']) {
     if (catalog[flag] !== undefined && typeof catalog[flag] !== 'boolean') {

--- a/scripts/validate-previews.mjs
+++ b/scripts/validate-previews.mjs
@@ -104,21 +104,46 @@ function bootstrapFromDisk(appId) {
   }
 }
 
+function fixPreviewPaths(appId, preview) {
+  if (!preview || typeof preview !== 'object') return preview
+  const next = { ...preview }
+  const fix = (p) => {
+    if (typeof p !== 'string') return p
+    if (p.startsWith('apps/')) return p
+    return packageRel(appId, p.replace(/^\.\//, ''))
+  }
+  if (next.html) next.html = fix(next.html)
+  if (Array.isArray(next.styles)) next.styles = next.styles.map(fix)
+  return next
+}
+
 function loadCatalogPreview(appId) {
   const catalogPath = join(root, 'apps', appId, 'catalog.json')
   if (!existsSync(catalogPath)) return null
   try {
     const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'))
     if (!catalog.preview) return null
-    const preview = { ...catalog.preview }
-    const fix = (p) => {
-      if (typeof p !== 'string') return p
-      if (p.startsWith('apps/')) return p
-      return packageRel(appId, p.replace(/^\.\//, ''))
+    return fixPreviewPaths(appId, catalog.preview)
+  } catch {
+    return null
+  }
+}
+
+function collectLocalePreviews(appId, locales, sourcePrefix, targets) {
+  if (!locales || typeof locales !== 'object' || Array.isArray(locales)) return
+  for (const [tag, entry] of Object.entries(locales)) {
+    if (entry?.preview) {
+      pushTarget(targets, appId, fixPreviewPaths(appId, entry.preview), `${sourcePrefix} locales.${tag}`)
     }
-    if (preview.html) preview.html = fix(preview.html)
-    if (Array.isArray(preview.styles)) preview.styles = preview.styles.map(fix)
-    return preview
+  }
+}
+
+function loadCatalogLocales(appId) {
+  const catalogPath = join(root, 'apps', appId, 'catalog.json')
+  if (!existsSync(catalogPath)) return null
+  try {
+    const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'))
+    return catalog.locales ?? null
   } catch {
     return null
   }
@@ -138,12 +163,15 @@ async function main() {
   if (args.app) {
     const entry = byId.get(args.app)
     if (entry?.preview) pushTarget(targets, args.app, entry.preview, 'index')
+    collectLocalePreviews(args.app, entry?.locales, 'index', targets)
     pushTarget(targets, args.app, loadCatalogPreview(args.app), 'catalog.json')
+    collectLocalePreviews(args.app, loadCatalogLocales(args.app), 'catalog.json', targets)
     const disk = bootstrapFromDisk(args.app)
     if (disk) pushTarget(targets, args.app, disk, 'disk')
   } else {
     for (const app of index.apps || []) {
       if (app.preview) pushTarget(targets, app.id, app.preview, 'index')
+      collectLocalePreviews(app.id, app.locales, 'index', targets)
     }
     if (args.disk) {
       for (const name of readdirSync(join(root, 'apps'))) {
@@ -155,6 +183,7 @@ async function main() {
         }
         if (byId.get(name)?.preview) continue
         const fromCatalog = loadCatalogPreview(name)
+        collectLocalePreviews(name, loadCatalogLocales(name), 'catalog.json', targets)
         if (fromCatalog) {
           pushTarget(targets, name, fromCatalog, 'catalog.json')
           continue


### PR DESCRIPTION
## Why

Official merchandising locales for **com.myriad.config-generator**. Split from #81 because store CI allows at most one `apps/<id>` per PR and forbids editing `index.json`.

## This PR

- `catalog.json` locale overlays (en-US / ja-JP)
- `preview.en-US.html` / `preview.ja-JP.html`
- Manifest version bump

Does **not** touch `index.json` — Catalog Sync regenerates it after merge.

Depends on host locale picking from Myriad #324 (`pickLocaleEntry`).