### PR TITLE
feat(config-generator): add setup passphrase and copy reminder

### DIFF
--- a/apps/com.myriad.config-generator/README.md
+++ b/apps/com.myriad.config-generator/README.md
@@ -4,11 +4,12 @@
 
 ## 版本
 
-`1.0.0`
+`1.0.4`
 
 ## 安全
 
-- **密钥白名单**：`JWT_SECRET` / `UPDATE_TOKEN` / `UPDATER_GATEWAY_SECRET`（及 bundled `POSTGRES_PASSWORD`）须匹配 `[A-Za-z0-9_-]{32,512}`；拒绝 CR/LF/NUL、`#`、`=`、空白，避免未加引号 `.env` 注入。
+- **密钥白名单**：`JWT_SECRET` / `UPDATE_TOKEN` / `UPDATER_GATEWAY_SECRET` / `MYRIAD_SETUP_SECRET`（及 bundled `POSTGRES_PASSWORD`）须匹配 `[A-Za-z0-9_-]{32,512}`；拒绝 CR/LF/NUL、`#`、`=`、空白，避免未加引号 `.env` 注入。
+- **安装暗号**：`MYRIAD_SETUP_SECRET` 写入 `.env` 并注入 backend。生成页和结果区都会提醒先复制，首次向导创建所有者必须对上。
 - **生成后自检**：对产物再 `parseDotenvStrict`，校验密钥一致、期望键齐全、`PROXY_ALLOW_DIRECT_UPDATER=false` 仅一次。
 - **Nginx 上传**：≤512KB、`.conf`/文本、拒 NUL。
 - **Docker Hub**：`Promise.allSettled`，单仓失败不拖垮；优先四组件共同 versioned tag。

--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -281,6 +281,7 @@ services:
       DATA_DIR: /app/data
       CACHE_DIR: /app/cache
       JWT_SECRET: \${JWT_SECRET}
