### PR TITLE
docs(cli): sync signed inbound /tapi routes from host

### DIFF
--- a/development/tapp/API_REFERENCE.md
+++ b/development/tapp/API_REFERENCE.md
@@ -1498,6 +1498,8 @@ const declaredApis = await Tapp.api.list();
   [Manifest · 安装级 API 凭据](MANIFEST.md#安装级-api-凭据-credentials)。
 - 详细 Manifest 字段和 REST 链路见 [Manifest](MANIFEST.md#api-声明-apis) 与
   [REST API](REST_API.md#manifest-声明-api)。
+- 给其他程序挂稳定 URL 时使用 `apis.*.route`（必须 HMAC）。沙箱不要自己拼 `/tapi`；
+  见 [入站路由](MANIFEST.md#入站路由-apisroute) 与 [REST API · 入站声明路由](REST_API.md#入站声明路由)。
 
 ## 文件与语音 API
 

--- a/development/tapp/ARCHITECTURE.md
+++ b/development/tapp/ARCHITECTURE.md
@@ -419,6 +419,10 @@ sequenceDiagram
 
 不要恢复旧式“传任意 URL 的 `/proxy`”设计；它会绕过 Manifest 审计和 SSRF 边界。
 
+需要给其他程序调用时，在同一条 `apis` 上声明 `route` + HMAC `verify`。宿主挂
+`/tapi/{tappId}/{path}`，不签发 Runtime Grant，不种游客 Cookie，也不提供未签名目录。
+验签、时间窗、nonce 账本和凭据小时封顶见 [Manifest · 入站路由](MANIFEST.md#入站路由-apisroute)。
+
 ## 性能策略
 
 - 商店弹窗及内置示例按需加载，不进入 Tapp 列表首屏包。

--- a/development/tapp/MANIFEST.md
+++ b/development/tapp/MANIFEST.md
@@ -539,7 +539,7 @@ prefix）。凭据值最长 16 KiB；该限制由管理 API 与宿主界面执�
 
 | 字段 | 说明 |
 | --- | --- |
-| `alg` | 白名单算法。已实现 `md5-sorted-kv`（`md5(token + sort(over).map(k+v).join(""))`）；`hmac-sha256-raw` 已占位，安装时拒绝 |
+| `alg` | 白名单算法。已实现 `md5-sorted-kv`（`md5(token + sort(over).map(k+v).join(""))`）和 `hmac-sha256-raw`（`hex(HMAC-SHA256(secret, sort(over).map(k+v).join("")))`） |
 | `over` | 参与签名的对象字段，1–16 个、不重复；不能包含签名字段本身 |
 | `timestampField` | 可选。若声明则必须列入 `over`；宿主在签名前用当前 UNIX 秒覆盖该字段 |
 
@@ -679,6 +679,7 @@ Manifest `defaultValue`，不是调用方参数。`{{secrets.*}}` 仍然 fail cl
 | `cacheTtl`    | number | ❌   | 响应缓存秒数；缓存按 Tapp、用户、客户端上下文隔离 |
 | `spoof`       | string | ❌   | 区域伪装：`china`/`japan`/`us`/`korea`/`taiwan`/`hongkong`（及别名，见下表） |
 | `description` | string | ❌   | API 描述                                          |
+| `route`       | object | ❌   | 入站挂载。有此字段时必须含 HMAC `verify`，且 `access` 必须是 `public` |
 
 `bodyMode` 控制模板解析后的最终请求体字节：
 
@@ -761,6 +762,63 @@ const summary = await Tapp.api("summarize", { prompt: "总结这些数据" });
 > 所有 `type: http` 的声明 API 都需要安装已授予 `network:fetch`；`access: public` 只放宽
 > 调用者范围（游客可调），**不能**代替 `network:fetch`。`access: protected` 额外要求登录主体。
 > `access: manager` 只允许安装 owner 或当前站点管理员调用。
+
+### 入站路由 (`apis.*.route`)
+
+给其他程序调用的稳定 HTTP 面。沙箱仍走 `Tapp.api`；`route` 把同一条声明挂到：
+
+`GET|POST /tapi/{tappId}{path}`
+
+有 `route` 就必须声明 HMAC `verify`，且该 API 的 `access` 必须是 `public`。
+`protected` / `manager` 和 `ai:*` builtin 不能挂入站。没有 `route` 的 API 行为不变。
+
+```json
+{
+  "route": {
+    "path": "/sponsors",
+    "methods": ["GET"],
+    "verify": {
+      "key": "inboundSecret",
+      "alg": "hmac-sha256-raw",
+      "header": "X-Signature",
+      "prefix": "sha256=",
+      "over": "canonical-query",
+      "timestampHeader": "X-Timestamp",
+      "nonceHeader": "X-Nonce",
+      "maxSkewSecs": 300
+    }
+  }
+}
+```
+
+| 字段 | 必填 | 说明 |
+| --- | --- | --- |
+| `path` | 是 | `/` + 1–64 位字母数字/`_`/`-`，Manifest 内唯一 |
+| `methods` | 否 | 仅 `GET` / `POST`，默认 `["GET"]`。`HEAD` 按 GET 验签 |
+| `verify.key` | 是 | 顶层 `credentials[].key`，可只绑入站 |
+| `verify.alg` | 是 | 仅 `hmac-sha256-raw` |
+| `verify.header` | 是 | `X-` 头；禁止会话头和代理头（`X-CSRF-Token`、`X-Tapp-Runtime-Grant`、`X-Forwarded-*`、`X-Real-IP`、`X-Request-Id` 等） |
+| `verify.prefix` | 否 | 如 `sha256=` |
+| `verify.over` | 是 | GET 用 `canonical-query`；POST 用 `raw-body` |
+| `verify.encoding` | 否 | `hex`（默认）或 `base64` |
+| `verify.timestampHeader` / `nonceHeader` | 是 | 与签名头互不相同的 `X-` 头 |
+| `verify.maxSkewSecs` | 否 | 默认 300，范围 30–3600 |
+
+签名材料（UTF-8，LF）：
+
+```text
+{METHOD}\n/tapi/{tappId}{path}\n{TIMESTAMP}\n{NONCE}\n{PAYLOAD}
+```
+
+GET 的 PAYLOAD 是解码后按键排序的 `k=v&k2=v2`（重复键拒绝），并作为 `params`。
+POST 的 PAYLOAD 是原始 body，超过 1 MiB 先拒；`params` 只来自身体（JSON 对象或 form），
+**未签名的 query 不会并入、也不能覆盖** 已签名字段。
+时间窗内同一 nonce 只能用一次。调用方必须自备 16–128 位 `[A-Za-z0-9_-]` nonce。
+
+入站 **不** 使用 Runtime Grant，也 **不** 查看游客 `network:fetch` 策略；HTTP 出站只要求该公开安装已批准 `network:fetch`。`/tapi` 忽略站点登录 Cookie，只解析 `visibility = all` 的公开安装。
+没有 `GET /tapi/{tappId}` 目录；验签参数写在 Manifest 里交给调用方，不由宿主对外广播本机装了哪些路由。
+入站密钥泄露后，owner 在详情页重填即可作废旧指纹；宿主另有每小时 180 次的凭据封顶。
+验签失败过多会按调用方指纹自动拉黑（不落原始 IP）；详情页可暂停该安装的入站或解除本安装拉黑。暂停/拉黑按安装 owner 隔离。
 
 ---
 

--- a/development/tapp/PLAYGROUND_GENERATION_CONTEXT.md
+++ b/development/tapp/PLAYGROUND_GENERATION_CONTEXT.md
@@ -129,6 +129,8 @@ await Tapp.storage.clear();
   临时预览不会实际执行 `Tapp.api`；完整字段见
   [MANIFEST · API 声明](./MANIFEST.md#api-声明-apis) 与
   [安装级凭据](./MANIFEST.md#安装级-api-凭据-credentials)。
+  若要给其他程序调用，再声明 `apis.*.route`（必须 `hmac-sha256-raw` + timestamp/nonce，
+  且 `access: public`）；不要编造未签名的 `/tapi` 或把密钥写进源码。
   **不要**在源码、`settings`、i18n 或注释里写入真实或示例密钥；`credentials` 只声明
   `key`/`label`，值由站主安装后写入。
 - 不要把 Three / Pocket 运行时打进生成物，也不要输出 CDN。完整 guest Three 样例见商店

--- a/development/tapp/REST_API.md
+++ b/development/tapp/REST_API.md
@@ -593,6 +593,29 @@ WebSocket 位于不同后端副本时仍可投递，每个标签页都能按自�
 
 旧的 `POST /api/tapp/{tappId}/proxy` 不存在，也不应重新引入。
 
+## 入站声明路由
+
+给其他程序用，不走 Runtime Grant，不种游客 Cookie，也**不读取**站点登录 Cookie。
+始终解析 `visibility = all` 的公开安装；私有安装和 `visibility = admin` 对 `/tapi` 一律按未安装处理（401 `ROUTE_VERIFY_INVALID`）。
+
+| 方法 | 路径 | 说明 |
+| ---- | ---- | ---- |
+| GET/POST | `/tapi/{tappId}/{path}` | 执行对应 `apis.*.route` |
+
+没有未签名的目录接口。调用方必须事先知道 Manifest 里的 `path` 和验签头，不能靠探测本机安装列表。
+未安装、无此 route、方法不对、缺头或 HMAC 错误一律 401 `ROUTE_VERIFY_INVALID`，不区分「有没有这条路由」。
+
+`{path}` 是 Manifest 里去掉前导 `/` 的单段。必须带声明的时间戳、nonce 和 HMAC 头。
+缺密钥或绑定指纹过期在 `/tapi` 上也回 401 `ROUTE_VERIFY_INVALID`（不把「这条路由已声明但未配密钥」暴露给探测方；owner 在 Tapp 详情页看凭据状态）。
+时间窗外 401 `ROUTE_VERIFY_EXPIRED`；nonce 重放 401 `ROUTE_VERIFY_REPLAY`（这两码只在 HMAC 已经通过之后出现）。
+限流：匿名 IP 每分钟 60 次；HMAC 通过后同一凭据每分钟 60 次、每小时 180 次。
+拉黑：10 分钟内对同一 Tapp 验签失败 25 次会自动封该调用方指纹 1 小时；全站 10 分钟失败 80 次会封全站入站 1 小时。不保存原始 IP。
+owner 可在 Tapp 详情里暂停**该安装**的 `/tapi`，或解除该安装下已列出的指纹。暂停/拉黑按安装 owner 隔离，私有副本不能冻结或解封公开安装。解除只清本安装拉黑，不清全站自动封禁。暂停返回 403 `ROUTE_PAUSED`，拉黑返回 403 `ROUTE_BLOCKED`。
+`/tapi` 验签替代 CSRF；带站点 Cookie 的 POST 也不要求 `X-CSRF-Token`。
+请求体上限 1 MiB。入站密钥泄露后应立刻在详情页轮换。
+
+签名规则见 [Manifest · 入站路由](MANIFEST.md#入站路由-apisroute)。
+
 ## 修改路由时的同步项
 
 新增或修改端点时同时检查：

--- a/development/tapp/TROUBLESHOOTING.md
+++ b/development/tapp/TROUBLESHOOTING.md
@@ -417,6 +417,7 @@ const data = await Tapp.api("data", {});
 2. 任意 `type: "http"` API（含 `public`、`protected` 与 `manager`）未授予 `network:fetch`
 3. 后端出站安全或参数模板校验拒绝了请求
 4. 游客调用 `access: "public"` API，但站点的游客 `network:fetch` 策略未开启（默认关闭）
+5. 其他程序调用 `/tapi/{tappId}/{path}` 时未带 HMAC / timestamp / nonce，或密钥未配置 / 重放（一律 401；`ROUTE_VERIFY_REPLAY` 只在 HMAC 已通过后出现）
 
 **解决方案**：
 

--- a/tapp-cli/src/generated/contract.json
+++ b/tapp-cli/src/generated/contract.json
@@ -48,6 +48,10 @@
     "pageModules": 64,
     "resourceBytes": 26214400,
     "resourcePathLength": 256,
+    "routeMaxBodyBytes": 1048576,
+    "routeMaxMaxSkewSecs": 3600,
+    "routeMinMaxSkewSecs": 30,
+    "routeVerifyPrefixLength": 256,
     "settingLabelLength": 255,
     "settingOptionValueLength": 255,
     "settingOptions": 100,
@@ -159,7 +163,8 @@
       "hmac-sha256-raw"
     ],
     "credentialSignAlgsImplemented": [
-      "md5-sorted-kv"
+      "md5-sorted-kv",
+      "hmac-sha256-raw"
     ],
     "cssModes": [
       "unified",
@@ -286,6 +291,34 @@
       "widgetStyles": ".css",
       "widgetTemplate": ".html"
     },
+    "routeMethods": [
+      "GET",
+      "POST"
+    ],
+    "routeReservedHeaders": [
+      "x-csrf-token",
+      "x-tapp-runtime-grant",
+      "x-forwarded-for",
+      "x-forwarded-host",
+      "x-forwarded-proto",
+      "x-forwarded-port",
+      "x-forwarded-prefix",
+      "x-real-ip",
+      "x-request-id",
+      "x-correlation-id",
+      "x-amzn-trace-id"
+    ],
+    "routeVerifyAlgs": [
+      "hmac-sha256-raw"
+    ],
+    "routeVerifyEncodings": [
+      "hex",
+      "base64"
+    ],
+    "routeVerifyOver": [
+      "raw-body",
+      "canonical-query"
+    ],
     "semverPrefixes": [
       "v"
     ],
@@ -654,6 +687,17 @@
             ],
             "type": "string"
           },
+          "route": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TappApiRoute"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional inbound HTTP mount at `/tapi/{tappId}{path}`."
+          },
           "spoof": {
             "type": [
               "string",
@@ -665,6 +709,31 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "TappApiRoute": {
+        "additionalProperties": false,
+        "properties": {
+          "methods": {
+            "default": [
+              "GET"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "path": {
+            "type": "string"
+          },
+          "verify": {
+            "$ref": "#/$defs/TappRouteVerify"
+          }
+        },
+        "required": [
+          "path",
+          "verify"
+        ],
         "type": "object"
       },
       "TappAuthor": {
@@ -936,6 +1005,78 @@
           "exact",
           "prefix",
           "origin"
+        ],
+        "type": "string"
+      },
+      "TappRouteVerify": {
+        "additionalProperties": false,
+        "description": "Host-verified inbound HMAC for `/tapi/{tappId}{path}`.",
+        "properties": {
+          "alg": {
+            "$ref": "#/$defs/TappCredentialSignAlg",
+            "enum": [
+              "hmac-sha256-raw"
+            ]
+          },
+          "encoding": {
+            "$ref": "#/$defs/TappRouteVerifyEncoding",
+            "enum": [
+              "hex",
+              "base64"
+            ]
+          },
+          "header": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "maxSkewSecs": {
+            "format": "uint32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "nonceHeader": {
+            "type": "string"
+          },
+          "over": {
+            "$ref": "#/$defs/TappRouteVerifyOver",
+            "enum": [
+              "raw-body",
+              "canonical-query"
+            ]
+          },
+          "prefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timestampHeader": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "alg",
+          "header",
+          "over",
+          "timestampHeader",
+          "nonceHeader"
+        ],
+        "type": "object"
+      },
+      "TappRouteVerifyEncoding": {
+        "enum": [
+          "hex",
+          "base64"
+        ],
+        "type": "string"
+      },
+      "TappRouteVerifyOver": {
+        "enum": [
+          "raw-body",
+          "canonical-query"
         ],
         "type": "string"
       },

--- a/tapp-cli/src/generated/manifest.schema.json
+++ b/tapp-cli/src/generated/manifest.schema.json
@@ -283,6 +283,17 @@
           ],
           "type": "string"
         },
+        "route": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TappApiRoute"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional inbound HTTP mount at `/tapi/{tappId}{path}`."
+        },
         "spoof": {
           "type": [
             "string",
@@ -294,6 +305,31 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "TappApiRoute": {
+      "additionalProperties": false,
+      "properties": {
+        "methods": {
+          "default": [
+            "GET"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path": {
+          "type": "string"
+        },
+        "verify": {
+          "$ref": "#/$defs/TappRouteVerify"
+        }
+      },
+      "required": [
+        "path",
+        "verify"
+      ],
       "type": "object"
     },
     "TappAuthor": {
@@ -565,6 +601,78 @@
         "exact",
         "prefix",
         "origin"
+      ],
+      "type": "string"
+    },
+    "TappRouteVerify": {
+      "additionalProperties": false,
+      "description": "Host-verified inbound HMAC for `/tapi/{tappId}{path}`.",
+      "properties": {
+        "alg": {
+          "$ref": "#/$defs/TappCredentialSignAlg",
+          "enum": [
+            "hmac-sha256-raw"
+          ]
+        },
+        "encoding": {
+          "$ref": "#/$defs/TappRouteVerifyEncoding",
+          "enum": [
+            "hex",
+            "base64"
+          ]
+        },
+        "header": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "maxSkewSecs": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "nonceHeader": {
+          "type": "string"
+        },
+        "over": {
+          "$ref": "#/$defs/TappRouteVerifyOver",
+          "enum": [
+            "raw-body",
+            "canonical-query"
+          ]
+        },
+        "prefix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timestampHeader": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "alg",
+        "header",
+        "over",
+        "timestampHeader",
+        "nonceHeader"
+      ],
+      "type": "object"
+    },
+    "TappRouteVerifyEncoding": {
+      "enum": [
+        "hex",
+        "base64"
+      ],
+      "type": "string"
+    },
+    "TappRouteVerifyOver": {
+      "enum": [
+        "raw-body",
+        "canonical-query"
       ],
       "type": "string"
     },

--- a/tapp-cli/src/project.mjs
+++ b/tapp-cli/src/project.mjs
@@ -272,6 +272,83 @@ function validateDeclaredCredential(definition, binding, name, diagnostics) {
   }
 }
 
+function isInboundRoutePath(value) {
+  return typeof value === 'string' && /^\/[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/.test(value)
+}
+
+function isInboundVerifyHeader(value) {
+  return typeof value === 'string'
+    && /^X-[A-Za-z0-9][A-Za-z0-9-]{0,62}$/.test(value)
+    && !(contract.rules.routeReservedHeaders || []).some((reserved) => reserved.toLowerCase() === value.toLowerCase())
+}
+
+function validateInboundRoute(definition, name, credentialKeys, boundCredentialKeys, inboundRoutePaths, diagnostics) {
+  const path = `apis.${name}.route`
+  if (!validateFields(definition.route, schemaFields('TappApiRoute'), path, diagnostics)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `${path} must be an object`))
+    return
+  }
+  const route = definition.route
+  if ((definition.access || 'protected') !== 'public') {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound route requires access public`))
+  }
+  if (definition.type === BUILTIN_API_TYPE && ['ai:chat', 'ai:generate'].includes(definition.builtin)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound route cannot expose AI builtins`))
+  }
+  if (!isInboundRoutePath(route.path)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound path is invalid`))
+  } else if (inboundRoutePaths.has(route.path)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound path ${route.path} is duplicated`))
+  } else {
+    inboundRoutePaths.add(route.path)
+  }
+  const methods = route.methods || ['GET']
+  const allowed = new Set(contract.rules.routeMethods || ['GET', 'POST'])
+  if (!Array.isArray(methods) || methods.length === 0 || new Set(methods).size !== methods.length || methods.some((method) => !allowed.has(method))) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound route methods must be GET and/or POST`))
+  }
+  const verifyPath = `${path}.verify`
+  if (!validateFields(route.verify, schemaFields('TappRouteVerify'), verifyPath, diagnostics)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `${verifyPath} must be an object`))
+    return
+  }
+  const verify = route.verify
+  if (typeof verify.key !== 'string' || !credentialKeys.has(verify.key)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound route references an undeclared credential`))
+  } else {
+    boundCredentialKeys.add(verify.key)
+  }
+  if (verify.alg !== 'hmac-sha256-raw') {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound verify algorithm must be hmac-sha256-raw`))
+  }
+  if (!isInboundVerifyHeader(verify.header) || !isInboundVerifyHeader(verify.timestampHeader) || !isInboundVerifyHeader(verify.nonceHeader)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound verify headers are invalid`))
+  } else if (new Set([verify.header, verify.timestampHeader, verify.nonceHeader].map((header) => header.toLowerCase())).size !== 3) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound verify headers must be distinct`))
+  }
+  const allowsGet = methods.includes('GET')
+  const allowsPost = methods.includes('POST')
+  if (verify.over === 'canonical-query' && (!allowsGet || allowsPost)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} canonical-query verify requires GET-only methods`))
+  }
+  if (verify.over === 'raw-body' && (!allowsPost || allowsGet)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} raw-body verify requires POST-only methods`))
+  }
+  const maxPrefix = contract.limits.routeVerifyPrefixLength || 256
+  if (verify.prefix !== undefined && (typeof verify.prefix !== 'string' || verify.prefix.length > maxPrefix)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound verify prefix is too long`))
+  }
+  const encodings = new Set(contract.rules.routeVerifyEncodings || ['hex', 'base64'])
+  if (verify.encoding !== undefined && !encodings.has(verify.encoding)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound verify encoding is invalid`))
+  }
+  const minSkew = contract.limits.routeMinMaxSkewSecs || 30
+  const maxSkew = contract.limits.routeMaxMaxSkewSecs || 3600
+  if (verify.maxSkewSecs !== undefined && (!Number.isInteger(verify.maxSkewSecs) || verify.maxSkewSecs < minSkew || verify.maxSkewSecs > maxSkew)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound maxSkewSecs must be between ${minSkew} and ${maxSkew}`))
+  }
+}
+
 function isDataExchangeId(value) {
   return typeof value === 'string' && value.length > 0 && value.length <= contract.limits.dataExchangeIdLength && NAMED_VALUE.test(value)
 }
