### PR TITLE
feat: Quick Notes store locales (en-US / ja-JP)

### DIFF
--- a/apps/com.myriad.quick-notes/catalog.json
+++ b/apps/com.myriad.quick-notes/catalog.json
@@ -1,0 +1,47 @@
+{
+  "long_description": "在页面中编写、搜索和整理便签，并通过 4×2 / 4×4 小组件在主页速览或速记。支持置顶、颜色、排序、导出导入与可选时间戳；便签保存在当前用户的私有存储中。跟随宿主明暗主题，内置中英日三语。",
+  "tags": ["笔记", "便签", "搜索", "小组件", "多语言"],
+  "featured": true,
+  "verified": true,
+  "license": "MIT",
+  "homepage": "https://github.com/Myriad-You/tapp-store/tree/main/apps/com.myriad.quick-notes",
+  "repository": "https://github.com/Myriad-You/tapp-store",
+  "preview": {
+    "version": 1,
+    "type": "snapshot",
+    "html": "preview.html",
+    "styles": ["page.css", "preview.css"],
+    "viewport": { "width": 1440, "height": 900 },
+    "fit": "cover",
+    "focus": { "x": 0.5, "y": 0.5 },
+    "theme": "dark"
+  },
+  "locales": {
+    "en-US": {
+      "long_description": "Write, search, and organize notes on the page, and use the 4×2 / 4×4 home widgets to glance or jot them down. Supports pinning, colors, sort, export/import, and optional timestamps; notes stay in the current user's private storage. Follows the host light/dark theme and includes Chinese, English, and Japanese.",
+      "preview": {
+        "version": 1,
+        "type": "snapshot",
+        "html": "preview.en-US.html",
+        "styles": ["page.css", "preview.css"],
+        "viewport": { "width": 1440, "height": 900 },
+        "fit": "cover",
+        "focus": { "x": 0.5, "y": 0.5 },
+        "theme": "dark"
+      }
+    },
+    "ja-JP": {
+      "long_description": "ページでメモを作成・検索・整理し、4×2 / 4×4 ホームウィジェットで一覧または素早くメモできます。固定、色、並び替え、エクスポート/インポート、任意のタイムスタンプに対応し、メモは現在のユーザーのプライベートストレージに保存されます。ホストのライト/ダークテーマに追従し、中国語・英語・日本語を内蔵しています。",
+      "preview": {
+        "version": 1,
+        "type": "snapshot",
+        "html": "preview.ja-JP.html",
+        "styles": ["page.css", "preview.css"],
+        "viewport": { "width": 1440, "height": 900 },
+        "fit": "cover",
+        "focus": { "x": 0.5, "y": 0.5 },
+        "theme": "dark"
+      }
+    }
+  }
+}