+      MYRIAD_SETUP_SECRET: \${MYRIAD_SETUP_SECRET}
       TRUST_PROXY_HEADERS: "true"
       CORS_ORIGINS: \${CORS_ORIGINS:-http://localhost}
       CSP_CONNECT_SRC: \${CSP_CONNECT_SRC:-'self' https:}
@@ -523,6 +524,8 @@ COSIGN_VERIFY={{COSIGN_VERIFY}}
 MYRIAD_DB_MODE={{MYRIAD_DB_MODE}}
 {{POSTGRES_ENV_BLOCK}}DATABASE_URL={{DATABASE_URL}}
 JWT_SECRET={{JWT_SECRET}}
+# First-owner claim passphrase. Required by /api/setup/create-admin.
+MYRIAD_SETUP_SECRET={{MYRIAD_SETUP_SECRET}}
 
 CORS_ORIGINS={{CORS_ORIGINS}}
 # BASE_URL / FRONTEND_URL = public HTTPS origin (required for federation Actor URLs)
@@ -680,6 +683,8 @@ docker compose pull && docker compose up -d
 
 \`backend-volume-init\` 会在 backend 启动前修复持久卷权限；无需手工 chown。
 
+首次打开站点会进入安装向导。创建所有者时必须填写 **安装暗号**（\`.env\` 里的 \`MYRIAD_SETUP_SECRET\`）。能读到这份配置的人才能当站长。
+
 可选：\`scripts/docker/deploy.sh up\`（含环境初始化与部署检查）。
 
 ## HTTPS
@@ -764,6 +769,10 @@ function generatePassword() {
   return generateSecret(40);
 }
 
+function generateSetupSecret() {
+  return generateSecret(48);
+}
+
 // ========================================
 // 安全：dotenv token / 内存 / PG / 上传限制
 // ========================================
@@ -781,7 +790,7 @@ var EXPECTED_ENV_KEYS_BASE = [
   'UPDATE_MODE', 'MYRIAD_GITHUB_REPO', 'CHECK_INTERVAL_SECS',
   'HTTP_BIND_ADDRESS', 'HTTP_PORT', 'PROXY_ALLOW_DIRECT_UPDATER',
   'COSIGN_VERIFY', 'MYRIAD_DB_MODE', 'DATABASE_URL', 'JWT_SECRET',
-  'CORS_ORIGINS', 'BASE_URL', 'FRONTEND_URL'
+  'MYRIAD_SETUP_SECRET', 'CORS_ORIGINS', 'BASE_URL', 'FRONTEND_URL'
 ];
 
 function isSafeDotenvToken(value) {
@@ -841,7 +850,7 @@ function parseDotenvStrict(text) {
 function validateGeneratedEnv(envText, secrets, opts) {
   opts = opts || {};
   var parsed = parseDotenvStrict(envText);
-  var requiredSecrets = ['JWT_SECRET', 'UPDATE_TOKEN', 'UPDATER_GATEWAY_SECRET'];
+  var requiredSecrets = ['JWT_SECRET', 'UPDATE_TOKEN', 'UPDATER_GATEWAY_SECRET', 'MYRIAD_SETUP_SECRET'];
   for (var i = 0; i < requiredSecrets.length; i++) {
     var k = requiredSecrets[i];
     if (parsed.map[k] !== secrets[k]) {
@@ -1595,6 +1604,7 @@ var state = {
   jwtSecret: '',
   updateToken: '',
   updaterGatewaySecret: '',
+  setupSecret: '',
   nginxConfig: null,
   nginxFileName: '',
   extraNginxConfig: null,
@@ -1664,6 +1674,7 @@ function initPage() {
   var jwtSecretInput = document.getElementById('jwt-secret');
   var updateTokenInput = document.getElementById('update-token');
   var gatewaySecretInput = document.getElementById('updater-gateway-secret');
+  var setupSecretInput = document.getElementById('setup-secret');
   var dbNameInput = document.getElementById('db-name');
   var dbUserInput = document.getElementById('db-user');
   var dbHostInput = document.getElementById('db-host');
@@ -1678,6 +1689,7 @@ function initPage() {
   var genJwtSecretBtn = document.getElementById('gen-jwt-secret');
   var genUpdateTokenBtn = document.getElementById('gen-update-token');
   var genGatewaySecretBtn = document.getElementById('gen-updater-gateway-secret');
+  var genSetupSecretBtn = document.getElementById('gen-setup-secret');
   var generateAllBtn = document.getElementById('btn-generate-all');
 
   var uploadNginx = document.getElementById('upload-nginx-conf');
@@ -1806,6 +1818,38 @@ function initPage() {
     });
   }
 
+  if (genSetupSecretBtn && setupSecretInput) {
+    pageListen(genSetupSecretBtn, 'click', function() {
+      setupSecretInput.value = generateSetupSecret();
+      animateButton(genSetupSecretBtn);
+    });
+  }
+
+  var copySetupSecretBtn = document.getElementById('copy-setup-secret');
+  if (copySetupSecretBtn && setupSecretInput) {
+    pageListen(copySetupSecretBtn, 'click', function() {
+      var value = setupSecretInput.value.trim();
+      if (!value) {
+        showNotification('还没有安装暗号，先点生成', 'error');
+        return;
+      }
+      copyToClipboard(value, copySetupSecretBtn);
+    });
+  }
+
+  var copySetupSecretResultBtn = document.getElementById('copy-setup-secret-result');
+  if (copySetupSecretResultBtn) {
+    pageListen(copySetupSecretResultBtn, 'click', function() {
+      var node = document.getElementById('setup-secret-reminder-value');
+      var value = ((node && node.textContent) || state.setupSecret || '').trim();
+      if (!value) {
+        showNotification('还没有安装暗号', 'error');
+        return;
+      }
+      copyToClipboard(value, copySetupSecretResultBtn);
+    });
+  }
+
   if (refreshTagsBtn) {
     pageListen(refreshTagsBtn, 'click', function() {
       // 用户明确刷新：覆盖自动/当前值为最新
@@ -1844,6 +1888,7 @@ function initPage() {
       var jwtSecret = jwtSecretInput.value.trim();
       var updateToken = updateTokenInput.value.trim();
       var gatewaySecret = gatewaySecretInput ? gatewaySecretInput.value.trim() : '';
+      var setupSecret = setupSecretInput ? setupSecretInput.value.trim() : '';
       var dbName = dbNameInput.value.trim();
       var dbUser = dbUserInput.value.trim();
       var dbMode = getSelectedDbMode();
@@ -1944,10 +1989,15 @@ function initPage() {
         gatewaySecret = generateUpdaterGatewaySecret();
         if (gatewaySecretInput) gatewaySecretInput.value = gatewaySecret;
       }
+      if (!setupSecret || setupSecret.length < 32) {
+        setupSecret = generateSetupSecret();
+        if (setupSecretInput) setupSecretInput.value = setupSecret;
+      }
       try {
         requireSafeDotenvToken(jwtSecret, 'JWT_SECRET');
         requireSafeDotenvToken(updateToken, 'UPDATE_TOKEN');
         requireSafeDotenvToken(gatewaySecret, 'UPDATER_GATEWAY_SECRET');
+        requireSafeDotenvToken(setupSecret, 'MYRIAD_SETUP_SECRET');
       } catch (secErr) {
         showNotification(secErr.message, 'error');
         return;
@@ -1959,6 +2009,7 @@ function initPage() {
       state.jwtSecret = jwtSecret;
       state.updateToken = updateToken;
       state.updaterGatewaySecret = gatewaySecret;
+      state.setupSecret = setupSecret;
       state.dbName = dbName;
       state.dbUser = dbUser;
       state.dbMode = dbMode;
@@ -2421,6 +2472,7 @@ function generateConfigs() {
     JWT_SECRET: state.jwtSecret,
     UPDATE_TOKEN: state.updateToken,
     UPDATER_GATEWAY_SECRET: state.updaterGatewaySecret,
+    MYRIAD_SETUP_SECRET: state.setupSecret,
     MAIN_DOMAIN: state.mainDomain,
     EXTRA_DOMAIN: state.extraDomain || '',
     CORS_ORIGINS: corsOrigins,
@@ -2497,6 +2549,7 @@ function generateConfigs() {
     JWT_SECRET: state.jwtSecret,
     UPDATE_TOKEN: state.updateToken,
     UPDATER_GATEWAY_SECRET: state.updaterGatewaySecret,
+    MYRIAD_SETUP_SECRET: state.setupSecret,
     POSTGRES_PASSWORD: isExternal ? undefined : state.dbPassword
   }, { bundled: !isExternal });
 
@@ -2593,11 +2646,18 @@ function generateConfigs() {
     nameExtra.textContent = state.extraDomain + '.conf';
   }
 
+  var reminder = document.getElementById('setup-secret-reminder');
+  var reminderValue = document.getElementById('setup-secret-reminder-value');
+  if (reminder && reminderValue && state.setupSecret) {
+    reminderValue.textContent = state.setupSecret;
+    reminder.hidden = false;
+  }
+
   var resultsSection = document.getElementById('results-section');
   resultsSection.hidden = false;
   resultsSection.scrollIntoView({ behavior: 'smooth' });
 
-  showNotification(panel.successNotify, 'success');
+  showNotification('已生成。请先复制安装暗号，创建所有者时要填。', 'success');
 }
 
 // ========================================

--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -524,7 +524,7 @@ COSIGN_VERIFY={{COSIGN_VERIFY}}
 MYRIAD_DB_MODE={{MYRIAD_DB_MODE}}
 {{POSTGRES_ENV_BLOCK}}DATABASE_URL={{DATABASE_URL}}
 JWT_SECRET={{JWT_SECRET}}
-# First-owner claim passphrase. Required by /api/setup/create-admin.
+# First-owner claim passphrase. The setup wizard asks for this when creating the site owner.
 MYRIAD_SETUP_SECRET={{MYRIAD_SETUP_SECRET}}
 
 CORS_ORIGINS={{CORS_ORIGINS}}

--- a/apps/com.myriad.config-generator/manifest.json
+++ b/apps/com.myriad.config-generator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.config-generator",
   "name": "Myriad 安装配置生成",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "minSystemVersion": "0.2.1",
   "description": "生成 Compose、.env 与 Nginx 部署配置（1Panel / 宝塔 / CLI · 整站反代 + 联邦）",
   "locales": {

--- a/apps/com.myriad.config-generator/page.css
+++ b/apps/com.myriad.config-generator/page.css
@@ -1081,6 +1081,48 @@ select.form-select:not(.cg-select-native) {
   transform: translateY(0);
 }
 
+.btn-copy-field {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  padding: 0 14px;
+  border: 1px solid var(--config-border);
+  border-radius: var(--config-radius-xs);
+  background: var(--config-input-bg);
+  color: var(--config-text);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: var(--config-transition);
+}
+
+.btn-copy-field:hover {
+  border-color: var(--config-primary);
+  color: var(--config-primary);
+}
+
+.btn-copy-field.copied {
+  border-color: var(--config-primary);
+  color: var(--config-primary);
+}
+
+.setup-secret-reminder-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.setup-secret-reminder-row code {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+}
+
 /* ========================================
    File Upload
    ======================================== */

--- a/apps/com.myriad.config-generator/page.html
+++ b/apps/com.myriad.config-generator/page.html
@@ -229,6 +229,19 @@
           </div>
           <span class="form-hint">backend ↔ gateway</span>
         </div>
+        <div class="form-group">
+          <label for="setup-secret">MYRIAD_SETUP_SECRET</label>
+          <div class="input-with-action">
+            <input type="text" id="setup-secret" class="form-input" placeholder="[A-Za-z0-9_-] ≥32" autocomplete="off" spellcheck="false">
+            <button type="button" id="gen-setup-secret" class="btn-generate" title="生成安装暗号">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
+              </svg>
+            </button>
+            <button type="button" id="copy-setup-secret" class="btn-copy-field" title="复制安装暗号">复制</button>
+          </div>
+          <span class="form-hint">首次打开站点<strong>创建所有者时要填</strong>。先点「复制」存下来，或从生成结果的 .env 里找 <code>MYRIAD_SETUP_SECRET</code>。不要发到群里。</span>
+        </div>
       </section>
 
       <section class="form-section">
@@ -507,6 +520,23 @@
       <p class="section-desc results-intro" id="results-intro">
         1Panel：复制 docker-compose.yml 到“编排”，复制 .env 到“环境变量”。
       </p>
+
+      <div class="section-warning" id="setup-secret-reminder" hidden>
+        <span class="section-warning-icon" aria-hidden="true">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+          </svg>
+        </span>
+        <div class="section-warning-content">
+          <span class="section-warning-title">先复制安装暗号</span>
+          第一次打开站点、创建所有者时要填这一项。现在复制，或从下面的 .env 找 <code>MYRIAD_SETUP_SECRET</code>。
+          <div class="setup-secret-reminder-row">
+            <code id="setup-secret-reminder-value"></code>
+            <button type="button" id="copy-setup-secret-result" class="btn-copy-field">复制暗号</button>
+          </div>
+        </div>
+      </div>
 
       <!-- Docker Compose -->
       <div class="result-card">

--- a/apps/com.myriad.config-generator/scripts/security-smoke.mjs
+++ b/apps/com.myriad.config-generator/scripts/security-smoke.mjs
@@ -31,6 +31,7 @@ assert.match(main, /isValidMemoryLimit/)
 assert.match(main, /isValidPgMajor/)
 assert.match(main, /parseImageRef/)
 assert.match(main, /nginx -t/)
+assert.match(main, /MYRIAD_SETUP_SECRET/)
 assert.doesNotMatch(main, /await Promise\.all\(\s*\[\s*fetchDockerHubTags/)
 
 // Extract pure helpers by executing a slice of main.js (no DOM / Tapp)
@@ -83,6 +84,7 @@ const injected =
   'UPDATE_TOKEN=' + goodSecret + '\nPROXY_ALLOW_DIRECT_UPDATER=true\n' +
   'UPDATER_GATEWAY_SECRET=' + goodSecret + '\n' +
   'JWT_SECRET=' + goodSecret + '\n' +
+  'MYRIAD_SETUP_SECRET=' + goodSecret + '\n' +
   'PROXY_ALLOW_DIRECT_UPDATER=false\n' +
   'MYRIAD_TAG=v1.0.0\nPROXY_TAG=v1.0.0\nUPDATER_TAG=v1.0.0\n' +
   'BACKEND_IMAGE=x\nFRONTEND_IMAGE=x\nCOMPOSE_PROJECT_NAME=myriad\n' +
@@ -95,7 +97,8 @@ assert.throws(
   () => h.validateGeneratedEnv(injected, {
     JWT_SECRET: goodSecret,
     UPDATE_TOKEN: goodSecret,
-    UPDATER_GATEWAY_SECRET: goodSecret
+    UPDATER_GATEWAY_SECRET: goodSecret,
+    MYRIAD_SETUP_SECRET: goodSecret
   }, { bundled: false }),
   /PROXY_ALLOW_DIRECT_UPDATER|重复/
 )
@@ -131,6 +134,7 @@ function buildCleanEnv(secrets, bundled) {
   lines.push(
     'DATABASE_URL=postgres://myriad:x@postgres:5432/myriad',
     'JWT_SECRET=' + secrets.JWT_SECRET,
+    'MYRIAD_SETUP_SECRET=' + secrets.MYRIAD_SETUP_SECRET,
     'CORS_ORIGINS=https://example.com',
     'BASE_URL=https://example.com',
     'FRONTEND_URL=https://example.com'
@@ -142,6 +146,7 @@ const secrets = {
   JWT_SECRET: 'J'.repeat(40),
   UPDATE_TOKEN: 'U'.repeat(40),
   UPDATER_GATEWAY_SECRET: 'G'.repeat(40),
+  MYRIAD_SETUP_SECRET: 'S'.repeat(40),
   POSTGRES_PASSWORD: 'P'.repeat(40)
 }
 const clean = buildCleanEnv(secrets, true)


### PR DESCRIPTION
## Summary
- Write `MYRIAD_SETUP_SECRET` into generated `.env` and inject it into backend compose env.
- Require it on first-owner claim when orchestration already set `DATABASE_URL`.
- Emphasize copy: form-side copy button, result-panel warning with the value, and a post-generate toast.

## Test plan
- [x] `node apps/com.myriad.config-generator/scripts/security-smoke.mjs`
- [x] `node scripts/validate-app.mjs --app com.myriad.config-generator`
- [x] `node tapp-cli/bin/myriad-tapp.mjs check apps/com.myriad.config-generator --json`
- [ ] Generate a stack, copy the passphrase, open the site wizard, confirm create-owner requires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)