@@ -837,6 +914,7 @@ function validateManifest(manifest, diagnostics, requiredPermissions) {
 
   const credentialKeys = new Set()
   const boundCredentialKeys = new Set()
+  const inboundRoutePaths = new Set()
   if (manifest.credentials !== undefined) {
     if (!Array.isArray(manifest.credentials)) {
       diagnostics.push(diagnostic('error', 'invalid-credentials', 'credentials must be an array'))
@@ -1006,6 +1084,9 @@ function validateManifest(manifest, diagnostics, requiredPermissions) {
       if (JSON.stringify(definition).includes('{{secrets.')) {
         diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} cannot reference host secret templates`))
       }
+      if (definition.route !== undefined) {
+        validateInboundRoute(definition, name, credentialKeys, boundCredentialKeys, inboundRoutePaths, diagnostics)
+      }
       const type = definition.type || DEFAULT_API_TYPE
       if (!API_TYPES.has(type)) {
         diagnostics.push(diagnostic('error', 'invalid-api', `API ${name} type must be one of: ${contract.rules.apiTypes.join(', ')}`))
@@ -1090,7 +1171,7 @@ function validateManifest(manifest, diagnostics, requiredPermissions) {
 
   for (const key of credentialKeys) {
     if (!boundCredentialKeys.has(key)) {
-      diagnostics.push(diagnostic('error', 'invalid-credential', `Credential ${key} must be bound to at least one declared HTTP API`))
+      diagnostics.push(diagnostic('error', 'invalid-credential', `Credential ${key} must be bound to at least one declared HTTP API or inbound route verify`))
     }
   }
 

--- a/tapp-cli/src/project.mjs
+++ b/tapp-cli/src/project.mjs
@@ -303,9 +303,10 @@ function validateInboundRoute(definition, name, credentialKeys, boundCredentialK
     inboundRoutePaths.add(route.path)
   }
   const methods = route.methods || ['GET']
-  const allowed = new Set(contract.rules.routeMethods || ['GET', 'POST'])
+  const allowedMethods = contract.rules.routeMethods || ['GET', 'POST']
+  const allowed = new Set(allowedMethods)
   if (!Array.isArray(methods) || methods.length === 0 || new Set(methods).size !== methods.length || methods.some((method) => !allowed.has(method))) {
-    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound route methods must be GET and/or POST`))
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound route methods must be one of: ${allowedMethods.join(', ')}`))
   }
   const verifyPath = `${path}.verify`
   if (!validateFields(route.verify, schemaFields('TappRouteVerify'), verifyPath, diagnostics)) {
@@ -326,13 +327,18 @@ function validateInboundRoute(definition, name, credentialKeys, boundCredentialK
   } else if (new Set([verify.header, verify.timestampHeader, verify.nonceHeader].map((header) => header.toLowerCase())).size !== 3) {
     diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound verify headers must be distinct`))
   }
