### PR TITLE
fix(cli): emit getUrlMap/resolve/rewriteUrl from sync-contract

### DIFF
--- a/tapp-cli/scripts/sdk-dts.mjs
+++ b/tapp-cli/scripts/sdk-dts.mjs
@@ -122,6 +122,9 @@ function localMembers() {
     get(path: string): Promise<unknown>
     getUrl(path: string): Promise<{ url: string; mimeType?: string; size?: number; path?: string }>
     getArrayBuffer(path: string): Promise<{ path: string; mimeType?: string; size?: number; buffer: ArrayBuffer }>
+    getUrlMap(): Promise<Record<string, string>>
+    resolve(path: string): Promise<{ url: string; mimeType?: string; size?: number; path?: string }>
+    rewriteUrl(url: string): string
     revoke(url: string): void
     revokeAll(): void
   }


### PR DESCRIPTION
Sync Myriad \`tools/tapp-cli/scripts/sdk-dts.mjs\` so \`npm run sync-contract\` keeps \`Tapp.assets.getUrlMap\` / \`resolve\` / \`rewriteUrl\`.

Committed \`tapp-sdk.d.ts\` is already correct. Docs-only path difference in README is intentional (store vs Myriad tree).

No \`apps/\` or \`index.json\` changes.