--- a/apps/com.myriad.quick-notes/manifest.json
+++ b/apps/com.myriad.quick-notes/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.quick-notes",
   "name": "便携便签",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minSystemVersion": "0.2.1",
   "description": "快速记录想法，支持搜索与主页小组件",
   "locales": {

--- a/apps/com.myriad.quick-notes/preview.en-US.html
+++ b/apps/com.myriad.quick-notes/preview.en-US.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html class="dark">
+<body>
+  <div id="tapp-background">
+    <div class="page-bg-base"></div>
+    <div class="page-bg-glow page-bg-glow-1"></div>
+    <div class="page-bg-glow page-bg-glow-2"></div>
+  </div>
+
+  <div id="tapp-content">
+    <div class="page-content">
+      <header class="status-header">
+        <div id="status-pill" class="status-pill">
+          <div class="status-avatar" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8 2v3M16 2v3M3 9h18"/>
+              <path d="M21 8.5V17c0 3-1.5 5-5 5H8c-3.5 0-5-2-5-5V8.5c0-3 1.5-5 5-5h8c3.5 0 5 2 5 5z"/>
+              <path d="M8 14h4M8 18h8"/>
+            </svg>
+          </div>
+          <div class="status-info">
+            <span class="status-title">Quick Notes</span>
+            <span class="status-subtitle">5 notes · Autosave</span>
+          </div>
+          <div class="status-actions">
+            <button class="status-action-btn" type="button" aria-label="Search">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+            </button>
+            <button class="status-action-btn" type="button" aria-label="More">
+              <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="19" cy="12" r="1.8"/></svg>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div class="notes-area">
+        <div class="notes-grid">
+          <article class="sticky-note color-0 pinned no-animate">
+            <span class="sticky-pin-mark" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M14 2l8 8-3 1-4 4 1 4-2 2-5-5-5 5-1-1 5-5-5-5 2-2 4 1 4-4 1-3z"/></svg>
+            </span>
+            <div class="sticky-content">
+              <div class="sticky-text">Pre-release checklist: store preview, mobile layout, release notes, and permission copy.</div>
+              <div class="sticky-footer"><span class="sticky-time">Today 09:24</span><span class="sticky-long-hint">Pin</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-2 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">The interface should stay quiet so the content is the strongest layer.</div>
+              <div class="sticky-footer"><span class="sticky-time">Today 08:40</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-1 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">App Store notes: the hero sets the mood, the title identifies the app, and details live on the detail page.</div>
+              <div class="sticky-footer"><span class="sticky-time">Yesterday 21:16</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-3 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">Evening plan<br>Run 30 minutes<br>Write the weekly project recap<br>Read two chapters</div>
+              <div class="sticky-footer"><span class="sticky-time">Yesterday 18:30</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-4 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">A good tool does not steal attention; it just makes complex information clear.</div>
+              <div class="sticky-footer"><span class="sticky-time">Mon 14:08</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-5 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">Weekend shopping: coffee beans, a notebook, and plant fertilizer.</div>
+              <div class="sticky-footer"><span class="sticky-time">Sun 11:32</span></div>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <div class="float-input-wrap">
+        <div class="input-card">
+          <div class="input-area">
+            <textarea class="page-input" rows="1" placeholder="Write a note..."></textarea>
+            <div class="input-footer">
+              <div class="composer-tools"><button class="color-toggle-btn" type="button"><span class="color-toggle-swatch color-0"></span></button></div>
+              <span class="char-count">0 / 500</span>
+            </div>
+          </div>
+          <button class="page-send-btn" type="button" aria-label="Add">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/apps/com.myriad.quick-notes/preview.ja-JP.html
+++ b/apps/com.myriad.quick-notes/preview.ja-JP.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html class="dark">
+<body>
+  <div id="tapp-background">
+    <div class="page-bg-base"></div>
+    <div class="page-bg-glow page-bg-glow-1"></div>
+    <div class="page-bg-glow page-bg-glow-2"></div>
+  </div>
+
+  <div id="tapp-content">
+    <div class="page-content">
+      <header class="status-header">
+        <div id="status-pill" class="status-pill">
+          <div class="status-avatar" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8 2v3M16 2v3M3 9h18"/>
+              <path d="M21 8.5V17c0 3-1.5 5-5 5H8c-3.5 0-5-2-5-5V8.5c0-3 1.5-5 5-5h8c3.5 0 5 2 5 5z"/>
+              <path d="M8 14h4M8 18h8"/>
+            </svg>
+          </div>
+          <div class="status-info">
+            <span class="status-title">クイックノート</span>
+            <span class="status-subtitle">5件のメモ · 自動保存</span>
+          </div>
+          <div class="status-actions">
+            <button class="status-action-btn" type="button" aria-label="検索">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+            </button>
+            <button class="status-action-btn" type="button" aria-label="その他">
+              <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.8"/><circle cx="12" cy="12" r="1.8"/><circle cx="19" cy="12" r="1.8"/></svg>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div class="notes-area">
+        <div class="notes-grid">
+          <article class="sticky-note color-0 pinned no-animate">
+            <span class="sticky-pin-mark" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M14 2l8 8-3 1-4 4 1 4-2 2-5-5-5 5-1-1 5-5-5-5 2-2 4 1 4-4 1-3z"/></svg>
+            </span>
+            <div class="sticky-content">
+              <div class="sticky-text">公開前チェック：ストアプレビュー、モバイルレイアウト、更新説明と権限の記述。</div>
+              <div class="sticky-footer"><span class="sticky-time">今日 09:24</span><span class="sticky-long-hint">固定</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-2 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">インターフェースは静かであるべきで、内容がいちばん目立つ階層になる。</div>
+              <div class="sticky-footer"><span class="sticky-time">今日 08:40</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-1 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">App Store の観察：大画像は雰囲気、タイトルは識別、詳細は詳細エリアに集約。</div>
+              <div class="sticky-footer"><span class="sticky-time">昨日 21:16</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-3 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">夜の予定<br>ランニング 30 分<br>プロジェクト週報を整理<br>2章読む</div>
+              <div class="sticky-footer"><span class="sticky-time">昨日 18:30</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-4 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">よい道具は注意を奪わない。複雑な情報を整理して見せるだけだ。</div>
+              <div class="sticky-footer"><span class="sticky-time">月曜 14:08</span></div>
+            </div>
+          </article>
+          <article class="sticky-note color-5 no-animate">
+            <div class="sticky-content">
+              <div class="sticky-text">週末の買い物：コーヒー豆、ノート、観葉植物の栄養剤。</div>
+              <div class="sticky-footer"><span class="sticky-time">日曜 11:32</span></div>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <div class="float-input-wrap">
+        <div class="input-card">
+          <div class="input-area">
+            <textarea class="page-input" rows="1" placeholder="メモを書く..."></textarea>
+            <div class="input-footer">
+              <div class="composer-tools"><button class="color-toggle-btn" type="button"><span class="color-toggle-swatch color-0"></span></button></div>
+              <span class="char-count">0 / 500</span>
+            </div>
+          </div>
+          <button class="page-send-btn" type="button" aria-label="追加">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/sync-index.mjs
+++ b/scripts/sync-index.mjs
@@ -3,7 +3,7 @@
 //
 // Manifest is the authority for install-critical fields (id/name/version/
 // description/locales/author/category/permissions/icons/theme/download map).
-// Store-only merchandising (long_description, tags, featured, preview, ...) is
+// Store-only merchandising (long_description, tags, featured, preview, locales, ...) is
 // loaded from apps/<id>/catalog.json when present, else preserved from the
 // previous index entry, or bootstrapped for new apps.
 //
@@ -378,6 +378,50 @@ function loadManifest(appId) {
  * Optional per-app merchandising file. Contributors edit this instead of index.json.
  * Paths in preview may be app-relative (preview.html) or repo-relative (apps/id/...).
  */
+function normalizeCatalogPreview(appId, preview) {
+  if (!preview || typeof preview !== 'object' || Array.isArray(preview)) return preview
+  const fix = (path) => {
+    if (typeof path !== 'string') return path
+    if (path.startsWith('apps/')) return path
+    return packageRel(appId, path.replace(/^\.\//, ''))
+  }
+  const next = { ...preview }
+  if (next.html) next.html = fix(next.html)
+  if (Array.isArray(next.styles)) next.styles = next.styles.map(fix)
+  return next
+}
+
+function mergeStoreLocales(manifestLocales, catalogLocales, appId, manifest) {
+  const fromManifest = cleanLocales(manifestLocales) || {}
+  const catalog =
+    catalogLocales && typeof catalogLocales === 'object' && !Array.isArray(catalogLocales)
+      ? catalogLocales
+      : {}
+  const tags = [...Object.keys(fromManifest)]
+  for (const tag of Object.keys(catalog)) {
+    if (!tags.includes(tag)) tags.push(tag)
+  }
+  const out = {}
+  for (const tag of tags) {
+    const entry = { ...(fromManifest[tag] || {}) }
+    const extra = catalog[tag]
+    if (extra && typeof extra === 'object' && !Array.isArray(extra)) {
+      if (typeof extra.long_description === 'string' && extra.long_description.trim()) {
+        entry.long_description = extra.long_description
+      }
+      if (extra.preview) {
+        entry.preview = sanitizePreview(
+          appId,
+          normalizeCatalogPreview(appId, extra.preview),
+          manifest,
+        )
+      }
+    }
+    if (Object.keys(entry).length) out[tag] = entry
+  }
+  return Object.keys(out).length ? out : undefined
+}
+
 function loadCatalogMeta(appId) {
   const path = join(appsDir, appId, 'catalog.json')
   if (!existsSync(path)) return null
@@ -390,17 +434,17 @@ function loadCatalogMeta(appId) {
   delete meta.securityReview
   delete meta.security_review
 
-  if (meta.preview && typeof meta.preview === 'object') {
-    const fix = (p) => {
-      if (typeof p !== 'string') return p
-      if (p.startsWith('apps/')) return p
-      return packageRel(appId, p.replace(/^\.\//, ''))
+  if (meta.preview) meta.preview = normalizeCatalogPreview(appId, meta.preview)
+  if (meta.locales && typeof meta.locales === 'object' && !Array.isArray(meta.locales)) {
+    const locales = {}
+    for (const [tag, entry] of Object.entries(meta.locales)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+      locales[tag] = { ...entry }
+      if (locales[tag].preview) {
+        locales[tag].preview = normalizeCatalogPreview(appId, locales[tag].preview)
+      }
     }
-    meta.preview = { ...meta.preview }
-    if (meta.preview.html) meta.preview.html = fix(meta.preview.html)
-    if (Array.isArray(meta.preview.styles)) {
-      meta.preview.styles = meta.preview.styles.map(fix)
-    }
+    meta.locales = locales
   }
   return meta
 }
@@ -467,10 +511,11 @@ function buildAlignedEntry(appId, previous = null) {
     description: manifest.description || '',
   }
 
-  const locales = cleanLocales(manifest.locales)
-  if (locales) entry.locales = locales
-
   applyMerchandising(entry, previous, catalog, appId, manifest, now)
+
+  const locales = mergeStoreLocales(manifest.locales, catalog?.locales, appId, manifest)
+  if (locales) entry.locales = locales
+  else delete entry.locales
 
   entry.author = cleanAuthor(manifest.author)
   if (manifest.license && !entry.license) entry.license = manifest.license

--- a/scripts/validate-app.mjs
+++ b/scripts/validate-app.mjs
@@ -64,6 +64,7 @@ const CATALOG_ALLOWED_KEYS = new Set([
   'icon_shell',
   'screenshots',
   'preview',
+  'locales',
   'featured',
   'verified',
   'license',
@@ -72,6 +73,11 @@ const CATALOG_ALLOWED_KEYS = new Set([
   'securityReview',
   'security_review',
 ])
+
+const CATALOG_LOCALE_KEYS = new Set(['long_description', 'preview'])
+const LOCALE_TAG = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{1,8})*$/
+const MAX_CATALOG_LOCALES = 32
+const MAX_LONG_DESCRIPTION = 20000
 
 const JUNK_NAME = /^(?:\.DS_Store|Thumbs\.db|\.env.*)$/i
 const MAX_PACKAGE_BYTES = 50 * 1024 * 1024 // 50 MiB hard
@@ -126,6 +132,44 @@ function isOfficial(appId) {
   return appId === 'com.myriad' || appId.startsWith('com.myriad.')
 }
 
+function validateCatalogLocales(appId, locales, errors) {
+  if (!locales || typeof locales !== 'object' || Array.isArray(locales)) {
+    errors.push(`${appId}: catalog.locales must be an object`)
+    return
+  }
+  const tags = Object.keys(locales)
+  if (tags.length > MAX_CATALOG_LOCALES) {
+    errors.push(`${appId}: catalog.locales accepts at most ${MAX_CATALOG_LOCALES} languages`)
+  }
+  for (const [tag, entry] of Object.entries(locales)) {
+    if (!LOCALE_TAG.test(tag)) {
+      errors.push(`${appId}: catalog.locales key "${tag}" must be a BCP-47 tag (e.g. zh-CN)`)
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push(`${appId}: catalog.locales.${tag} must be an object`)
+      continue
+    }
+    for (const key of Object.keys(entry)) {
+      if (!CATALOG_LOCALE_KEYS.has(key)) {
+        errors.push(
+          `${appId}: catalog.locales.${tag} unknown key "${key}" (name/description belong in manifest.locales)`,
+        )
+      }
+    }
+    if (entry.long_description !== undefined && typeof entry.long_description !== 'string') {
+      errors.push(`${appId}: catalog.locales.${tag}.long_description must be a string`)
+    }
+    if (entry.long_description && entry.long_description.length > MAX_LONG_DESCRIPTION) {
+      errors.push(
+        `${appId}: catalog.locales.${tag}.long_description too long (max ${MAX_LONG_DESCRIPTION})`,
+      )
+    }
+    if (entry.preview != null && (typeof entry.preview !== 'object' || Array.isArray(entry.preview))) {
+      errors.push(`${appId}: catalog.locales.${tag}.preview must be an object`)
+    }
+  }
+}
+
 function validateCatalogJson(appId, catalog, errors, warnings) {
   if (!catalog || typeof catalog !== 'object' || Array.isArray(catalog)) {
     errors.push(`${appId}: catalog.json must be a JSON object`)
@@ -146,8 +190,11 @@ function validateCatalogJson(appId, catalog, errors, warnings) {
   if (catalog.long_description !== undefined && typeof catalog.long_description !== 'string') {
     errors.push(`${appId}: catalog.long_description must be a string`)
   }
-  if (catalog.long_description && catalog.long_description.length > 20000) {
-    errors.push(`${appId}: catalog.long_description too long (max 20000)`)
+  if (catalog.long_description && catalog.long_description.length > MAX_LONG_DESCRIPTION) {
+    errors.push(`${appId}: catalog.long_description too long (max ${MAX_LONG_DESCRIPTION})`)
+  }
+  if (catalog.locales !== undefined) {
+    validateCatalogLocales(appId, catalog.locales, errors)
   }
   for (const flag of ['featured', 'verified', 'icon_shell', 'securityReview', 'security_review']) {
     if (catalog[flag] !== undefined && typeof catalog[flag] !== 'boolean') {

--- a/scripts/validate-previews.mjs
+++ b/scripts/validate-previews.mjs
@@ -104,21 +104,46 @@ function bootstrapFromDisk(appId) {
   }
 }
 
+function fixPreviewPaths(appId, preview) {
+  if (!preview || typeof preview !== 'object') return preview
+  const next = { ...preview }
+  const fix = (p) => {
+    if (typeof p !== 'string') return p
+    if (p.startsWith('apps/')) return p
+    return packageRel(appId, p.replace(/^\.\//, ''))
+  }
+  if (next.html) next.html = fix(next.html)
+  if (Array.isArray(next.styles)) next.styles = next.styles.map(fix)
+  return next
+}
+
 function loadCatalogPreview(appId) {
   const catalogPath = join(root, 'apps', appId, 'catalog.json')
   if (!existsSync(catalogPath)) return null
   try {
     const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'))
     if (!catalog.preview) return null
-    const preview = { ...catalog.preview }
-    const fix = (p) => {
-      if (typeof p !== 'string') return p
-      if (p.startsWith('apps/')) return p
-      return packageRel(appId, p.replace(/^\.\//, ''))
+    return fixPreviewPaths(appId, catalog.preview)
+  } catch {
+    return null
+  }
+}
+
+function collectLocalePreviews(appId, locales, sourcePrefix, targets) {
+  if (!locales || typeof locales !== 'object' || Array.isArray(locales)) return
+  for (const [tag, entry] of Object.entries(locales)) {
+    if (entry?.preview) {
+      pushTarget(targets, appId, fixPreviewPaths(appId, entry.preview), `${sourcePrefix} locales.${tag}`)
     }
-    if (preview.html) preview.html = fix(preview.html)
-    if (Array.isArray(preview.styles)) preview.styles = preview.styles.map(fix)
-    return preview
+  }
+}
+
+function loadCatalogLocales(appId) {
+  const catalogPath = join(root, 'apps', appId, 'catalog.json')
+  if (!existsSync(catalogPath)) return null
+  try {
+    const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'))
+    return catalog.locales ?? null
   } catch {
     return null
   }
@@ -138,12 +163,15 @@ async function main() {
   if (args.app) {
     const entry = byId.get(args.app)
     if (entry?.preview) pushTarget(targets, args.app, entry.preview, 'index')
+    collectLocalePreviews(args.app, entry?.locales, 'index', targets)
     pushTarget(targets, args.app, loadCatalogPreview(args.app), 'catalog.json')
+    collectLocalePreviews(args.app, loadCatalogLocales(args.app), 'catalog.json', targets)
     const disk = bootstrapFromDisk(args.app)
     if (disk) pushTarget(targets, args.app, disk, 'disk')
   } else {
     for (const app of index.apps || []) {
       if (app.preview) pushTarget(targets, app.id, app.preview, 'index')
+      collectLocalePreviews(app.id, app.locales, 'index', targets)
     }
     if (args.disk) {
       for (const name of readdirSync(join(root, 'apps'))) {
@@ -155,6 +183,7 @@ async function main() {
         }
         if (byId.get(name)?.preview) continue
         const fromCatalog = loadCatalogPreview(name)
+        collectLocalePreviews(name, loadCatalogLocales(name), 'catalog.json', targets)
         if (fromCatalog) {
           pushTarget(targets, name, fromCatalog, 'catalog.json')
           continue


### PR DESCRIPTION
## Why

Official merchandising locales for **com.myriad.quick-notes**. Split from #81 because store CI allows at most one `apps/<id>` per PR and forbids editing `index.json`.

## This PR

- `catalog.json` locale overlays (en-US / ja-JP)
- `preview.en-US.html` / `preview.ja-JP.html`
- Manifest version bump

Does **not** touch `index.json` — Catalog Sync regenerates it after merge.

Depends on host locale picking from Myriad #324 (`pickLocaleEntry`).