### PR TITLE
feat: Music Player store locales (en-US / ja-JP)

### DIFF
--- a/apps/com.myriad.music-player/catalog.json
+++ b/apps/com.myriad.music-player/catalog.json
@@ -1,0 +1,47 @@
+{
+  "long_description": "对接系统播放器，显示封面、进度与播放控制；支持同步歌词、列表搜索，以及顺序、循环、单曲和随机模式。",
+  "tags": ["音乐", "播放器", "歌词", "播放列表", "多语言"],
+  "featured": true,
+  "verified": true,
+  "license": "MIT",
+  "homepage": "https://github.com/Myriad-You/tapp-store/tree/main/apps/com.myriad.music-player",
+  "repository": "https://github.com/Myriad-You/tapp-store",
+  "preview": {
+    "version": 1,
+    "type": "snapshot",
+    "html": "preview.html",
+    "styles": ["page.css", "preview.css"],
+    "viewport": { "width": 1440, "height": 900 },
+    "fit": "cover",
+    "focus": { "x": 0.5, "y": 0.5 },
+    "theme": "dark"
+  },
+  "locales": {
+    "en-US": {
+      "long_description": "Connects to the system music player and shows artwork, progress, and playback controls. Supports synced lyrics, playlist search, and sequential, repeat, single-track, and shuffle modes.",
+      "preview": {
+        "version": 1,
+        "type": "snapshot",
+        "html": "preview.en-US.html",
+        "styles": ["page.css", "preview.css"],
+        "viewport": { "width": 1440, "height": 900 },
+        "fit": "cover",
+        "focus": { "x": 0.5, "y": 0.5 },
+        "theme": "dark"
+      }
+    },
+    "ja-JP": {
+      "long_description": "システム音楽プレーヤーに接続し、ジャケット、再生位置、再生コントロールを表示します。同期歌詞、プレイリスト検索、および順再生・リピート・1曲リピート・シャッフルに対応します。",
+      "preview": {
+        "version": 1,
+        "type": "snapshot",
+        "html": "preview.ja-JP.html",
+        "styles": ["page.css", "preview.css"],
+        "viewport": { "width": 1440, "height": 900 },
+        "fit": "cover",
+        "focus": { "x": 0.5, "y": 0.5 },
+        "theme": "dark"
+      }
+    }
+  }
+}