-  const allowsGet = methods.includes('GET')
-  const allowsPost = methods.includes('POST')
-  if (verify.over === 'canonical-query' && (!allowsGet || allowsPost)) {
-    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} canonical-query verify requires GET-only methods`))
-  }
-  if (verify.over === 'raw-body' && (!allowsPost || allowsGet)) {
-    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} raw-body verify requires POST-only methods`))
+  const allowedOver = new Set(contract.rules.routeVerifyOver || ['raw-body', 'canonical-query'])
+  if (!allowedOver.has(verify.over)) {
+    diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} inbound verify.over must be one of: ${[...allowedOver].join(', ')}`))
+  } else {
+    const allowsGet = methods.includes('GET')
+    const allowsPost = methods.includes('POST')
+    if (verify.over === 'canonical-query' && (!allowsGet || allowsPost)) {
+      diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} canonical-query verify requires GET-only methods`))
+    }
+    if (verify.over === 'raw-body' && (!allowsPost || allowsGet)) {
+      diagnostics.push(diagnostic('error', 'invalid-api-route', `API ${name} raw-body verify requires POST-only methods`))
+    }
   }
   const maxPrefix = contract.limits.routeVerifyPrefixLength || 256
   if (verify.prefix !== undefined && (typeof verify.prefix !== 'string' || verify.prefix.length > maxPrefix)) {

--- a/tapp-cli/test/project.test.mjs
+++ b/tapp-cli/test/project.test.mjs
@@ -692,6 +692,175 @@ Tapp.storage.get(key)
     assert.match(messages, /Credential unused must be bound/)
   })
 
