### PR TITLE
feat: accept catalog.locales in store validators

### DIFF
--- a/scripts/sync-index.mjs
+++ b/scripts/sync-index.mjs
@@ -3,7 +3,7 @@
 //
 // Manifest is the authority for install-critical fields (id/name/version/
 // description/locales/author/category/permissions/icons/theme/download map).
-// Store-only merchandising (long_description, tags, featured, preview, ...) is
+// Store-only merchandising (long_description, tags, featured, preview, locales, ...) is
 // loaded from apps/<id>/catalog.json when present, else preserved from the
 // previous index entry, or bootstrapped for new apps.
 //
@@ -378,6 +378,50 @@ function loadManifest(appId) {
  * Optional per-app merchandising file. Contributors edit this instead of index.json.
  * Paths in preview may be app-relative (preview.html) or repo-relative (apps/id/...).
  */
+function normalizeCatalogPreview(appId, preview) {
+  if (!preview || typeof preview !== 'object' || Array.isArray(preview)) return preview
+  const fix = (path) => {
+    if (typeof path !== 'string') return path
+    if (path.startsWith('apps/')) return path
+    return packageRel(appId, path.replace(/^\.\//, ''))
+  }
+  const next = { ...preview }
+  if (next.html) next.html = fix(next.html)
+  if (Array.isArray(next.styles)) next.styles = next.styles.map(fix)
+  return next
+}
+
+function mergeStoreLocales(manifestLocales, catalogLocales, appId, manifest) {
+  const fromManifest = cleanLocales(manifestLocales) || {}
+  const catalog =
+    catalogLocales && typeof catalogLocales === 'object' && !Array.isArray(catalogLocales)
+      ? catalogLocales
+      : {}
+  const tags = [...Object.keys(fromManifest)]
+  for (const tag of Object.keys(catalog)) {
+    if (!tags.includes(tag)) tags.push(tag)
+  }
+  const out = {}
+  for (const tag of tags) {
+    const entry = { ...(fromManifest[tag] || {}) }
+    const extra = catalog[tag]
+    if (extra && typeof extra === 'object' && !Array.isArray(extra)) {
+      if (typeof extra.long_description === 'string' && extra.long_description.trim()) {
+        entry.long_description = extra.long_description
+      }
+      if (extra.preview) {
+        entry.preview = sanitizePreview(
+          appId,
+          normalizeCatalogPreview(appId, extra.preview),
+          manifest,
+        )
+      }
+    }
+    if (Object.keys(entry).length) out[tag] = entry
+  }
+  return Object.keys(out).length ? out : undefined
+}
+
 function loadCatalogMeta(appId) {
   const path = join(appsDir, appId, 'catalog.json')
   if (!existsSync(path)) return null
@@ -390,17 +434,17 @@ function loadCatalogMeta(appId) {
   delete meta.securityReview
   delete meta.security_review
 
-  if (meta.preview && typeof meta.preview === 'object') {
-    const fix = (p) => {
-      if (typeof p !== 'string') return p
-      if (p.startsWith('apps/')) return p
-      return packageRel(appId, p.replace(/^\.\//, ''))
+  if (meta.preview) meta.preview = normalizeCatalogPreview(appId, meta.preview)
+  if (meta.locales && typeof meta.locales === 'object' && !Array.isArray(meta.locales)) {
+    const locales = {}
+    for (const [tag, entry] of Object.entries(meta.locales)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+      locales[tag] = { ...entry }
+      if (locales[tag].preview) {
+        locales[tag].preview = normalizeCatalogPreview(appId, locales[tag].preview)
+      }
     }
-    meta.preview = { ...meta.preview }
-    if (meta.preview.html) meta.preview.html = fix(meta.preview.html)
-    if (Array.isArray(meta.preview.styles)) {
-      meta.preview.styles = meta.preview.styles.map(fix)
-    }
+    meta.locales = locales
   }
   return meta
 }
@@ -467,10 +511,11 @@ function buildAlignedEntry(appId, previous = null) {
     description: manifest.description || '',
   }
 
-  const locales = cleanLocales(manifest.locales)
-  if (locales) entry.locales = locales
-
   applyMerchandising(entry, previous, catalog, appId, manifest, now)
+
+  const locales = mergeStoreLocales(manifest.locales, catalog?.locales, appId, manifest)
+  if (locales) entry.locales = locales
+  else delete entry.locales
 
   entry.author = cleanAuthor(manifest.author)
   if (manifest.license && !entry.license) entry.license = manifest.license

--- a/scripts/validate-app.mjs
+++ b/scripts/validate-app.mjs
@@ -64,6 +64,7 @@ const CATALOG_ALLOWED_KEYS = new Set([
   'icon_shell',
   'screenshots',
   'preview',
+  'locales',
   'featured',
   'verified',
   'license',
@@ -72,6 +73,11 @@ const CATALOG_ALLOWED_KEYS = new Set([
   'securityReview',
   'security_review',
 ])
+
+const CATALOG_LOCALE_KEYS = new Set(['long_description', 'preview'])
+const LOCALE_TAG = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{1,8})*$/
+const MAX_CATALOG_LOCALES = 32
+const MAX_LONG_DESCRIPTION = 20000
 
 const JUNK_NAME = /^(?:\.DS_Store|Thumbs\.db|\.env.*)$/i
 const MAX_PACKAGE_BYTES = 50 * 1024 * 1024 // 50 MiB hard
@@ -126,6 +132,44 @@ function isOfficial(appId) {
   return appId === 'com.myriad' || appId.startsWith('com.myriad.')
 }
 
+function validateCatalogLocales(appId, locales, errors) {
+  if (!locales || typeof locales !== 'object' || Array.isArray(locales)) {
+    errors.push(`${appId}: catalog.locales must be an object`)
+    return
+  }
+  const tags = Object.keys(locales)
+  if (tags.length > MAX_CATALOG_LOCALES) {
+    errors.push(`${appId}: catalog.locales accepts at most ${MAX_CATALOG_LOCALES} languages`)
+  }
+  for (const [tag, entry] of Object.entries(locales)) {
+    if (!LOCALE_TAG.test(tag)) {
+      errors.push(`${appId}: catalog.locales key "${tag}" must be a BCP-47 tag (e.g. zh-CN)`)
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push(`${appId}: catalog.locales.${tag} must be an object`)
+      continue
+    }
+    for (const key of Object.keys(entry)) {
+      if (!CATALOG_LOCALE_KEYS.has(key)) {
+        errors.push(
+          `${appId}: catalog.locales.${tag} unknown key "${key}" (name/description belong in manifest.locales)`,
+        )
+      }
+    }
+    if (entry.long_description !== undefined && typeof entry.long_description !== 'string') {
+      errors.push(`${appId}: catalog.locales.${tag}.long_description must be a string`)
+    }
+    if (entry.long_description && entry.long_description.length > MAX_LONG_DESCRIPTION) {
+      errors.push(
+        `${appId}: catalog.locales.${tag}.long_description too long (max ${MAX_LONG_DESCRIPTION})`,
+      )
+    }
+    if (entry.preview != null && (typeof entry.preview !== 'object' || Array.isArray(entry.preview))) {
+      errors.push(`${appId}: catalog.locales.${tag}.preview must be an object`)
+    }
+  }
+}
+
 function validateCatalogJson(appId, catalog, errors, warnings) {
   if (!catalog || typeof catalog !== 'object' || Array.isArray(catalog)) {
     errors.push(`${appId}: catalog.json must be a JSON object`)
@@ -146,8 +190,11 @@ function validateCatalogJson(appId, catalog, errors, warnings) {
   if (catalog.long_description !== undefined && typeof catalog.long_description !== 'string') {
     errors.push(`${appId}: catalog.long_description must be a string`)
   }
-  if (catalog.long_description && catalog.long_description.length > 20000) {
-    errors.push(`${appId}: catalog.long_description too long (max 20000)`)
+  if (catalog.long_description && catalog.long_description.length > MAX_LONG_DESCRIPTION) {
+    errors.push(`${appId}: catalog.long_description too long (max ${MAX_LONG_DESCRIPTION})`)
+  }
+  if (catalog.locales !== undefined) {
+    validateCatalogLocales(appId, catalog.locales, errors)
   }
   for (const flag of ['featured', 'verified', 'icon_shell', 'securityReview', 'security_review']) {
     if (catalog[flag] !== undefined && typeof catalog[flag] !== 'boolean') {

--- a/scripts/validate-previews.mjs
+++ b/scripts/validate-previews.mjs
@@ -104,21 +104,46 @@ function bootstrapFromDisk(appId) {
   }
 }
 
+function fixPreviewPaths(appId, preview) {
+  if (!preview || typeof preview !== 'object') return preview
+  const next = { ...preview }
+  const fix = (p) => {
+    if (typeof p !== 'string') return p
+    if (p.startsWith('apps/')) return p
+    return packageRel(appId, p.replace(/^\.\//, ''))
+  }
+  if (next.html) next.html = fix(next.html)
+  if (Array.isArray(next.styles)) next.styles = next.styles.map(fix)
+  return next
+}
+
 function loadCatalogPreview(appId) {
   const catalogPath = join(root, 'apps', appId, 'catalog.json')
   if (!existsSync(catalogPath)) return null
   try {
     const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'))
     if (!catalog.preview) return null
-    const preview = { ...catalog.preview }
-    const fix = (p) => {
-      if (typeof p !== 'string') return p
-      if (p.startsWith('apps/')) return p
-      return packageRel(appId, p.replace(/^\.\//, ''))
+    return fixPreviewPaths(appId, catalog.preview)
+  } catch {
+    return null
+  }
+}
+
+function collectLocalePreviews(appId, locales, sourcePrefix, targets) {
+  if (!locales || typeof locales !== 'object' || Array.isArray(locales)) return
+  for (const [tag, entry] of Object.entries(locales)) {
+    if (entry?.preview) {
+      pushTarget(targets, appId, fixPreviewPaths(appId, entry.preview), `${sourcePrefix} locales.${tag}`)
     }
-    if (preview.html) preview.html = fix(preview.html)
-    if (Array.isArray(preview.styles)) preview.styles = preview.styles.map(fix)
-    return preview
+  }
+}
+
+function loadCatalogLocales(appId) {
+  const catalogPath = join(root, 'apps', appId, 'catalog.json')
+  if (!existsSync(catalogPath)) return null
+  try {
+    const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'))
+    return catalog.locales ?? null
   } catch {
     return null
   }
@@ -138,12 +163,15 @@ async function main() {
   if (args.app) {
     const entry = byId.get(args.app)
     if (entry?.preview) pushTarget(targets, args.app, entry.preview, 'index')
+    collectLocalePreviews(args.app, entry?.locales, 'index', targets)
     pushTarget(targets, args.app, loadCatalogPreview(args.app), 'catalog.json')
+    collectLocalePreviews(args.app, loadCatalogLocales(args.app), 'catalog.json', targets)
     const disk = bootstrapFromDisk(args.app)
     if (disk) pushTarget(targets, args.app, disk, 'disk')
   } else {
     for (const app of index.apps || []) {
       if (app.preview) pushTarget(targets, app.id, app.preview, 'index')
+      collectLocalePreviews(app.id, app.locales, 'index', targets)
     }
     if (args.disk) {
       for (const name of readdirSync(join(root, 'apps'))) {
@@ -155,6 +183,7 @@ async function main() {
         }
         if (byId.get(name)?.preview) continue
         const fromCatalog = loadCatalogPreview(name)
+        collectLocalePreviews(name, loadCatalogLocales(name), 'catalog.json', targets)
         if (fromCatalog) {
           pushTarget(targets, name, fromCatalog, 'catalog.json')
           continue


### PR DESCRIPTION
## Why

Store CI on `main` rejects `catalog.json` key `locales`. Official merchandising PRs (#82–#86) need this validator update first.

Zero apps — scripts only. `index.json` is untouched.

## This PR

- `validate-app.mjs` allows and type-checks `catalog.locales`
- Preview / sync-index follow the same overlay rules