--- a/apps/com.myriad.music-player/manifest.json
+++ b/apps/com.myriad.music-player/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.music-player",
   "name": "音乐播放器",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minSystemVersion": "0.2.1",
   "description": "控制系统音乐播放，查看歌词与播放列表",
   "locales": {

--- a/apps/com.myriad.music-player/preview.en-US.html
+++ b/apps/com.myriad.music-player/preview.en-US.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html class="mp-side-lyrics mp-has-lyrics player-playing fx-compositing">
+<body>
+  <div id="tapp-background">
+    <div class="bg-artwork"></div>
+    <div class="bg-overlay"></div>
+    <div class="rhythm-layer" aria-hidden="true"><div class="rhythm-ripple"></div><div class="rhythm-ripple"></div><div class="rhythm-ripple"></div></div>
+  </div>
+  <div id="tapp-content">
+    <div class="content-area">
+      <div class="player-left">
+        <div class="player-hero">
+          <div class="artwork-container">
+            <div class="artwork-aurora"><span class="aurora-blob aurora-bass"></span><span class="aurora-blob aurora-mid"></span><span class="aurora-blob aurora-high"></span></div>
+            <div class="artwork-wrapper"><div class="preview-album-cover"><span>夜間飛行</span><small>NIGHT SIGNALS</small><i></i></div></div>
+          </div>
+          <div class="track-info">
+            <div class="track-title-row"><h1 class="track-title"><span class="marquee-inner">夜間飛行</span></h1></div>
+            <p class="track-artist"><span class="marquee-inner">Lumen · City Lights</span></p>
+          </div>
+        </div>
+      </div>
+      <div class="player-right side-open">
+        <section class="panel panel-lyrics active">
+          <div class="lyrics-scroll">
+            <div class="lyrics-inner preview-lyrics">
+              <div class="lyric-line passed">灯りが滲む窓の向こう</div>
+              <div class="lyric-line passed">静かな街を越えて</div>
+              <div class="lyric-line active">夜の風に名前を預けて</div>
+              <div class="lyric-line near-1">まだ見えない朝へ向かう</div>
+              <div class="lyric-line near-2">We follow the fading lights</div>
+              <div class="lyric-line near-3">Until the skyline turns to blue</div>
+            </div>
+          </div>
+          <div class="fab-host fab-host--br"><div class="fab-btn active">✦</div></div>
+        </section>
+      </div>
+    </div>
+    <div class="controls-bar">
+      <div class="controls-group">
+        <div class="control-btn control-main"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z"/></svg></div>
+        <div class="control-btn control-play"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z"/></svg></div>
+        <div class="control-btn control-main"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/></svg></div>
+      </div>
+      <div class="progress-section"><span class="time-display">2:18</span><div class="progress-track"><div class="progress-fill"></div></div><span class="time-display time-remaining">-1:48</span></div>
+      <div class="volume-section"><div class="volume-icon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z"/></svg></div><div class="volume-track"><div class="volume-fill"></div></div></div>
+      <div class="right-controls"><div class="tab-btn active">Lyrics</div><div class="tab-btn">≡<span class="tab-badge">12</span></div><div class="control-btn control-secondary control-mode">↻</div></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/apps/com.myriad.music-player/preview.ja-JP.html
+++ b/apps/com.myriad.music-player/preview.ja-JP.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html class="mp-side-lyrics mp-has-lyrics player-playing fx-compositing">
+<body>
+  <div id="tapp-background">
+    <div class="bg-artwork"></div>
+    <div class="bg-overlay"></div>
+    <div class="rhythm-layer" aria-hidden="true"><div class="rhythm-ripple"></div><div class="rhythm-ripple"></div><div class="rhythm-ripple"></div></div>
+  </div>
+  <div id="tapp-content">
+    <div class="content-area">
+      <div class="player-left">
+        <div class="player-hero">
+          <div class="artwork-container">
+            <div class="artwork-aurora"><span class="aurora-blob aurora-bass"></span><span class="aurora-blob aurora-mid"></span><span class="aurora-blob aurora-high"></span></div>
+            <div class="artwork-wrapper"><div class="preview-album-cover"><span>夜間飛行</span><small>NIGHT SIGNALS</small><i></i></div></div>
+          </div>
+          <div class="track-info">
+            <div class="track-title-row"><h1 class="track-title"><span class="marquee-inner">夜間飛行</span></h1></div>
+            <p class="track-artist"><span class="marquee-inner">Lumen · City Lights</span></p>
+          </div>
+        </div>
+      </div>
+      <div class="player-right side-open">
+        <section class="panel panel-lyrics active">
+          <div class="lyrics-scroll">
+            <div class="lyrics-inner preview-lyrics">
+              <div class="lyric-line passed">灯りが滲む窓の向こう</div>
+              <div class="lyric-line passed">静かな街を越えて</div>
+              <div class="lyric-line active">夜の風に名前を預けて</div>
+              <div class="lyric-line near-1">まだ見えない朝へ向かう</div>
+              <div class="lyric-line near-2">We follow the fading lights</div>
+              <div class="lyric-line near-3">Until the skyline turns to blue</div>
+            </div>
+          </div>
+          <div class="fab-host fab-host--br"><div class="fab-btn active">✦</div></div>
+        </section>
+      </div>
+    </div>
+    <div class="controls-bar">
+      <div class="controls-group">
+        <div class="control-btn control-main"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z"/></svg></div>
+        <div class="control-btn control-play"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 4h4v16H6V4zm8 0h4v16h-4V4z"/></svg></div>
+        <div class="control-btn control-main"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/></svg></div>
+      </div>
+      <div class="progress-section"><span class="time-display">2:18</span><div class="progress-track"><div class="progress-fill"></div></div><span class="time-display time-remaining">-1:48</span></div>
+      <div class="volume-section"><div class="volume-icon"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z"/></svg></div><div class="volume-track"><div class="volume-fill"></div></div></div>
+      <div class="right-controls"><div class="tab-btn active">歌詞</div><div class="tab-btn">≡<span class="tab-badge">12</span></div><div class="control-btn control-secondary control-mode">↻</div></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/sync-index.mjs
+++ b/scripts/sync-index.mjs
@@ -3,7 +3,7 @@
 //
 // Manifest is the authority for install-critical fields (id/name/version/
 // description/locales/author/category/permissions/icons/theme/download map).
-// Store-only merchandising (long_description, tags, featured, preview, ...) is
+// Store-only merchandising (long_description, tags, featured, preview, locales, ...) is
 // loaded from apps/<id>/catalog.json when present, else preserved from the
 // previous index entry, or bootstrapped for new apps.
 //
@@ -378,6 +378,50 @@ function loadManifest(appId) {
  * Optional per-app merchandising file. Contributors edit this instead of index.json.
  * Paths in preview may be app-relative (preview.html) or repo-relative (apps/id/...).
  */
+function normalizeCatalogPreview(appId, preview) {
+  if (!preview || typeof preview !== 'object' || Array.isArray(preview)) return preview
+  const fix = (path) => {
+    if (typeof path !== 'string') return path
+    if (path.startsWith('apps/')) return path
+    return packageRel(appId, path.replace(/^\.\//, ''))
+  }
+  const next = { ...preview }
+  if (next.html) next.html = fix(next.html)
+  if (Array.isArray(next.styles)) next.styles = next.styles.map(fix)
+  return next
+}
+
+function mergeStoreLocales(manifestLocales, catalogLocales, appId, manifest) {
+  const fromManifest = cleanLocales(manifestLocales) || {}
+  const catalog =
+    catalogLocales && typeof catalogLocales === 'object' && !Array.isArray(catalogLocales)
+      ? catalogLocales
+      : {}
+  const tags = [...Object.keys(fromManifest)]
+  for (const tag of Object.keys(catalog)) {
+    if (!tags.includes(tag)) tags.push(tag)
+  }
+  const out = {}
+  for (const tag of tags) {
+    const entry = { ...(fromManifest[tag] || {}) }
+    const extra = catalog[tag]
+    if (extra && typeof extra === 'object' && !Array.isArray(extra)) {
+      if (typeof extra.long_description === 'string' && extra.long_description.trim()) {
+        entry.long_description = extra.long_description
+      }
+      if (extra.preview) {
+        entry.preview = sanitizePreview(
+          appId,
+          normalizeCatalogPreview(appId, extra.preview),
+          manifest,
+        )
+      }
+    }
+    if (Object.keys(entry).length) out[tag] = entry
+  }
+  return Object.keys(out).length ? out : undefined
+}
+
 function loadCatalogMeta(appId) {
   const path = join(appsDir, appId, 'catalog.json')
   if (!existsSync(path)) return null
@@ -390,17 +434,17 @@ function loadCatalogMeta(appId) {
   delete meta.securityReview
   delete meta.security_review
 
-  if (meta.preview && typeof meta.preview === 'object') {
-    const fix = (p) => {
-      if (typeof p !== 'string') return p
-      if (p.startsWith('apps/')) return p
-      return packageRel(appId, p.replace(/^\.\//, ''))
+  if (meta.preview) meta.preview = normalizeCatalogPreview(appId, meta.preview)
+  if (meta.locales && typeof meta.locales === 'object' && !Array.isArray(meta.locales)) {
+    const locales = {}
+    for (const [tag, entry] of Object.entries(meta.locales)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+      locales[tag] = { ...entry }
+      if (locales[tag].preview) {
+        locales[tag].preview = normalizeCatalogPreview(appId, locales[tag].preview)
+      }
     }
-    meta.preview = { ...meta.preview }
-    if (meta.preview.html) meta.preview.html = fix(meta.preview.html)
-    if (Array.isArray(meta.preview.styles)) {
-      meta.preview.styles = meta.preview.styles.map(fix)
-    }
+    meta.locales = locales
   }
   return meta
 }
@@ -467,10 +511,11 @@ function buildAlignedEntry(appId, previous = null) {
     description: manifest.description || '',
   }
 
-  const locales = cleanLocales(manifest.locales)
-  if (locales) entry.locales = locales
-
   applyMerchandising(entry, previous, catalog, appId, manifest, now)
+
+  const locales = mergeStoreLocales(manifest.locales, catalog?.locales, appId, manifest)
+  if (locales) entry.locales = locales
+  else delete entry.locales
 
   entry.author = cleanAuthor(manifest.author)
   if (manifest.license && !entry.license) entry.license = manifest.license

--- a/scripts/validate-app.mjs
+++ b/scripts/validate-app.mjs
@@ -64,6 +64,7 @@ const CATALOG_ALLOWED_KEYS = new Set([
   'icon_shell',
   'screenshots',
   'preview',
+  'locales',
   'featured',
   'verified',
   'license',
@@ -72,6 +73,11 @@ const CATALOG_ALLOWED_KEYS = new Set([
   'securityReview',
   'security_review',
 ])
+
+const CATALOG_LOCALE_KEYS = new Set(['long_description', 'preview'])
+const LOCALE_TAG = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{1,8})*$/
+const MAX_CATALOG_LOCALES = 32
+const MAX_LONG_DESCRIPTION = 20000
 
 const JUNK_NAME = /^(?:\.DS_Store|Thumbs\.db|\.env.*)$/i
 const MAX_PACKAGE_BYTES = 50 * 1024 * 1024 // 50 MiB hard
@@ -126,6 +132,44 @@ function isOfficial(appId) {
   return appId === 'com.myriad' || appId.startsWith('com.myriad.')
 }
 
+function validateCatalogLocales(appId, locales, errors) {
+  if (!locales || typeof locales !== 'object' || Array.isArray(locales)) {
+    errors.push(`${appId}: catalog.locales must be an object`)
+    return
+  }
+  const tags = Object.keys(locales)
+  if (tags.length > MAX_CATALOG_LOCALES) {
+    errors.push(`${appId}: catalog.locales accepts at most ${MAX_CATALOG_LOCALES} languages`)
+  }
+  for (const [tag, entry] of Object.entries(locales)) {
+    if (!LOCALE_TAG.test(tag)) {
+      errors.push(`${appId}: catalog.locales key "${tag}" must be a BCP-47 tag (e.g. zh-CN)`)
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push(`${appId}: catalog.locales.${tag} must be an object`)
+      continue
+    }
+    for (const key of Object.keys(entry)) {
+      if (!CATALOG_LOCALE_KEYS.has(key)) {
+        errors.push(
+          `${appId}: catalog.locales.${tag} unknown key "${key}" (name/description belong in manifest.locales)`,
+        )
+      }
+    }
+    if (entry.long_description !== undefined && typeof entry.long_description !== 'string') {
+      errors.push(`${appId}: catalog.locales.${tag}.long_description must be a string`)
+    }
+    if (entry.long_description && entry.long_description.length > MAX_LONG_DESCRIPTION) {
+      errors.push(
+        `${appId}: catalog.locales.${tag}.long_description too long (max ${MAX_LONG_DESCRIPTION})`,
+      )
+    }
+    if (entry.preview != null && (typeof entry.preview !== 'object' || Array.isArray(entry.preview))) {
+      errors.push(`${appId}: catalog.locales.${tag}.preview must be an object`)
+    }
+  }
+}
+
 function validateCatalogJson(appId, catalog, errors, warnings) {
   if (!catalog || typeof catalog !== 'object' || Array.isArray(catalog)) {
     errors.push(`${appId}: catalog.json must be a JSON object`)
@@ -146,8 +190,11 @@ function validateCatalogJson(appId, catalog, errors, warnings) {
   if (catalog.long_description !== undefined && typeof catalog.long_description !== 'string') {
     errors.push(`${appId}: catalog.long_description must be a string`)
   }
-  if (catalog.long_description && catalog.long_description.length > 20000) {
-    errors.push(`${appId}: catalog.long_description too long (max 20000)`)
+  if (catalog.long_description && catalog.long_description.length > MAX_LONG_DESCRIPTION) {
+    errors.push(`${appId}: catalog.long_description too long (max ${MAX_LONG_DESCRIPTION})`)
+  }
+  if (catalog.locales !== undefined) {
+    validateCatalogLocales(appId, catalog.locales, errors)
   }
   for (const flag of ['featured', 'verified', 'icon_shell', 'securityReview', 'security_review']) {
     if (catalog[flag] !== undefined && typeof catalog[flag] !== 'boolean') {

--- a/scripts/validate-previews.mjs
+++ b/scripts/validate-previews.mjs
@@ -104,21 +104,46 @@ function bootstrapFromDisk(appId) {
   }
 }
 
+function fixPreviewPaths(appId, preview) {
+  if (!preview || typeof preview !== 'object') return preview
+  const next = { ...preview }
+  const fix = (p) => {
+    if (typeof p !== 'string') return p
+    if (p.startsWith('apps/')) return p
+    return packageRel(appId, p.replace(/^\.\//, ''))
+  }
+  if (next.html) next.html = fix(next.html)
+  if (Array.isArray(next.styles)) next.styles = next.styles.map(fix)
+  return next
+}
+
 function loadCatalogPreview(appId) {
   const catalogPath = join(root, 'apps', appId, 'catalog.json')
   if (!existsSync(catalogPath)) return null
   try {
     const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'))
     if (!catalog.preview) return null
-    const preview = { ...catalog.preview }
-    const fix = (p) => {
-      if (typeof p !== 'string') return p
-      if (p.startsWith('apps/')) return p
-      return packageRel(appId, p.replace(/^\.\//, ''))
+    return fixPreviewPaths(appId, catalog.preview)
+  } catch {
+    return null
+  }
+}
+
+function collectLocalePreviews(appId, locales, sourcePrefix, targets) {
+  if (!locales || typeof locales !== 'object' || Array.isArray(locales)) return
+  for (const [tag, entry] of Object.entries(locales)) {
+    if (entry?.preview) {
+      pushTarget(targets, appId, fixPreviewPaths(appId, entry.preview), `${sourcePrefix} locales.${tag}`)
     }
-    if (preview.html) preview.html = fix(preview.html)
-    if (Array.isArray(preview.styles)) preview.styles = preview.styles.map(fix)
-    return preview
+  }
+}
+
+function loadCatalogLocales(appId) {
+  const catalogPath = join(root, 'apps', appId, 'catalog.json')
+  if (!existsSync(catalogPath)) return null
+  try {
+    const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'))
+    return catalog.locales ?? null
   } catch {
     return null
   }
@@ -138,12 +163,15 @@ async function main() {
   if (args.app) {
     const entry = byId.get(args.app)
     if (entry?.preview) pushTarget(targets, args.app, entry.preview, 'index')
+    collectLocalePreviews(args.app, entry?.locales, 'index', targets)
     pushTarget(targets, args.app, loadCatalogPreview(args.app), 'catalog.json')
+    collectLocalePreviews(args.app, loadCatalogLocales(args.app), 'catalog.json', targets)
     const disk = bootstrapFromDisk(args.app)
     if (disk) pushTarget(targets, args.app, disk, 'disk')
   } else {
     for (const app of index.apps || []) {
       if (app.preview) pushTarget(targets, app.id, app.preview, 'index')
+      collectLocalePreviews(app.id, app.locales, 'index', targets)
     }
     if (args.disk) {
       for (const name of readdirSync(join(root, 'apps'))) {
@@ -155,6 +183,7 @@ async function main() {
         }
         if (byId.get(name)?.preview) continue
         const fromCatalog = loadCatalogPreview(name)
+        collectLocalePreviews(name, loadCatalogLocales(name), 'catalog.json', targets)
         if (fromCatalog) {
           pushTarget(targets, name, fromCatalog, 'catalog.json')
           continue


### PR DESCRIPTION
## Why

Official merchandising locales for **com.myriad.music-player**. Split from #81 because store CI allows at most one `apps/<id>` per PR and forbids editing `index.json`.

## This PR

- `catalog.json` locale overlays (en-US / ja-JP)
- `preview.en-US.html` / `preview.ja-JP.html`
- Manifest version bump

Does **not** touch `index.json` — Catalog Sync regenerates it after merge.

Depends on host locale picking from Myriad #324 (`pickLocaleEntry`).