+  it('accepts a signed inbound /tapi route bound to a write-only credential', async () => {
+    const root = await temporaryDirectory('inbound-route-valid')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.permissions.push('network:fetch')
+    manifest.credentials = [{ key: 'hookSecret', label: 'Hook HMAC' }]
+    manifest.apis = {
+      hook: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: {
+          path: '/hook',
+          methods: ['POST'],
+          verify: {
+            key: 'hookSecret',
+            alg: 'hmac-sha256-raw',
+            header: 'X-Signature',
+            over: 'raw-body',
+            timestampHeader: 'X-Timestamp',
+            nonceHeader: 'X-Nonce',
+          },
+        },
+      },
+    }
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    const report = await inspectProject(root)
+    assert.deepEqual(
+      report.diagnostics.filter(({ code }) => code === 'invalid-api-route' || code.includes('credential')),
+      [],
+    )
+  })
+
+  it('rejects inbound route access, path, header, over, and credential mistakes', async () => {
+    const root = await temporaryDirectory('inbound-route-invalid')
+    await createProject(root, { type: 'page' })
+    const manifestPath = join(root, 'manifest.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+    manifest.permissions.push('network:fetch')
+    manifest.credentials = [{ key: 'hookSecret', label: 'Hook HMAC' }]
+    const verify = {
+      key: 'hookSecret',
+      alg: 'hmac-sha256-raw',
+      header: 'X-Signature',
+      over: 'raw-body',
+      timestampHeader: 'X-Timestamp',
+      nonceHeader: 'X-Nonce',
+    }
+    manifest.apis = {
+      privateHook: {
+        type: 'http',
+        access: 'protected',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: { path: '/private', methods: ['POST'], verify },
+      },
+      firstDup: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: { path: '/dup', methods: ['POST'], verify },
+      },
+      secondDup: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: { path: '/dup', methods: ['POST'], verify },
+      },
+      lowercaseHeader: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: {
+          path: '/lower',
+          methods: ['POST'],
+          verify: { ...verify, header: 'x-signature' },
+        },
+      },
+      reservedHeader: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: {
+          path: '/reserved',
+          methods: ['POST'],
+          verify: { ...verify, header: 'X-Forwarded-For' },
+        },
+      },
+      duplicateHeaders: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: {
+          path: '/same-headers',
+          methods: ['POST'],
+          verify: { ...verify, timestampHeader: 'X-Signature' },
+        },
+      },
+      badOver: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: {
+          path: '/bad-over',
+          methods: ['POST'],
+          verify: { ...verify, over: 'unsigned' },
+        },
+      },
+      overMethodMismatch: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'GET',
+        route: {
+          path: '/query-post',
+          methods: ['GET', 'POST'],
+          verify: { ...verify, over: 'canonical-query' },
+        },
+      },
+      missingOver: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: {
+          path: '/missing-over',
+          methods: ['POST'],
+          verify: { ...verify, over: undefined },
+        },
+      },
+      missingCred: {
+        type: 'http',
+        access: 'public',
+        endpoint: 'https://api.example.com/hook',
+        method: 'POST',
+        route: {
+          path: '/missing',
+          methods: ['POST'],
+          verify: { ...verify, key: 'missing' },
+        },
+      },
+    }
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    const report = await inspectProject(root)
+    const messages = report.diagnostics
+      .filter(({ code }) => code === 'invalid-api-route')
+      .map(({ message }) => message)
+      .join('\n')
+    assert.match(messages, /privateHook inbound route requires access public/)
+    assert.match(messages, /secondDup inbound path \/dup is duplicated/)
+    assert.match(messages, /lowercaseHeader inbound verify headers are invalid/)
+    assert.match(messages, /reservedHeader inbound verify headers are invalid/)
+    assert.match(messages, /duplicateHeaders inbound verify headers must be distinct/)
+    assert.match(messages, /badOver inbound verify\.over must be one of/)
+    assert.match(messages, /missingOver inbound verify\.over must be one of/)
+    assert.match(messages, /overMethodMismatch canonical-query verify requires GET-only methods/)
+    assert.match(messages, /missingCred inbound route references an undeclared credential/)
+  })
+
   it('rejects invalid declared API body mode shapes', async () => {
     const root = await temporaryDirectory('invalid-http-body-modes')
     await createProject(root, { type: 'page' })


### PR DESCRIPTION
## Summary

Docs + CLI only. Mirrors [Myriad #326](https://github.com/Myriad-You/Myriad/pull/326) so store-side authors see the same inbound contract:

- `apis.*.route` + required `hmac-sha256-raw` verify
- `/tapi/{tappId}/{path}` for other programs (no unsigned catalog)
- CLI `check` validates public access, methods, headers, skew, and credential binding

No `apps/` or `index.json` changes.

Related: #66

## Test plan

- [x] `MYRIAD_REPO_ROOT=<host worktree> npm test` in `tapp-cli` (51 passed)
- [x] Diff is docs + generated contract/schema + `project.mjs` only