### PR TITLE
feat(config-generator): rebuild install wizard as a full-window flow

### DIFF
--- a/apps/com.myriad.config-generator/README.md
+++ b/apps/com.myriad.config-generator/README.md
@@ -4,7 +4,7 @@
 
 ## 版本
 
-`1.0.4`
+`1.1.0`
 
 ## 安全
 
@@ -13,12 +13,16 @@
 - **生成后自检**：对产物再 `parseDotenvStrict`，校验密钥一致、期望键齐全、`PROXY_ALLOW_DIRECT_UPDATER=false` 仅一次。
 - **Nginx 上传**：≤512KB、`.conf`/文本、拒 NUL。
 - **Docker Hub**：`Promise.allSettled`，单仓失败不拖垮；优先四组件共同 versioned tag。
-- **资源边界**：内存 16M–256G；PostgreSQL 主版本 18–20。
+- **资源边界**：内存 16M–256G；PostgreSQL 主版本 18–20。限额「小型」会写入 `MYRIAD_MEMORY_PROFILE=saver`。
+- **内存节约**：`.env` / backend 注入 `MYRIAD_MEMORY_PROFILE`（`saver`|`default`）。选小型档自动打开，高级页可改。
 - **Digest**：tag 可写 `vX.Y.Z@sha256:<64hex>`。
 - 自检脚本：`node apps/com.myriad.config-generator/scripts/security-smoke.mjs`
 
 ## UI
 
+- **分步向导**：铺满宿主窗口。欢迎 → 面板 → 域名 → 站点 → 数据库 → 限额 → 完成。高级可选。每次只问一件事。背景用壁纸主色做淡渐变（沙箱无法真透明，不再套浮卡）。
+- **站点独立一步**：先去面板/服务器创建网站并配好 SSL，再把现成 `.conf` 丢过来；生成时尽量保留证书，改成整站反代。没有文件也能继续，会写默认 conf。
+- **主路径极简**：密钥自动填。限额默认可直接过。完成页先复制安装暗号。
 - **自定义下拉**：`select.form-select` 在运行时增强为 `.cg-select`（自绘 trigger + option 列表），跟随壁纸主色/深色模式；原生 `<select>` 仅作值载体（系统 option 菜单无法主题化）。
 
 ## 面板适配（用户可选）
@@ -101,10 +105,12 @@ curl -sS "https://YOUR_DOMAIN/.well-known/nodeinfo" | head -c 200
 
 ## 用法
 
-1. 选择面板（1Panel / 宝塔 / 通用）  
-2. 填域名 / 数据库（内置或外置），确认密钥  
-3. 可选上传 Nginx 站点配置（会规范为整站反代 + ACME 本地挑战）  
-4. 生成并下载  
+1. 选面板（1Panel / 宝塔 / 命令行）  
+2. 填域名（额外域名可选）  
+3. 先在服务器创建网站并配好 SSL，再把站点 `.conf` 拖进来  
+4. 选数据库（内置或外置；密钥与版本自动填）  
+5. 按机器大小调整 CPU / 内存限额（默认可直接过）  
+6. 生成后先复制安装暗号，再按面板提示拿走文件  
 
 **1Panel：** YAML → 编排，`.env` → 环境变量。  
 **宝塔：** 目录内同时放 compose + `.env` → Docker 容器编排添加项目；网站反向代理目标 `127.0.0.1:HTTP_PORT`，代理 `/`。  

--- a/apps/com.myriad.config-generator/catalog.json
+++ b/apps/com.myriad.config-generator/catalog.json
@@ -1,5 +1,5 @@
 {
-  "long_description": "填写域名与数据库参数，按所选面板（1Panel / 宝塔 / 通用 CLI）生成官方生产拓扑的 docker-compose、.env、Nginx 与部署说明。密钥白名单与 .env 再解析防注入；原生表单/通知全自定义；宝塔可粘贴编排或目录部署。",
+  "long_description": "按欢迎 → 面板 → 域名 → 站点 → 数据库 → 限额分步生成官方生产拓扑的 docker-compose、.env、Nginx 与部署说明。先建好网站和 SSL 再丢站点 conf。密钥和镜像版本自动填好，高级选项默认收起。密钥白名单与 .env 再解析防注入；宝塔可粘贴编排或目录部署。",
   "tags": ["配置", "部署", "Docker", "Nginx", "Updater", "1Panel", "宝塔", "工具", "开发者"],
   "featured": true,
   "verified": true,
@@ -18,7 +18,7 @@
   },
   "locales": {
     "en-US": {
-      "long_description": "Enter domain and database settings, then generate official production docker-compose, .env, Nginx, and deploy notes for the selected panel (1Panel / Baota / generic CLI). Secrets are allowlisted and the .env is parsed again to block injection; native forms and notifications are fully custom-drawn. On Baota you can paste compose or deploy from a directory.",
+      "long_description": "A step wizard (welcome, panel, domain, site, database, limits) generates official production docker-compose, .env, Nginx, and deploy notes. Create the site and SSL first, then drop the existing conf. Secrets and image tags are filled in automatically; advanced options stay collapsed. Secrets are allowlisted and the .env is parsed again to block injection. On Baota you can paste compose or deploy from a directory.",
       "preview": {
         "version": 1,
         "type": "snapshot",
@@ -31,7 +31,7 @@
       }
     },
     "ja-JP": {
-      "long_description": "ドメインとデータベースのパラメータを入力し、選択したパネル（1Panel / 宝塔 / 汎用 CLI）向けに公式本番トポロジの docker-compose、.env、Nginx、デプロイ手順を生成します。シークレットはホワイトリスト検証し、.env を再パースしてインジェクションを防ぎます。ネイティブのフォームと通知はすべてカスタム描画です。宝塔では編成の貼り付けまたはディレクトリ配置が可能です。",
+      "long_description": "ようこそ → パネル → ドメイン → サイト → データベース → 上限のステップで、公式本番トポロジの docker-compose、.env、Nginx、デプロイ手順を生成します。先にサイトと SSL を用意し、既存 conf を渡します。シークレットとイメージタグは自動入力、詳細設定は折りたたみです。シークレットはホワイトリスト検証し、.env を再パースしてインジェクションを防ぎます。宝塔では編成の貼り付けまたはディレクトリ配置が可能です。",
       "preview": {
         "version": 1,
         "type": "snapshot",

--- a/apps/com.myriad.config-generator/main.js
+++ b/apps/com.myriad.config-generator/main.js
@@ -24,8 +24,14 @@ var PANEL_PROFILES = {
     envBadge: '1Panel 环境变量框 · 勿公开',
     envCopyLabel: '复制到 1Panel',
     composeBadge: '1Panel 编排 · 粘贴 YAML',
-    resultsIntro: '1Panel：docker-compose.yml →「容器 / 编排」；.env →「环境变量」。站点整站反代到 HTTP_BIND:HTTP_PORT。',
-    successNotify: '生成成功：1Panel 将 YAML 粘到「编排」，.env 粘到「环境变量」',
+    wizardHint: '生成后：编排里贴 YAML，环境变量里贴 .env。',
+    siteSteps: [
+      '打开 1Panel → 网站，创建 {domain}',
+      '先申请并开启 SSL',
+      '把站点配置文件拖到下面'
+    ],
+    siteConfPath: '也可在服务器上找网站目录或 OpenResty conf.d 里的 {domain}.conf',
+    resultsIntro: '1Panel：把 docker-compose.yml 贴到「容器 / 编排」，把 .env 贴到「环境变量」。网站整站反代到本机端口。',
     // Baota-specific include patterns not used; 1Panel proxy includes stripped in transform
     proxyIncludeRe: /^[ \t]*include\s+[^;\n]*\/proxy\/\*\.conf\s*;[ \t]*$/gm
   },
@@ -40,8 +46,14 @@ var PANEL_PROFILES = {
     envBadge: '与 compose 同目录 · .env 文件',
     envCopyLabel: '复制 .env',
     composeBadge: '粘贴 YAML 或目录部署',
-    resultsIntro: '宝塔：可「创建编排」粘贴 YAML，或目录内放 compose+.env；内置库务必 chown 70:70 pgdata（见部署说明）。',
-    successNotify: '生成成功：宝塔可粘贴编排或目录部署；内置 Postgres 请先 chown 70:70 pgdata',
+    wizardHint: '生成后：可以粘编排，也可以把两个文件放到同一目录。',
+    siteSteps: [
+      '打开宝塔 → 网站，添加 {domain}',
+      '在站点设置里申请 SSL',
+      '把站点配置文件拖到下面'
+    ],
+    siteConfPath: '常见路径：/www/server/panel/vhost/nginx/{domain}.conf',
+    resultsIntro: '宝塔：可「创建编排」粘贴 YAML，或目录内放 compose + .env。内置库请先看部署说明里的目录权限。',
     // 宝塔反向代理 / 扩展 include
     proxyIncludeRe: /^[ \t]*include\s+[^;\n]*(?:\/proxy\/|\/extension\/)[^;\n]*\*\.conf\s*;[ \t]*$/gm
   },
@@ -56,14 +68,165 @@ var PANEL_PROFILES = {
     envBadge: 'compose 同目录 · .env 文件',
     envCopyLabel: '复制 .env',
     composeBadge: 'docker compose · CLI',
-    resultsIntro: '通用部署：同目录放置 docker-compose.yml 与 .env，执行 docker compose up -d；外层 Nginx/Caddy 整站反代。',
-    successNotify: '生成成功：请将文件放到同一目录后执行 docker compose up -d',
+    wizardHint: '生成后：两个文件放到同一目录，再执行 docker compose up -d。',
+    siteSteps: [
+      '先给 {domain} 签好证书',
+      '确认 HTTPS 能打开',
+      '把现有 nginx conf 拖到下面'
+    ],
+    siteConfPath: '常见路径：/etc/nginx/sites-available/{domain} 或 /etc/nginx/conf.d/{domain}.conf',
+    resultsIntro: '命令行：把 docker-compose.yml 和 .env 放在同一目录，执行 docker compose up -d。外层再整站反代。',
     proxyIncludeRe: /^[ \t]*include\s+[^;\n]*\/proxy\/\*\.conf\s*;[ \t]*$/gm
   }
 };
 
 function getPanelProfile(panelId) {
   return PANEL_PROFILES[panelId] || PANEL_PROFILES['1panel'];
+}
+
+function buildDoneGuide(panelId, ctx) {
+  var external = !!ctx.external;
+  var domain = ctx.domain || '你的域名';
+  var port = ctx.httpPort || 8080;
+  var bind = (ctx.httpBind || '127.0.0.1') + ':' + port;
+  var extra = ctx.extraDomain || '';
+  var pgCmd = 'mkdir -p pgdata state backups && chown -R 70:70 pgdata && chmod 700 pgdata && chmod 600 .env';
+  var cliCmd = external
+    ? 'mkdir -p state backups && chmod 600 .env && docker compose pull && docker compose up -d'
+    : pgCmd + ' && docker compose pull && docker compose up -d';
+
+  var overview;
+  var steps = [];
+
+  if (panelId === 'generic') {
+    overview = ['收暗号', '放文件启动', '接上反代', '打开站点'];
+    steps.push({
+      title: '把文件放到同一目录并启动',
+      body: '在服务器建一个目录，放入 docker-compose.yml 和 .env，再执行命令。',
+      files: ['compose', 'env'],
+      command: cliCmd
+    });
+    steps.push({
+      title: '接上外层反代',
+      body: '把生成的 ' + domain + '.conf 放到 Nginx，整站反代到 ' + bind + '。不要只反代 /api。',
+      files: extra ? ['nginx', 'nginx-extra'] : ['nginx']
+    });
+  } else if (panelId === 'baota') {
+    overview = ['收暗号', '贴编排', '覆盖 conf', '打开站点'];
+    steps.push({
+      title: '把编排贴进宝塔',
+      body: '打开宝塔 → Docker → 容器编排 → 创建编排，粘贴 docker-compose.yml。.env 放到同一目录。',
+      files: ['compose', 'env']
+    });
+    steps.push({
+      title: '覆盖站点配置',
+      body: '到宝塔网站 → 设置 → 配置文件，用生成的 ' + domain + '.conf 覆盖。反代目标 ' + bind + '，必须是整站 /。',
+      files: extra ? ['nginx', 'nginx-extra'] : ['nginx']
+    });
+  } else {
+    overview = ['收暗号', '贴编排', '覆盖 conf', '打开站点'];
+    steps.push({
+      title: '把编排贴进 1Panel',
+      body: '打开 1Panel → 容器 → 编排 → 创建。YAML 贴 docker-compose.yml，环境变量贴 .env 全文。',
+      files: ['compose', 'env']
+    });
+    steps.push({
+      title: '覆盖站点配置',
+      body: '到 1Panel 网站 → 配置文件，用生成的 ' + domain + '.conf 覆盖。目标 http://' + bind + '，必须整站反代。',
+      files: extra ? ['nginx', 'nginx-extra'] : ['nginx']
+    });
+  }
+
+  steps.push({
+    title: '打开站点创建所有者',
+    body: '容器起来后打开安装链接。向导会自动填入暗号。'
+  });
+
+  return { overview: overview, steps: steps };
+}
+
+var GUIDE_FILE_ACTIONS = {
+  compose: { target: 'docker-compose', filename: 'docker-compose.yml', label: 'docker-compose.yml' },
+  env: { target: 'env', filename: '.env', label: '.env' },
+  nginx: { target: 'main-nginx', filename: '', label: '站点 .conf' },
+  'nginx-extra': { target: 'extra-nginx', filename: '', label: '额外域名 .conf' }
+};
+
+function renderDoneGuide(panelId, ctx) {
+  var guide = buildDoneGuide(panelId, ctx);
+  var overviewEl = document.getElementById('cg-guide-overview');
+  var listEl = document.getElementById('cg-guide-list');
+  if (overviewEl) {
+    overviewEl.style.setProperty('--cg-guide-cols', String(guide.overview.length || 5));
+    overviewEl.innerHTML = '';
+    guide.overview.forEach(function (label, index) {
+      var item = document.createElement('li');
+      var num = document.createElement('b');
+      num.textContent = String(index + 1);
+      var span = document.createElement('span');
+      span.textContent = label;
+      item.appendChild(num);
+      item.appendChild(span);
+      overviewEl.appendChild(item);
+    });
+  }
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  guide.steps.forEach(function (step, index) {
+    var card = document.createElement('article');
+    card.className = 'cg-guide-card';
+    var header = document.createElement('header');
+    var num = document.createElement('b');
+    num.textContent = String(index + 2);
+    var title = document.createElement('h2');
+    title.textContent = step.title;
+    header.appendChild(num);
+    header.appendChild(title);
+    card.appendChild(header);
+    var body = document.createElement('p');
+    body.textContent = step.body;
+    card.appendChild(body);
+    if (step.files && step.files.length) {
+      var actions = document.createElement('div');
+      actions.className = 'cg-guide-actions';
+      step.files.forEach(function (key) {
+        var spec = GUIDE_FILE_ACTIONS[key];
+        if (!spec) return;
+        var copyBtn = document.createElement('button');
+        copyBtn.type = 'button';
+        copyBtn.className = 'btn-copy';
+        copyBtn.setAttribute('data-target', spec.target);
+        copyBtn.textContent = '复制 ' + spec.label;
+        var downBtn = document.createElement('button');
+        downBtn.type = 'button';
+        downBtn.className = 'btn-download';
+        downBtn.setAttribute('data-target', spec.target);
+        downBtn.setAttribute(
+          'data-filename',
+          spec.filename || ((key === 'nginx' ? ctx.domain : ctx.extraDomain) || spec.label) + '.conf'
+        );
+        downBtn.textContent = '下载';
+        actions.appendChild(copyBtn);
+        actions.appendChild(downBtn);
+      });
+      card.appendChild(actions);
+    }
+    if (step.command) {
+      var cmd = document.createElement('div');
+      cmd.className = 'cg-guide-cmd';
+      var code = document.createElement('code');
+      code.textContent = step.command;
+      var cmdBtn = document.createElement('button');
+      cmdBtn.type = 'button';
+      cmdBtn.className = 'btn-copy-field';
+      cmdBtn.setAttribute('data-copy-text', step.command);
+      cmdBtn.textContent = '复制命令';
+      cmd.appendChild(code);
+      cmd.appendChild(cmdBtn);
+      card.appendChild(cmd);
+    }
+    listEl.appendChild(card);
+  });
 }
 
 /**
@@ -291,6 +454,7 @@ services:
       RUST_LOG: \${RUST_LOG:-info}
       TZ: Asia/Shanghai
       MYRIAD_VERSION: \${MYRIAD_TAG}
+      MYRIAD_MEMORY_PROFILE: \${MYRIAD_MEMORY_PROFILE:-default}
       MYRIAD_UPDATER_URL: http://updater-gateway:1104
       UPDATER_GATEWAY_SECRET: \${UPDATER_GATEWAY_SECRET}
     depends_on:
@@ -519,6 +683,8 @@ PROXY_ALLOW_DIRECT_UPDATER=false
 
 COSIGN_VERIFY={{COSIGN_VERIFY}}
 {{COSIGN_INSECURE_HINT}}
+# saver = 小主机内存节约（收紧缓存/连接池）；default = 均衡
+MYRIAD_MEMORY_PROFILE={{MYRIAD_MEMORY_PROFILE}}
 
 # MYRIAD_DB_MODE=bundled|external — external: no compose postgres; updater skips pgdata snapshots
 MYRIAD_DB_MODE={{MYRIAD_DB_MODE}}
@@ -683,7 +849,7 @@ docker compose pull && docker compose up -d
 
 \`backend-volume-init\` 会在 backend 启动前修复持久卷权限；无需手工 chown。
 
-首次打开站点会进入安装向导。创建所有者时必须填写 **安装暗号**（\`.env\` 里的 \`MYRIAD_SETUP_SECRET\`）。能读到这份配置的人才能当站长。
+首次打开站点会进入安装向导。创建所有者时必须填写 **安装暗号**（\`.env\` 里的 \`MYRIAD_SETUP_SECRET\`）。也可以打开 \`https://{{MAIN_DOMAIN}}/#setup_secret=…\`，向导会自动填入。能读到这份配置或链接的人才能当站长。
 
 可选：\`scripts/docker/deploy.sh up\`（含环境初始化与部署检查）。
 
@@ -789,7 +955,7 @@ var EXPECTED_ENV_KEYS_BASE = [
   'COMPOSE_PROJECT_NAME', 'UPDATE_TOKEN', 'UPDATER_GATEWAY_SECRET', 'CHANNEL',
   'UPDATE_MODE', 'MYRIAD_GITHUB_REPO', 'CHECK_INTERVAL_SECS',
   'HTTP_BIND_ADDRESS', 'HTTP_PORT', 'PROXY_ALLOW_DIRECT_UPDATER',
-  'COSIGN_VERIFY', 'MYRIAD_DB_MODE', 'DATABASE_URL', 'JWT_SECRET',
+  'COSIGN_VERIFY', 'MYRIAD_MEMORY_PROFILE', 'MYRIAD_DB_MODE', 'DATABASE_URL', 'JWT_SECRET',
   'MYRIAD_SETUP_SECRET', 'CORS_ORIGINS', 'BASE_URL', 'FRONTEND_URL'
 ];
 
@@ -860,6 +1026,9 @@ function validateGeneratedEnv(envText, secrets, opts) {
   }
   if (parsed.map.PROXY_ALLOW_DIRECT_UPDATER !== 'false') {
     throw new Error('PROXY_ALLOW_DIRECT_UPDATER 必须为 false（生成器固定值）');
+  }
+  if (parsed.map.MYRIAD_MEMORY_PROFILE !== 'saver' && parsed.map.MYRIAD_MEMORY_PROFILE !== 'default') {
+    throw new Error('MYRIAD_MEMORY_PROFILE 必须是 saver 或 default');
   }
   var allowCount = (String(envText).match(/^PROXY_ALLOW_DIRECT_UPDATER=/gm) || []).length;
   if (allowCount !== 1) {
@@ -1621,8 +1790,9 @@ var state = {
   dbHost: '',
   dbPort: 5432,
   dbSslmode: '',
-  dbCpuLimit: '2.0',
-  dbMemLimit: '2G',
+  dbCpuLimit: '1.0',
+  dbMemLimit: '1G',
+  memoryProfile: 'default',
   // 运行时由 Docker Hub 解析填充，不在源码中写死版本
   myriadTag: '',
   proxyTag: '',
@@ -1634,9 +1804,9 @@ var state = {
   cosignVerify: 'strict',
   // PostgreSQL / backend / frontend 可按宿主机条件限制
   backendCpuLimit: '2.0',
-  backendMemLimit: '4G',
-  frontendCpuLimit: '2.0',
-  frontendMemLimit: '2G',
+  backendMemLimit: '2G',
+  frontendCpuLimit: '1.0',
+  frontendMemLimit: '512M',
   netMyriad: 'myriad-net',
   netAdmin: 'myriad-admin-net',
   netGuard: 'myriad-docker-guard-net',
@@ -1653,7 +1823,269 @@ var pageLifecycle = {
   unsubs: []
 };
 
+/**
+ * 向导：欢迎 → 面板 → 域名 → 站点 → 数据库 → 限额 → 完成；高级为限额页可选。
+ * 主路径每次只问一件事。
+ */
+var WIZARD_FLOW = ['welcome', 'panel', 'domain', 'site', 'database', 'limits', 'advanced', 'done'];
+var WIZARD_META = {
+  welcome: { index: 0, name: '欢迎', back: '', backLabel: '' },
+  panel: { index: 1, name: '面板', back: 'welcome', backLabel: '欢迎' },
+  domain: { index: 2, name: '域名', back: 'panel', backLabel: '面板' },
+  site: { index: 3, name: '站点', back: 'domain', backLabel: '域名' },
+  database: { index: 4, name: '数据库', back: 'site', backLabel: '站点' },
+  limits: { index: 5, name: '限额', back: 'database', backLabel: '数据库' },
+  advanced: { index: 0, name: '高级', back: 'limits', backLabel: '限额' },
+  done: { index: 0, name: '', back: 'limits', backLabel: '限额' }
+};
+var WIZARD_TOTAL = 5;
+var wizardStep = 'welcome';
+var wizardDoneFrom = 'limits';
+
+var LIMIT_PRESETS = {
+  small: {
+    hint: '小型档：数据库 0.5 核 / 512M，后端 1 核 / 1G，前端 0.5 核 / 256M。已自动打开内存节约。',
+    dbCpu: '0.5', dbMem: '512M',
+    backendCpu: '1.0', backendMem: '1G',
+    frontendCpu: '0.5', frontendMem: '256M',
+    memorySaver: true
+  },
+  standard: {
+    hint: '推荐档：数据库 1 核 / 1G，后端 2 核 / 2G，前端 1 核 / 512M。',
+    dbCpu: '1.0', dbMem: '1G',
+    backendCpu: '2.0', backendMem: '2G',
+    frontendCpu: '1.0', frontendMem: '512M',
+    memorySaver: false
+  },
+  large: {
+    hint: '宽裕档：数据库 2 核 / 2G，后端 2 核 / 2G，前端 1 核 / 1G。',
+    dbCpu: '2.0', dbMem: '2G',
+    backendCpu: '2.0', backendMem: '2G',
+    frontendCpu: '1.0', frontendMem: '1G',
+    memorySaver: false
+  }
+};
+
+function wizardPane(step) {
+  return document.querySelector('.cg-ob__pane[data-step="' + step + '"]');
+}
+
+function setWizardNote(step, message, tone) {
+  var host = document.getElementById('cg-note-' + step);
+  if (!host) return;
+  host.innerHTML = '';
+  if (!message) return;
+  var note = document.createElement('p');
+  note.className = 'cg-ob-note' + (tone === 'error' ? ' is-error' : '');
+  note.textContent = message;
+  host.appendChild(note);
+}
+
+function renderWizardChrome(step, dir) {
+  var meta = WIZARD_META[step] || WIZARD_META.welcome;
+  if (step === 'done') {
+    meta = {
+      index: 0,
+      name: '',
+      back: wizardDoneFrom,
+      backLabel: wizardDoneFrom === 'advanced' ? '高级' : '限额'
+    };
+  }
+  var side = document.getElementById('cg-top-side');
+  var stepEl = document.getElementById('cg-top-step');
+  var nameEl = document.getElementById('cg-top-name');
+  var progressEl = document.getElementById('cg-top-progress');
+
+  if (side) {
+    if (meta.back) {
+      side.innerHTML =
+        '<div class="cg-ob-back">' +
+        '<button type="button" class="cg-ob-back__hit" data-wizard-back aria-label="返回' + meta.backLabel + '">' +
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>' +
+        '</button>' +
+        '<span class="cg-ob-back__label">' + meta.backLabel + '</span>' +
+        '</div>';
+    } else {
+      side.innerHTML = '<span class="cg-ob-brand">配置生成</span>';
+    }
+  }
+
+  if (stepEl && nameEl && progressEl) {
+    if (meta.index) {
+      stepEl.hidden = false;
+      nameEl.textContent = meta.name;
+      progressEl.textContent = meta.index + ' / ' + WIZARD_TOTAL;
+    } else {
+      stepEl.hidden = true;
+    }
+  }
+
+  WIZARD_FLOW.forEach(function (id) {
+    var pane = wizardPane(id);
+    if (!pane) return;
+    var active = id === step;
+    pane.hidden = !active;
+    if (active) {
+      pane.setAttribute('data-dir', dir || 'fade');
+    }
+  });
+}
+
+var topBarScroll = { el: null, fn: null };
+
+function unbindTopBarDense() {
+  if (topBarScroll.el && topBarScroll.fn) {
+    topBarScroll.el.removeEventListener('scroll', topBarScroll.fn);
+  }
+  topBarScroll.el = null;
+  topBarScroll.fn = null;
+}
+
+function bindTopBarDense(scroller) {
+  var card = document.getElementById('cg-card');
+  unbindTopBarDense();
+  if (!card) return;
+  function sync() {
+    var top = scroller ? scroller.scrollTop : 0;
+    var t = Math.min(1, Math.max(0, top / 128));
+    card.style.setProperty('--sob-top-dense', (t * t * (3 - 2 * t)).toFixed(3));
+  }
+  sync();
+  if (!scroller) return;
+  topBarScroll.el = scroller;
+  topBarScroll.fn = sync;
+  scroller.addEventListener('scroll', sync, { passive: true });
+}
+
+function goWizard(next, dir) {
+  if (WIZARD_FLOW.indexOf(next) < 0) return;
+  wizardStep = next;
+  renderWizardChrome(next, dir || 'fade');
+  var pane = wizardPane(next);
+  if (pane) pane.scrollTop = 0;
+  bindTopBarDense(pane);
+  if (next === 'site') syncSiteStepUi();
+}
+
+function selectedPanelIdFromUi() {
+  var selected = document.querySelector('input[name="panel-mode"]:checked');
+  var v = selected && selected.value;
+  if (v === 'baota' || v === 'generic' || v === '1panel') return v;
+  return '1panel';
+}
+
+function syncSiteStepUi() {
+  var profile = getPanelProfile(selectedPanelIdFromUi());
+  var mainInput = document.getElementById('main-domain');
+  var extraInput = document.getElementById('extra-domain');
+  var mainDomain = normalizeDomain(mainInput ? mainInput.value : '');
+  var extraDomain = normalizeDomain(extraInput ? extraInput.value : '');
+  var domainNote = document.getElementById('cg-site-domain-note');
+  var stepsEl = document.getElementById('cg-site-steps');
+  var pathEl = document.getElementById('cg-site-path');
+  var extraItem = document.getElementById('site-extra-upload');
+  var group = document.getElementById('site-upload-group');
+  var mainLabel = document.getElementById('site-main-upload-label');
+  var extraLabel = document.getElementById('site-extra-upload-label');
+  var shown = mainDomain || '这个域名';
+
+  if (domainNote) {
+    domainNote.textContent = '';
+    if (!mainDomain) {
+      domainNote.textContent = '请先回到上一步填写域名。';
+    } else {
+      domainNote.appendChild(document.createTextNode('当前域名  '));
+      var strong = document.createElement('strong');
+      strong.textContent = extraDomain ? mainDomain + '  ·  ' + extraDomain : mainDomain;
+      domainNote.appendChild(strong);
+    }
+  }
+  if (stepsEl) {
+    stepsEl.innerHTML = '';
+    (profile.siteSteps || []).forEach(function (text, index) {
+      var item = document.createElement('li');
+      var num = document.createElement('b');
+      num.textContent = String(index + 1);
+      var span = document.createElement('span');
+      span.textContent = String(text).split('{domain}').join(shown);
+      item.appendChild(num);
+      item.appendChild(span);
+      stepsEl.appendChild(item);
+    });
+  }
+  if (pathEl) {
+    var pathText = profile.siteConfPath
+      ? String(profile.siteConfPath).split('{domain}').join(mainDomain || '<domain>')
+      : '';
+    pathEl.hidden = !pathText;
+    pathEl.textContent = pathText;
+  }
+  if (mainLabel) mainLabel.textContent = (mainDomain || '主域名') + ' .conf';
+  if (extraLabel) extraLabel.textContent = (extraDomain || '额外域名') + ' .conf';
+  if (extraItem) extraItem.hidden = !extraDomain;
+  if (group) group.classList.toggle('is-single', !extraDomain);
+}
+
+function validateWizardStep(step) {
+  if (step === 'domain') {
+    var mainInput = document.getElementById('main-domain');
+    var extraInput = document.getElementById('extra-domain');
+    var mainDomain = normalizeDomain(mainInput ? mainInput.value : '');
+    var extraDomain = normalizeDomain(extraInput ? extraInput.value : '');
+    if (!mainDomain) {
+      setWizardNote('domain', '请先填写主域名', 'error');
+      if (mainInput) mainInput.focus();
+      return false;
+    }
+    if (!isValidDomain(mainDomain)) {
+      setWizardNote('domain', '主域名格式不对，写成 myriad.example.com 这样', 'error');
+      if (mainInput) mainInput.focus();
+      return false;
+    }
+    if (extraDomain && !isValidDomain(extraDomain)) {
+      setWizardNote('domain', '额外域名格式不对，没有就留空', 'error');
+      if (extraInput) extraInput.focus();
+      return false;
+    }
+    setWizardNote('domain', '');
+    return true;
+  }
+  if (step === 'database') {
+    var mode = document.querySelector('input[name="db-mode"]:checked');
+    var isExternal = mode && mode.value === 'external';
+    if (!isExternal) {
+      setWizardNote('database', '');
+      return true;
+    }
+    var hostInput = document.getElementById('db-host');
+    var passInput = document.getElementById('db-password');
+    if (!isValidDbHost(hostInput ? hostInput.value.trim() : '')) {
+      setWizardNote('database', '请填写外置库的主机地址', 'error');
+      if (hostInput) hostInput.focus();
+      return false;
+    }
+    if (!passInput || !passInput.value.trim()) {
+      setWizardNote('database', '请填写外置库密码', 'error');
+      if (passInput) passInput.focus();
+      return false;
+    }
+    setWizardNote('database', '');
+    return true;
+  }
+  return true;
+}
+
+function wizardNextFrom(step) {
+  if (step === 'welcome') return 'panel';
+  if (step === 'panel') return 'domain';
+  if (step === 'domain') return 'site';
+  if (step === 'site') return 'database';
+  if (step === 'database') return 'limits';
+  return '';
+}
+
 function disposePage() {
+  unbindTopBarDense();
   var list = pageLifecycle.unsubs.slice();
   pageLifecycle.unsubs = [];
   pageLifecycle.ready = false;
@@ -1668,6 +2100,79 @@ function initPage() {
   }
   pageLifecycle.ready = true;
 
+  var card = document.getElementById('cg-card');
+  function onWizardClick(event) {
+    var backBtn = event.target.closest('[data-wizard-back]');
+    if (backBtn) {
+      event.preventDefault();
+      var backTo = (WIZARD_META[wizardStep] || {}).back;
+      if (backTo) goWizard(backTo, 'back');
+      return;
+    }
+    var nextBtn = event.target.closest('[data-wizard-next]');
+    if (!nextBtn) return;
+    event.preventDefault();
+    if (!validateWizardStep(wizardStep)) return;
+    var next = wizardNextFrom(wizardStep);
+    if (next) goWizard(next, 'forward');
+  }
+  if (card) pageListen(card, 'click', onWizardClick);
+
+  var domainForm = wizardPane('domain');
+  if (domainForm) {
+    pageListen(domainForm, 'submit', function (event) {
+      event.preventDefault();
+    });
+    pageListen(domainForm, 'keydown', function (event) {
+      if (event.key !== 'Enter' || event.target.tagName === 'TEXTAREA') return;
+      event.preventDefault();
+      if (!validateWizardStep('domain')) return;
+      goWizard('site', 'forward');
+    });
+  }
+
+  var databaseForm = wizardPane('database');
+  if (databaseForm) {
+    pageListen(databaseForm, 'submit', function (event) {
+      event.preventDefault();
+    });
+    pageListen(databaseForm, 'keydown', function (event) {
+      if (event.key !== 'Enter' || event.target.tagName === 'TEXTAREA') return;
+      event.preventDefault();
+      if (!validateWizardStep('database')) return;
+      goWizard('limits', 'forward');
+    });
+  }
+
+  var limitsPane = wizardPane('limits');
+  if (limitsPane) {
+    pageListen(limitsPane, 'keydown', function (event) {
+      if (event.key !== 'Enter' || event.target.tagName === 'TEXTAREA') return;
+      event.preventDefault();
+      var generateBtn = document.getElementById('btn-generate-all');
+      if (generateBtn && !generateBtn.disabled) generateBtn.click();
+    });
+  }
+
+  var gotoAdvancedBtn = document.getElementById('btn-goto-advanced');
+  if (gotoAdvancedBtn) {
+    pageListen(gotoAdvancedBtn, 'click', function () {
+      goWizard('advanced', 'forward');
+    });
+  }
+
+  var advancedPane = wizardPane('advanced');
+  if (advancedPane) {
+    pageListen(advancedPane, 'keydown', function (event) {
+      if (event.key !== 'Enter' || event.target.tagName === 'TEXTAREA') return;
+      event.preventDefault();
+      var generateBtn = document.getElementById('btn-generate-advanced');
+      if (generateBtn && !generateBtn.disabled) generateBtn.click();
+    });
+  }
+
+  goWizard('welcome', 'fade');
+
   var mainDomainInput = document.getElementById('main-domain');
   var extraDomainInput = document.getElementById('extra-domain');
   var dbPasswordInput = document.getElementById('db-password');
@@ -1680,17 +2185,13 @@ function initPage() {
   var dbHostInput = document.getElementById('db-host');
   var dbPortInput = document.getElementById('db-port');
   var dbSslmodeSelect = document.getElementById('db-sslmode');
-  var dbModeBundledFields = document.getElementById('db-mode-bundled-fields');
   var dbModeExternalFields = document.getElementById('db-mode-external-fields');
   var dbResourceGroup = document.getElementById('db-resource-group');
   var dbModeRadios = document.querySelectorAll('input[name="db-mode"]');
 
   var genDbPasswordBtn = document.getElementById('gen-db-password');
-  var genJwtSecretBtn = document.getElementById('gen-jwt-secret');
-  var genUpdateTokenBtn = document.getElementById('gen-update-token');
-  var genGatewaySecretBtn = document.getElementById('gen-updater-gateway-secret');
-  var genSetupSecretBtn = document.getElementById('gen-setup-secret');
   var generateAllBtn = document.getElementById('btn-generate-all');
+  var generateAdvancedBtn = document.getElementById('btn-generate-advanced');
 
   var uploadNginx = document.getElementById('upload-nginx-conf');
   var fileNginx = document.getElementById('file-nginx-conf');
@@ -1729,15 +2230,8 @@ function initPage() {
     return (selected && selected.value === 'external') ? 'external' : 'bundled';
   }
 
-  function getSelectedPanelId() {
-    var selected = document.querySelector('input[name="panel-mode"]:checked');
-    var v = selected && selected.value;
-    if (v === 'baota' || v === 'generic' || v === '1panel') return v;
-    return '1panel';
-  }
-
   function syncPanelModeUi() {
-    state.panelId = getSelectedPanelId();
+    state.panelId = selectedPanelIdFromUi();
     document.querySelectorAll('.panel-mode-option').forEach(function (label) {
       var input = label.querySelector('input[name="panel-mode"]');
       if (!input) return;
@@ -1745,16 +2239,21 @@ function initPage() {
     });
     var profile = getPanelProfile(state.panelId);
     var info = document.getElementById('panel-mode-hint');
-    if (info) info.textContent = profile.resultsIntro;
+    if (info) info.textContent = profile.wizardHint || profile.resultsIntro;
   }
 
   function syncDbModeUi() {
     var mode = getSelectedDbMode();
     state.dbMode = mode;
     var isExternal = mode === 'external';
-    if (dbModeBundledFields) dbModeBundledFields.hidden = isExternal;
     if (dbModeExternalFields) dbModeExternalFields.hidden = !isExternal;
     if (dbResourceGroup) dbResourceGroup.hidden = isExternal;
+    var dbVersionField = document.getElementById('db-version-field');
+    if (dbVersionField) dbVersionField.hidden = isExternal;
+    var bundledHint = document.getElementById('db-bundled-hint');
+    if (bundledHint) bundledHint.hidden = isExternal;
+    var passwordField = document.getElementById('db-password-field');
+    if (passwordField) passwordField.hidden = !isExternal;
     // Segmented control active styles
     document.querySelectorAll('.db-mode-option').forEach(function(label) {
       var input = label.querySelector('input[name="db-mode"]');
@@ -1778,6 +2277,82 @@ function initPage() {
     syncDbModeUi();
   }
 
+  function applyLimitPreset(preset) {
+    var spec = LIMIT_PRESETS[preset];
+    if (!spec) return;
+    function setVal(id, value) {
+      var el = document.getElementById(id);
+      if (el) el.value = value;
+    }
+    setVal('db-cpu-limit', spec.dbCpu);
+    setVal('db-mem-limit', spec.dbMem);
+    setVal('backend-cpu-limit', spec.backendCpu);
+    setVal('backend-mem-limit', spec.backendMem);
+    setVal('frontend-cpu-limit', spec.frontendCpu);
+    setVal('frontend-mem-limit', spec.frontendMem);
+    var saver = document.getElementById('memory-saver');
+    if (saver) saver.checked = !!spec.memorySaver;
+  }
+
+  function syncLimitPresetUi(mode) {
+    var customFields = document.getElementById('limit-custom-fields');
+    var hint = document.getElementById('limit-preset-hint');
+    var customBtn = document.getElementById('limit-preset-custom');
+    var isCustom = mode === 'custom';
+    if (customFields) customFields.hidden = !isCustom;
+    if (customBtn) customBtn.setAttribute('aria-pressed', isCustom ? 'true' : 'false');
+    document.querySelectorAll('.limit-preset-toggle .cg-choice__card').forEach(function (label) {
+      var input = label.querySelector('input[name="limit-preset"]');
+      if (!input) return;
+      if (isCustom) {
+        input.checked = false;
+        label.classList.remove('is-active');
+      } else {
+        label.classList.toggle('is-active', input.checked);
+      }
+    });
+    if (!isCustom) {
+      if (customBtn) customBtn.dataset.lastPreset = mode;
+      applyLimitPreset(mode);
+      if (hint && LIMIT_PRESETS[mode]) hint.textContent = LIMIT_PRESETS[mode].hint;
+    } else if (hint) {
+      hint.textContent = '自己填每个服务的 CPU 和内存。内存写成 512M、2G 这样。';
+    }
+    syncDbModeUi();
+  }
+
+  function getSelectedLimitPreset() {
+    if (document.getElementById('limit-preset-custom') &&
+        document.getElementById('limit-preset-custom').getAttribute('aria-pressed') === 'true') {
+      return 'custom';
+    }
+    var selected = document.querySelector('input[name="limit-preset"]:checked');
+    return (selected && selected.value) || 'standard';
+  }
+
+  var limitPresetRadios = document.querySelectorAll('input[name="limit-preset"]');
+  if (limitPresetRadios && limitPresetRadios.length) {
+    limitPresetRadios.forEach(function (radio) {
+      pageListen(radio, 'change', function () {
+        syncLimitPresetUi(radio.value);
+      });
+    });
+  }
+  var customLimitBtn = document.getElementById('limit-preset-custom');
+  if (customLimitBtn) {
+    pageListen(customLimitBtn, 'click', function () {
+      if (customLimitBtn.getAttribute('aria-pressed') === 'true') {
+        var last = customLimitBtn.dataset.lastPreset || 'standard';
+        var radio = document.querySelector('input[name="limit-preset"][value="' + last + '"]');
+        if (radio) radio.checked = true;
+        syncLimitPresetUi(last);
+        return;
+      }
+      syncLimitPresetUi('custom');
+    });
+  }
+  syncLimitPresetUi(getSelectedLimitPreset());
+
   function markTagManual(input) {
     if (!input) return;
     input.dataset.autoFilled = 'false';
@@ -1796,44 +2371,10 @@ function initPage() {
     });
   }
 
-  pageListen(genDbPasswordBtn, 'click', function() {
-    dbPasswordInput.value = generatePassword();
-    animateButton(genDbPasswordBtn);
-  });
-
-  pageListen(genJwtSecretBtn, 'click', function() {
-    jwtSecretInput.value = generateJwtSecret();
-    animateButton(genJwtSecretBtn);
-  });
-
-  pageListen(genUpdateTokenBtn, 'click', function() {
-    updateTokenInput.value = generateUpdateToken();
-    animateButton(genUpdateTokenBtn);
-  });
-
-  if (genGatewaySecretBtn && gatewaySecretInput) {
-    pageListen(genGatewaySecretBtn, 'click', function() {
-      gatewaySecretInput.value = generateUpdaterGatewaySecret();
-      animateButton(genGatewaySecretBtn);
-    });
-  }
-
-  if (genSetupSecretBtn && setupSecretInput) {
-    pageListen(genSetupSecretBtn, 'click', function() {
-      setupSecretInput.value = generateSetupSecret();
-      animateButton(genSetupSecretBtn);
-    });
-  }
-
-  var copySetupSecretBtn = document.getElementById('copy-setup-secret');
-  if (copySetupSecretBtn && setupSecretInput) {
-    pageListen(copySetupSecretBtn, 'click', function() {
-      var value = setupSecretInput.value.trim();
-      if (!value) {
-        showNotification('还没有安装暗号，先点生成', 'error');
-        return;
-      }
-      copyToClipboard(value, copySetupSecretBtn);
+  if (genDbPasswordBtn && dbPasswordInput) {
+    pageListen(genDbPasswordBtn, 'click', function() {
+      dbPasswordInput.value = generatePassword();
+      animateButton(genDbPasswordBtn);
     });
   }
 
@@ -1847,6 +2388,19 @@ function initPage() {
         return;
       }
       copyToClipboard(value, copySetupSecretResultBtn);
+    });
+  }
+
+  var copySetupSecretLinkBtn = document.getElementById('copy-setup-secret-link');
+  if (copySetupSecretLinkBtn) {
+    pageListen(copySetupSecretLinkBtn, 'click', function() {
+      var node = document.getElementById('setup-secret-link-value');
+      var value = ((node && node.textContent) || '').trim();
+      if (!value) {
+        showNotification('还没有安装链接', 'error');
+        return;
+      }
+      copyToClipboard(value, copySetupSecretLinkBtn);
     });
   }
 
@@ -1877,9 +2431,10 @@ function initPage() {
     });
   }
 
-  pageListen(generateAllBtn, 'click', async function() {
-    if (generateAllBtn.disabled) return;
+  async function runGenerateAll() {
+    if (!generateAllBtn || generateAllBtn.disabled) return;
     generateAllBtn.disabled = true;
+    if (generateAdvancedBtn) generateAdvancedBtn.disabled = true;
 
     try {
       var mainDomain = normalizeDomain(mainDomainInput.value);
@@ -1893,7 +2448,7 @@ function initPage() {
       var dbUser = dbUserInput.value.trim();
       var dbMode = getSelectedDbMode();
       var isExternal = dbMode === 'external';
-      state.panelId = getSelectedPanelId();
+      state.panelId = selectedPanelIdFromUi();
 
       if (!mainDomain) {
         showNotification('请输入主域名', 'error');
@@ -2066,12 +2621,14 @@ function initPage() {
       state.channel = channelSelect.value || 'stable';
       state.cosignVerify = cosignSelect.value || 'strict';
 
-      state.dbCpuLimit = (dbCpuLimitInput && dbCpuLimitInput.value.trim()) || '2.0';
-      state.dbMemLimit = (dbMemLimitInput && dbMemLimitInput.value.trim()) || '2G';
+      state.dbCpuLimit = (dbCpuLimitInput && dbCpuLimitInput.value.trim()) || '1.0';
+      state.dbMemLimit = (dbMemLimitInput && dbMemLimitInput.value.trim()) || '1G';
       state.backendCpuLimit = backendCpuLimitInput.value.trim() || '2.0';
-      state.backendMemLimit = backendMemLimitInput.value.trim() || '4G';
-      state.frontendCpuLimit = frontendCpuLimitInput.value.trim() || '2.0';
-      state.frontendMemLimit = frontendMemLimitInput.value.trim() || '2G';
+      state.backendMemLimit = backendMemLimitInput.value.trim() || '2G';
+      state.frontendCpuLimit = frontendCpuLimitInput.value.trim() || '1.0';
+      state.frontendMemLimit = frontendMemLimitInput.value.trim() || '512M';
+      var memorySaverEl = document.getElementById('memory-saver');
+      state.memoryProfile = (memorySaverEl && memorySaverEl.checked) ? 'saver' : 'default';
 
       var cpuValues = isExternal
         ? [state.backendCpuLimit, state.frontendCpuLimit]
@@ -2176,41 +2733,55 @@ function initPage() {
       }
     } finally {
       generateAllBtn.disabled = false;
+      if (generateAdvancedBtn) generateAdvancedBtn.disabled = false;
     }
-  });
+  }
 
-  document.querySelectorAll('.btn-copy').forEach(function(btn) {
-    pageListen(btn, 'click', function() {
-      var target = btn.getAttribute('data-target');
-      var content = document.getElementById('result-' + target).textContent;
-      copyToClipboard(content, btn);
-    });
-  });
+  pageListen(generateAllBtn, 'click', function () { void runGenerateAll(); });
+  if (generateAdvancedBtn) {
+    pageListen(generateAdvancedBtn, 'click', function () { void runGenerateAll(); });
+  }
 
-  document.querySelectorAll('.btn-download').forEach(function(btn) {
-    pageListen(btn, 'click', function() {
-      var target = btn.getAttribute('data-target');
-      var content = document.getElementById('result-' + target).textContent;
-      var filename = btn.getAttribute('data-filename');
-
-      if (target === 'main-nginx') {
-        filename = state.mainDomain + '.conf';
-      } else if (target === 'extra-nginx') {
-        filename = (state.extraDomain || 'extra') + '.conf';
+  var resultsHost = document.getElementById('results-section') || card;
+  if (resultsHost) {
+    pageListen(resultsHost, 'click', function (event) {
+      var header = event.target.closest('.result-header');
+      if (header && !event.target.closest('button')) {
+        var resultCard = header.closest('.result-card');
+        if (resultCard) resultCard.classList.toggle('is-open');
+        return;
       }
-
-      downloadFile(content, filename);
+      var copyTextBtn = event.target.closest('[data-copy-text]');
+      if (copyTextBtn) {
+        copyToClipboard(copyTextBtn.getAttribute('data-copy-text') || '', copyTextBtn);
+        return;
+      }
+      var copyBtn = event.target.closest('.btn-copy');
+      if (copyBtn) {
+        var copyTarget = copyBtn.getAttribute('data-target');
+        var copyNode = document.getElementById('result-' + copyTarget);
+        if (copyNode) copyToClipboard(copyNode.textContent, copyBtn);
+        return;
+      }
+      var downBtn = event.target.closest('.btn-download');
+      if (downBtn) {
+        var downTarget = downBtn.getAttribute('data-target');
+        var downNode = document.getElementById('result-' + downTarget);
+        if (!downNode) return;
+        var filename = downBtn.getAttribute('data-filename');
+        if (downTarget === 'main-nginx') filename = state.mainDomain + '.conf';
+        else if (downTarget === 'extra-nginx') filename = (state.extraDomain || 'extra') + '.conf';
+        downloadFile(downNode.textContent, filename);
+      }
     });
-  });
+  }
 
   // 自定义下拉（系统 option 列表无法按主题着色）
   enhanceAllSelects();
 
-  // 自动生成密钥
-  genDbPasswordBtn.click();
-  genJwtSecretBtn.click();
-  genUpdateTokenBtn.click();
-  if (genGatewaySecretBtn) genGatewaySecretBtn.click();
+  if (jwtSecretInput) jwtSecretInput.value = generateJwtSecret();
+  if (updateTokenInput) updateTokenInput.value = generateUpdateToken();
+  if (gatewaySecretInput) gatewaySecretInput.value = generateUpdaterGatewaySecret();
 
   // 启动时解析 Docker Hub 最新 versioned tag（不写死版本号）
   refreshLatestTags(tagInputs, channelSelect, { notify: false });
@@ -2335,10 +2906,15 @@ function hideUploadSuccess(uploadBox) {
 }
 
 function animateButton(btn) {
-  btn.style.transform = 'rotate(180deg)';
-  setTimeout(function() {
-    btn.style.transform = '';
-  }, 300);
+  if (!btn) return;
+  btn.classList.remove('is-spinning');
+  void btn.offsetWidth;
+  btn.classList.add('is-spinning');
+  var svg = btn.querySelector('svg');
+  if (!svg) return;
+  svg.addEventListener('animationend', function () {
+    btn.classList.remove('is-spinning');
+  }, { once: true });
 }
 
 // ========================================
@@ -2489,6 +3065,7 @@ function generateConfigs() {
     UPDATER_TAG: state.updaterTag,
     CHANNEL: state.channel,
     COSIGN_VERIFY: state.cosignVerify,
+    MYRIAD_MEMORY_PROFILE: state.memoryProfile === 'saver' ? 'saver' : 'default',
     COSIGN_INSECURE_HINT: cosignInsecureHint,
     PANEL_LABEL: panel.label,
     PANEL_DEPLOY_SECTION: buildPanelDeploySection(
@@ -2629,10 +3206,10 @@ function generateConfigs() {
   if (envCopyBtn) {
     var label = panel.envCopyLabel || '复制';
     envCopyBtn.innerHTML =
-      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
       '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>' +
       '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>' +
-      '</svg> ' + label;
+      '</svg><span>' + label + '</span>';
   }
 
   var extraResult = document.getElementById('result-extra-nginx');
@@ -2651,11 +3228,23 @@ function generateConfigs() {
   if (reminder && reminderValue && state.setupSecret) {
     reminderValue.textContent = state.setupSecret;
     reminder.hidden = false;
+    var linkValue = document.getElementById('setup-secret-link-value');
+    if (linkValue && state.mainDomain) {
+      linkValue.textContent =
+        'https://' + state.mainDomain + '/#setup_secret=' + encodeURIComponent(state.setupSecret);
+    }
   }
 
-  var resultsSection = document.getElementById('results-section');
-  resultsSection.hidden = false;
-  resultsSection.scrollIntoView({ behavior: 'smooth' });
+  renderDoneGuide(panelId, {
+    domain: state.mainDomain,
+    extraDomain: state.extraDomain,
+    httpPort: state.httpPort,
+    httpBind: state.httpBindAddress,
+    external: isExternal
+  });
+
+  wizardDoneFrom = wizardStep === 'advanced' ? 'advanced' : 'limits';
+  goWizard('done', 'forward');
 
   showNotification('已生成。请先复制安装暗号，创建所有者时要填。', 'success');
 }
@@ -2669,7 +3258,7 @@ function copyToClipboard(text, btn) {
 
   function onSuccess() {
     btn.classList.add('copied');
-    btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg> 已复制';
+    btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg><span>已复制</span>';
 
     setTimeout(function() {
       btn.classList.remove('copied');
@@ -2779,13 +3368,11 @@ async function showNotification(message, type) {
 
 var CHEVRON_SVG =
   '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>';
-var CHECK_SVG =
-  '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>';
 
 function closeAllCustomSelects(exceptRoot) {
   document.querySelectorAll('.cg-select.is-open').forEach(function (root) {
     if (exceptRoot && root === exceptRoot) return;
-    root.classList.remove('is-open');
+    root.classList.remove('is-open', 'is-up');
     var menu = root.querySelector('.cg-select-menu');
     var trigger = root.querySelector('.cg-select-trigger');
     if (menu) menu.hidden = true;
@@ -2837,7 +3424,13 @@ function enhanceNativeSelect(select) {
     trigger.setAttribute('aria-labelledby', select.getAttribute('aria-labelledby'));
   } else if (select.id) {
     var lab = document.querySelector('label[for="' + select.id + '"]');
-    if (lab && lab.id) trigger.setAttribute('aria-labelledby', lab.id);
+    var title = !lab && select.closest('.cg-ob-field');
+    if (title) title = title.querySelector('.cg-ob-field__label');
+    var named = (lab && lab.id) ? lab : title;
+    if (named) {
+      if (!named.id) named.id = select.id + '-label';
+      trigger.setAttribute('aria-labelledby', named.id);
+    }
   }
 
   var labelSpan = document.createElement('span');
@@ -2869,13 +3462,7 @@ function enhanceNativeSelect(select) {
           btn.disabled = true;
           btn.setAttribute('aria-disabled', 'true');
         }
-        var text = document.createElement('span');
-        text.textContent = opt.textContent;
-        var check = document.createElement('span');
-        check.className = 'cg-select-option-check';
-        check.innerHTML = CHECK_SVG;
-        btn.appendChild(text);
-        btn.appendChild(check);
+        btn.textContent = opt.textContent;
         pageListen(btn, 'click', function (e) {
           e.preventDefault();
           e.stopPropagation();
@@ -2912,10 +3499,21 @@ function enhanceNativeSelect(select) {
     root.classList.add('is-open');
     menu.hidden = false;
     trigger.setAttribute('aria-expanded', 'true');
+    var triggerRect = trigger.getBoundingClientRect();
+    var spaceBelow = window.innerHeight - triggerRect.bottom;
+    var spaceAbove = triggerRect.top;
+    var need = Math.min(240, menu.scrollHeight + 12);
+    root.classList.toggle('is-up', spaceBelow < need && spaceAbove > spaceBelow);
     var selected = menu.querySelector('.cg-select-option.is-selected');
     if (selected) {
       selected.classList.add('is-active');
-      try { selected.scrollIntoView({ block: 'nearest' }); } catch (e) { /* ignore */ }
+      var menuRect = menu.getBoundingClientRect();
+      var selRect = selected.getBoundingClientRect();
+      if (selRect.top < menuRect.top) {
+        menu.scrollTop -= menuRect.top - selRect.top;
+      } else if (selRect.bottom > menuRect.bottom) {
+        menu.scrollTop += selRect.bottom - menuRect.bottom;
+      }
     }
   }
 

--- a/apps/com.myriad.config-generator/manifest.json
+++ b/apps/com.myriad.config-generator/manifest.json
@@ -1,17 +1,17 @@
 {
   "id": "com.myriad.config-generator",
   "name": "Myriad 安装配置生成",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "minSystemVersion": "0.2.1",
-  "description": "生成 Compose、.env 与 Nginx 部署配置（1Panel / 宝塔 / CLI · 整站反代 + 联邦）",
+  "description": "分步生成 Compose、.env 与 Nginx（1Panel / 宝塔 / 命令行）",
   "locales": {
     "en-US": {
       "name": "Myriad Install Config Generator",
-      "description": "Generate Compose, .env, and Nginx configs for 1Panel, Baota, or CLI (site-wide reverse proxy + federation)"
+      "description": "Step-by-step Compose, .env, and Nginx files for 1Panel, Baota, or CLI"
     },
     "ja-JP": {
       "name": "Myriad インストール設定ジェネレーター",
-      "description": "1Panel / 宝塔 / CLI 向け Compose・.env・Nginx 設定を生成（サイト全体リバプロ + フェデレーション）"
+      "description": "ステップ形式で 1Panel / 宝塔 / CLI 向け Compose・.env・Nginx を生成"
     }
   },
   "category": "developer",

--- a/apps/com.myriad.config-generator/page.css
+++ b/apps/com.myriad.config-generator/page.css
@@ -1,70 +1,96 @@
+/* ============================================
+   配置生成向导 — 铺满宿主窗口
+   沙箱做不了真透明：背景用壁纸主色做一层淡渐变，不再套浮卡。
+   ============================================ */
+
+@property --sob-top-dense {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0;
+}
+
 :root {
-  --config-primary: var(--tapp-primary, #6366f1);
-  --config-primary-rgb: var(--tapp-primary-rgb, 99, 102, 241);
-  --config-secondary: color-mix(in srgb, var(--config-primary) 80%, #8b5cf6);
-  --config-accent: color-mix(in srgb, var(--config-primary) 60%, #a78bfa);
-  --config-success: #10b981;
-  --config-error: #ef4444;
-  --config-warning: #f59e0b;
-  --config-bg-solid: #f8f9fa;
-  --config-surface: rgba(255, 255, 255, 0.85);
-  --config-surface-elevated: rgba(255, 255, 255, 0.95);
-  
-  /* 文字色 */
-  --config-text: #1f2937;
-  --config-text-secondary: #6b7280;
-  --config-text-muted: #9ca3af;
-  
-  /* 边框色 */
-  --config-border: rgba(0, 0, 0, 0.08);
-  --config-border-strong: rgba(0, 0, 0, 0.15);
-  
-  /* 光效色 */
-  --config-glow: rgba(var(--config-primary-rgb), 0.15);
-  --config-glow-strong: rgba(var(--config-primary-rgb), 0.25);
-  
-  /* 输入框 */
-  --config-input-bg: rgba(0, 0, 0, 0.03);
-  
-  /* 代码块 */
-  --config-code-bg: rgba(0, 0, 0, 0.04);
-  
-  /* 尺寸变量 */
-  --config-radius: 20px;
-  --config-radius-lg: 24px;
-  --config-radius-sm: 12px;
-  --config-radius-xs: 8px;
-  
-  /* 阴影 */
-  --config-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
-  --config-shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.15);
-  --config-shadow-glow: 0 0 20px rgba(var(--config-primary-rgb), 0.2);
-  
-  /* 过渡 */
-  --config-transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  --config-primary: var(--tapp-primary, var(--color-primary, #7c6ee6));
+  --sob-canvas: var(--bg-primary, var(--tapp-bg, #f6f7fb));
+  --sob-fill-strong: color-mix(in srgb, var(--config-primary) 14%, var(--sob-canvas));
 }
 
-/* 深色模式变量 */
-.dark {
-  --config-bg-solid: #0a0a0a;
-  --config-surface: rgba(0, 0, 0, 0.85);
-  --config-surface-elevated: rgba(23, 23, 23, 0.95);
-  --config-text: #f3f4f6;
-  --config-text-secondary: #9ca3af;
-  --config-text-muted: #6b7280;
-  --config-border: rgba(255, 255, 255, 0.1);
-  --config-border-strong: rgba(255, 255, 255, 0.15);
-  --config-glow: rgba(var(--config-primary-rgb), 0.2);
-  --config-glow-strong: rgba(var(--config-primary-rgb), 0.35);
-  --config-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-  --config-shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.5);
-  --config-input-bg: rgba(255, 255, 255, 0.05);
-  --config-code-bg: rgba(0, 0, 0, 0.3);
+.dark,
+html.dark,
+body.dark {
+  color-scheme: dark;
+  --sob-canvas: var(--bg-primary, var(--tapp-bg, #101014));
+  --sob-fill-strong: color-mix(in srgb, var(--config-primary) 24%, var(--sob-canvas));
 }
 
-/* ========================================
-   分层架构 - 背景层
-   ======================================== */
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+/* ---------- 令牌 ---------- */
+
+.cg-ob {
+  --sob-ink: color-mix(in srgb, var(--text-primary, #171923) 92%, transparent);
+  --sob-muted: color-mix(in srgb, var(--text-secondary, #667085) 82%, transparent);
+  --sob-line: color-mix(in srgb, var(--sob-ink) 14%, transparent);
+  --sob-accent: var(--config-primary);
+  --sob-dur-fast: 160ms;
+  --sob-dur-base: 280ms;
+  --sob-dur-slow: 420ms;
+  --sob-dur-enter: 480ms;
+  --sob-stagger: 42ms;
+  --sob-shift-sm: 10px;
+  --sob-shift-x: 22px;
+  --sob-scale-press: 0.94;
+  --sob-scale-hover: 1.04;
+  --sob-lift: -2px;
+  --sob-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --sob-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --sob-ease-glide: cubic-bezier(0.32, 0.72, 0, 1);
+  --sob-t-fill:
+    background-color var(--sob-dur-fast) var(--sob-ease-glide),
+    border-color var(--sob-dur-fast) var(--sob-ease-glide),
+    color var(--sob-dur-fast) var(--sob-ease-glide);
+  --sob-t-elevate:
+    transform var(--sob-dur-base) var(--sob-ease-spring),
+    box-shadow var(--sob-dur-base) var(--sob-ease-glide),
+    border-color var(--sob-dur-fast) var(--sob-ease-glide),
+    filter var(--sob-dur-fast) var(--sob-ease-glide);
+  --sob-t-control:
+    border-color var(--sob-dur-fast) var(--sob-ease-glide),
+    box-shadow var(--sob-dur-base) var(--sob-ease-glide),
+    background-color var(--sob-dur-fast) var(--sob-ease-glide);
+  --sob-liq-border: color-mix(in srgb, var(--sob-line) 70%, transparent);
+
+  position: relative;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  color: var(--sob-ink);
+}
+
+.dark .cg-ob,
+html.dark .cg-ob,
+body.dark .cg-ob {
+  --sob-ink: color-mix(in srgb, var(--text-primary, #f3f4f6) 92%, transparent);
+  --sob-muted: color-mix(in srgb, var(--text-secondary, #9ca3af) 86%, transparent);
+  --sob-line: color-mix(in srgb, var(--config-primary) 26%, var(--sob-canvas));
+  --sob-liq-border: color-mix(in srgb, var(--config-primary) 26%, var(--sob-canvas));
+}
+
+/* ---------- 背景：壁纸主色淡渐变，不装透明 ---------- */
 
 #tapp-background {
   position: absolute;
@@ -72,713 +98,1459 @@
   z-index: 0;
   overflow: hidden;
   pointer-events: none;
+  background:
+    radial-gradient(
+      90% 70% at 12% -8%,
+      color-mix(in srgb, var(--config-primary) 22%, transparent),
+      transparent 58%
+    ),
+    radial-gradient(
+      80% 60% at 108% 108%,
+      color-mix(in srgb, var(--config-primary) 14%, transparent),
+      transparent 52%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--config-primary) 6%, var(--sob-canvas)),
+      var(--sob-canvas) 46%
+    );
 }
 
-/* 背景基础 */
-.page-bg-base {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 50%, #f8f9fa 100%);
+.dark #tapp-background,
+html.dark #tapp-background {
+  background:
+    radial-gradient(
+      90% 70% at 12% -8%,
+      color-mix(in srgb, var(--config-primary) 28%, transparent),
+      transparent 58%
+    ),
+    radial-gradient(
+      80% 60% at 108% 108%,
+      color-mix(in srgb, var(--config-primary) 16%, transparent),
+      transparent 52%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--config-primary) 10%, var(--sob-canvas)),
+      var(--sob-canvas) 48%
+    );
 }
-
-.dark .page-bg-base {
-  background: linear-gradient(135deg, #0a0a0a 0%, #171717 50%, #0a0a0a 100%);
-}
-
-/* 背景光效装饰 */
-.page-bg-glow {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(80px);
-  opacity: 0.3;
-  animation: page-glow-breathe 6s ease-in-out infinite;
-  background: var(--config-primary);
-}
-
-.page-bg-glow-1 {
-  width: 400px;
-  height: 400px;
-  top: -100px;
-  right: -100px;
-}
-
-.page-bg-glow-2 {
-  width: 300px;
-  height: 300px;
-  bottom: -50px;
-  left: -50px;
-  background: var(--config-secondary);
-  animation-delay: 3s;
-}
-
-@keyframes page-glow-breathe {
-  0%, 100% { opacity: 0.25; transform: scale(1); }
-  50% { opacity: 0.4; transform: scale(1.15); }
-}
-
-/* ========================================
-   分层架构 - 内容层
-   ======================================== */
 
 #tapp-content {
   position: absolute;
   inset: 0;
   z-index: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-#tapp-content::-webkit-scrollbar {
-  width: 6px;
-}
-
-#tapp-content::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-#tapp-content::-webkit-scrollbar-thumb {
-  background: rgba(var(--config-primary-rgb), 0.2);
-  border-radius: 3px;
-}
-
-#tapp-content::-webkit-scrollbar-thumb:hover {
-  background: rgba(var(--config-primary-rgb), 0.4);
-}
-
-/* ========================================
-   Page 内容区
-   ======================================== */
-
-.page-content {
-  position: relative;
-  max-width: 840px;
-  margin: 0 auto;
-  padding: 20px 20px 48px;
-}
-
-/* ========================================
-   Header - 状态胶囊
-   ======================================== */
-
-.page-header {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 18px 12px 12px;
-  margin-bottom: 20px;
-  background: var(--config-surface-elevated);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
-  border: 1px solid var(--config-border);
-  border-radius: 50px;
-  box-shadow: var(--config-shadow-lg);
-  transition: var(--config-transition);
-}
-
-.header-icon {
-  width: 36px;
-  height: 36px;
-  background: linear-gradient(135deg, var(--config-primary), var(--config-secondary));
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  color: #fff;
-  box-shadow: 0 4px 12px rgba(var(--config-primary-rgb), 0.28);
-}
-
-.header-icon svg {
-  display: block;
-  flex-shrink: 0;
-}
-
-.header-info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-.header-title {
-  margin: 0;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--config-text);
-  letter-spacing: -0.01em;
-  line-height: 1.3;
-}
-
-.header-subtitle {
-  margin: 0;
-  font-size: 12px;
-  color: var(--config-text-secondary);
-  line-height: 1.35;
-}
-
-/* ========================================
-   Form Sections - 卡片式
-   ======================================== */
-
-.config-form {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.form-section {
-  background: var(--config-surface);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
-  border: 1px solid var(--config-border);
-  border-radius: var(--config-radius);
-  padding: 20px;
-  box-shadow: var(--config-shadow);
-  transition: border-color var(--config-transition), box-shadow var(--config-transition);
-}
-
-.form-section:hover {
-  border-color: rgba(var(--config-primary-rgb), 0.22);
-  box-shadow: var(--config-shadow), 0 0 0 1px rgba(var(--config-primary-rgb), 0.04);
-}
-
-.section-title {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 0 0 8px;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--config-text);
-  letter-spacing: -0.01em;
-}
-
-.section-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  flex-shrink: 0;
-  border-radius: 9px;
-  background: rgba(var(--config-primary-rgb), 0.1);
-  color: var(--config-primary);
-  border: 1px solid rgba(var(--config-primary-rgb), 0.14);
-}
-
-.section-icon svg {
-  display: block;
-}
-
-.section-desc {
-  margin: 0 0 16px;
-  font-size: 13px;
-  color: var(--config-text-secondary);
-  line-height: 1.55;
-}
-
-/* ========================================
-   高级选项折叠面板
-   ======================================== */
-
-.advanced-panel {
-  padding: 0;
   overflow: hidden;
 }
 
-.advanced-panel > .advanced-summary {
-  list-style: none;
-  cursor: pointer;
+/* ---------- 满窗壳：不是浮卡 ---------- */
+
+.cg-ob__card {
+  --sob-pad: clamp(20px, 2.6vw, 36px);
+  --sob-pad-x: clamp(24px, 3.2vw, 48px);
+  --sob-top-h: calc((var(--sob-pad) - 6px) + 34px + 14px);
+  --sob-label-gap: 10px;
+  --sob-top-dense: 0;
+
+  transition: --sob-top-dense 140ms ease-out;
+  position: relative;
+  z-index: 1;
   display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+/* ---------- 顶栏 ---------- */
+
+.cg-ob-top {
+  position: absolute;
+  z-index: 7;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: flex;
+  min-height: 40px;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 16px 20px;
+  padding: calc(var(--sob-pad) - 6px) var(--sob-pad-x) 14px;
+  isolation: isolate;
+  pointer-events: none;
+}
+
+.cg-ob-top::before {
+  content: '';
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: calc(100% + clamp(28px, 4.2vh, 48px));
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--sob-canvas) calc(48% + 44% * var(--sob-top-dense, 0)), transparent) 0%,
+    color-mix(in srgb, var(--sob-canvas) calc(24% + 40% * var(--sob-top-dense, 0)), transparent) 34%,
+    color-mix(in srgb, var(--sob-canvas) calc(8% + 24% * var(--sob-top-dense, 0)), transparent) 58%,
+    transparent 100%
+  );
+  backdrop-filter: blur(16px) saturate(1.18);
+  -webkit-backdrop-filter: blur(16px) saturate(1.18);
+  mask-image: linear-gradient(to bottom, #000 0%, #000 36%, transparent 82%);
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 36%, transparent 82%);
+}
+
+.cg-ob-top__side,
+.cg-ob-top__step {
+  position: relative;
+  z-index: 1;
+  pointer-events: auto;
+}
+
+.cg-ob-top__side {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.cg-ob-top__step {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: baseline;
+  gap: 7px;
+  margin: 0 0 0 12px;
+  color: color-mix(in srgb, var(--sob-muted) 72%, var(--sob-ink));
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.cg-ob-top__step b {
+  color: color-mix(in srgb, var(--sob-ink) 78%, var(--sob-muted));
+  font-weight: 620;
+}
+
+.cg-ob-top__step span {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  opacity: 0.72;
+}
+
+.cg-ob-back {
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  color: var(--sob-muted);
+  font-size: 13px;
+  font-weight: 580;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+.cg-ob-back__hit {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--config-primary) 10%, var(--sob-canvas));
+  color: color-mix(in srgb, var(--sob-ink) 72%, var(--sob-muted));
+  cursor: pointer;
+  font: inherit;
+  place-items: center;
+  transition: var(--sob-t-elevate), var(--sob-t-fill);
+}
+
+.cg-ob-back__hit svg {
+  width: 17px;
+  height: 17px;
+  margin-left: -1px;
+}
+
+.cg-ob-back__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  pointer-events: none;
   user-select: none;
 }
 
-.advanced-panel > .advanced-summary::-webkit-details-marker {
+.cg-ob-back__hit:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--sob-accent) 40%, var(--sob-liq-border));
+  background: color-mix(in srgb, var(--sob-accent) 14%, var(--sob-canvas));
+  color: var(--sob-ink);
+  transform: translate3d(-2px, 0, 0);
+}
+
+.cg-ob-back__hit:active:not(:disabled) {
+  transform: scale(var(--sob-scale-press));
+}
+
+.cg-ob-back__hit:focus-visible {
+  outline: 2px solid var(--sob-accent);
+  outline-offset: 2px;
+}
+
+.cg-ob-brand {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 13px;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sob-accent) 14%, transparent);
+  color: color-mix(in srgb, var(--sob-accent) 62%, var(--sob-ink));
+  font-size: 11.5px;
+  font-weight: 620;
+  letter-spacing: 0.04em;
+}
+
+/* ---------- 视口 / 步骤 ---------- */
+
+.cg-ob__viewport {
+  display: grid;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.cg-ob__pane {
+  position: relative;
+  width: 100%;
+  min-height: 0;
+  padding-top: var(--sob-top-h);
+  padding-bottom: 76px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  grid-area: 1 / 1;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--sob-muted) 34%, transparent) transparent;
+  animation: cg-ob-pane-fade var(--sob-dur-enter) var(--sob-ease-out) backwards;
+}
+
+.cg-ob__pane[hidden] {
+  display: none !important;
+}
+
+@keyframes cg-ob-pane-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.cg-ob__pane[data-dir='forward'] .cg-ob-hero > *,
+.cg-ob__pane[data-dir='forward'] .cg-ob-body > *,
+.cg-ob__pane[data-dir='forward'] .cg-ob-welcome > *:not(.cg-ob-body) {
+  --sob-enter-x: var(--sob-shift-x);
+  --sob-enter-y: 0px;
+}
+
+.cg-ob__pane[data-dir='back'] .cg-ob-hero > *,
+.cg-ob__pane[data-dir='back'] .cg-ob-body > *,
+.cg-ob__pane[data-dir='back'] .cg-ob-welcome > *:not(.cg-ob-body) {
+  --sob-enter-x: calc(var(--sob-shift-x) * -1);
+  --sob-enter-y: 0px;
+}
+
+.cg-ob__pane.is-welcome {
+  --sob-pad-x: clamp(26px, 4.6vw, 54px);
+  display: flex;
+  flex-direction: column;
+}
+
+.cg-ob-welcome {
+  display: grid;
+  align-content: start;
+  gap: 9px;
+  width: 100%;
+  max-width: none;
+  margin: auto 0;
+  text-align: left;
+}
+
+.cg-ob-welcome__mark {
+  display: grid;
+  width: clamp(72px, 11vw, 108px);
+  height: clamp(72px, 11vw, 108px);
+  margin: 0 0 9px var(--sob-pad-x);
+  border-radius: 28px;
+  background: color-mix(in srgb, var(--sob-accent) 16%, transparent);
+  color: var(--sob-accent);
+  place-items: center;
+  animation: cg-ob-mark-in var(--sob-dur-slow) var(--sob-ease-out) backwards;
+}
+
+.cg-ob-welcome__mark svg {
+  width: 42%;
+  height: 42%;
+}
+
+.cg-ob-welcome .cg-ob-hero h1 {
+  font-size: clamp(28px, 4vw, 40px);
+  letter-spacing: -0.04em;
+}
+
+.cg-ob-welcome .cg-ob-hero {
+  gap: 10px;
+}
+
+.cg-ob-welcome .cg-ob-hero__lead {
+  max-width: 54ch;
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+.cg-ob-welcome .cg-ob-body {
+  gap: 18px;
+  padding-top: 26px;
+}
+
+.cg-ob-hero {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  max-width: none;
+  padding: 2px var(--sob-pad-x) 0;
+  text-align: left;
+}
+
+.cg-ob-hero > * {
+  animation: cg-ob-rise var(--sob-dur-base) var(--sob-ease-out) backwards;
+}
+
+.cg-ob-hero > :nth-child(1) { animation-delay: calc(var(--sob-stagger) * 0.5); }
+.cg-ob-hero > :nth-child(2) { animation-delay: calc(var(--sob-stagger) * 1.2); }
+.cg-ob-hero > :nth-child(3) { animation-delay: calc(var(--sob-stagger) * 1.9); }
+
+.cg-ob-hero h1 {
+  margin: 0;
+  color: var(--sob-ink);
+  font-size: clamp(21px, 2.6vw, 30px);
+  font-weight: 720;
+  letter-spacing: -0.035em;
+  line-height: 1.2;
+}
+
+.cg-ob-hero__lead {
+  margin: 0;
+  max-width: 68ch;
+  color: var(--sob-muted);
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+
+.cg-ob-hero__notes {
+  display: grid;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.cg-ob-hero__notes:empty {
   display: none;
 }
 
-.advanced-summary-main {
+.cg-ob-body {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  width: 100%;
+  max-width: none;
+  padding: 14px var(--sob-pad-x) 0;
+  text-align: left;
+}
+
+.cg-ob-body > * {
+  animation: cg-ob-rise var(--sob-dur-base) var(--sob-ease-out) backwards;
+}
+
+.cg-ob-body > *:nth-child(1) { animation-delay: calc(var(--sob-stagger) * 1.4); }
+.cg-ob-body > *:nth-child(2) { animation-delay: calc(var(--sob-stagger) * 1.9); }
+.cg-ob-body > *:nth-child(3) { animation-delay: calc(var(--sob-stagger) * 2.4); }
+.cg-ob-body > *:nth-child(n + 4) { animation-delay: calc(var(--sob-stagger) * 2.8); }
+
+@keyframes cg-ob-rise {
+  from {
+    transform: translate3d(
+      var(--sob-enter-x, 0),
+      var(--sob-enter-y, var(--sob-shift-sm)),
+      0
+    );
+  }
+  to { transform: translate3d(0, 0, 0); }
+}
+
+@keyframes cg-ob-mark-in {
+  from {
+    transform: translate3d(
+      var(--sob-enter-x, 0),
+      var(--sob-enter-y, var(--sob-shift-sm)),
+      0
+    ) scale(0.92);
+  }
+  to { transform: none; }
+}
+
+/* ---------- FAB ---------- */
+
+.cg-ob-bar {
+  position: absolute;
+  z-index: 20;
+  pointer-events: auto;
+  right: var(--sob-pad-x);
+  bottom: max(16px, calc(var(--sob-pad) - 6px));
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 10px;
-  min-width: 0;
+  animation: cg-ob-bar-in var(--sob-dur-slow) var(--sob-ease-out)
+    calc(var(--sob-stagger) * 2) backwards;
 }
 
-.advanced-summary-text {
+@keyframes cg-ob-bar-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 8px, 0) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+.cg-ob-bar.is-split {
+  left: var(--sob-pad-x);
+  justify-content: space-between;
+}
+
+.cg-ob-bar__note {
+  max-width: 62%;
+  margin: 0;
+  color: color-mix(in srgb, var(--sob-muted) 78%, transparent);
+  font-size: 11.5px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.cg-ob-bar .cg-ob-cta {
+  position: relative;
+  display: grid;
+  width: 58px;
+  height: 58px;
+  min-height: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  border-radius: 50%;
+  background: var(--sob-accent);
+  box-shadow: 0 10px 24px -10px color-mix(in srgb, var(--sob-accent) 55%, transparent);
+  color: #fff;
+  isolation: isolate;
+  transition: var(--sob-t-elevate);
+  cursor: pointer;
+  font: inherit;
+  place-items: center;
+}
+
+.cg-ob-bar .cg-ob-cta > span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+  clip-path: inset(50%);
+}
+
+.cg-ob-bar .cg-ob-cta svg {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 21px;
+  height: 21px;
+  transition: transform var(--sob-dur-fast) var(--sob-ease-out);
+}
+
+.cg-ob-bar .cg-ob-cta:hover:not(:disabled) {
+  transform: translate3d(0, var(--sob-lift), 0) scale(var(--sob-scale-hover));
+}
+
+.cg-ob-bar .cg-ob-cta:hover:not(:disabled) svg {
+  transform: translate3d(3px, 0, 0);
+}
+
+.cg-ob-bar .cg-ob-cta.js-generate:hover:not(:disabled) svg {
+  transform: translate3d(0, 3px, 0);
+}
+
+.cg-ob-bar .cg-ob-cta:active:not(:disabled) {
+  transform: scale(var(--sob-scale-press));
+}
+
+.cg-ob-bar .cg-ob-cta:focus-visible {
+  outline: 2px solid var(--sob-accent);
+  outline-offset: 3px;
+}
+
+.cg-ob-bar .cg-ob-cta:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+/* ---------- 选择卡 ---------- */
+
+.cg-choice {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.cg-choice--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.limit-preset-toggle .cg-choice__card {
+  min-height: 5.4rem;
+}
+
+.cg-limit-custom-btn {
+  justify-self: start;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--sob-accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 620;
+  transition: color var(--sob-dur-fast) var(--sob-ease-glide);
+}
+
+.cg-limit-custom-btn[aria-pressed='true'] {
+  color: var(--sob-ink);
+}
+
+.cg-choice__card {
+  position: relative;
   display: flex;
+  min-height: 8.6rem;
   flex-direction: column;
-  gap: 2px;
-  min-width: 0;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 0.28rem;
+  padding: 1rem 1rem 1.05rem;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 20px;
+  background: var(--sob-canvas);
+  color: var(--sob-ink);
+  cursor: pointer;
+  transition: var(--sob-t-elevate);
+  user-select: none;
 }
 
-.advanced-summary-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--config-text);
-}
-
-.advanced-summary-sub {
-  font-size: 12px;
-  color: var(--config-text-muted);
-  line-height: 1.4;
-}
-
-.advanced-chevron {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
+.cg-choice__logo {
+  display: grid;
   width: 28px;
   height: 28px;
-  border-radius: 8px;
-  color: var(--config-text-muted);
-  background: var(--config-input-bg);
-  border: 1px solid var(--config-border);
-  transition: transform var(--config-transition), color var(--config-transition), border-color var(--config-transition);
+  flex: 0 0 auto;
+  margin: 0 0 0.55rem;
+  background: none;
+  place-items: center;
 }
 
-.advanced-chevron svg {
+.cg-choice__logo svg,
+.cg-choice__logo img {
   display: block;
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
 }
 
-.advanced-panel[open] > .advanced-summary .advanced-chevron {
-  transform: rotate(180deg);
-  color: var(--config-primary);
-  border-color: rgba(var(--config-primary-rgb), 0.25);
-  background: rgba(var(--config-primary-rgb), 0.08);
+.cg-logo-cli {
+  color: var(--sob-accent);
 }
 
-.advanced-summary:hover .advanced-chevron {
-  color: var(--config-primary);
+.cg-choice__card input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
 }
 
-.advanced-panel[open] > .advanced-summary {
-  border-bottom: 1px solid var(--config-border);
+.cg-choice__card:hover {
+  border-color: color-mix(in srgb, var(--sob-accent) 28%, var(--sob-liq-border));
+  background: var(--sob-canvas);
+  color: var(--sob-ink);
+  transform: translate3d(0, var(--sob-lift), 0);
 }
 
-.advanced-body {
-  padding: 16px 20px 20px;
+.cg-choice__card:active {
+  transform: scale(var(--sob-scale-press));
 }
 
-.advanced-subtitle {
-  margin: 16px 0 12px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--config-text);
+.cg-choice__card:has(input:focus-visible) {
+  border-color: var(--sob-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--sob-accent) 22%, transparent);
 }
 
-.advanced-body > .advanced-subtitle:first-of-type {
-  margin-top: 0;
+.cg-choice__card.is-active {
+  border-color: color-mix(in srgb, var(--sob-accent) 46%, var(--sob-liq-border));
+  background: var(--sob-canvas);
+  color: var(--sob-ink);
 }
 
-.advanced-body .section-desc {
-  margin: 0 0 14px;
+.cg-choice__title {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--sob-ink);
 }
 
-.advanced-body .section-warning {
-  margin: 0 0 16px;
-}
-
-/* ========================================
-   提示框 - 警告样式
-   ======================================== */
-
-.section-warning {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  margin: -4px 0 16px;
-  padding: 12px 14px;
-  background: rgba(245, 158, 11, 0.1);
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  border-radius: var(--config-radius-sm);
+.cg-choice__desc {
   font-size: 12px;
-  color: var(--config-text-secondary);
+  line-height: 1.45;
+  color: var(--sob-muted);
+}
+
+.cg-ob-features {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.cg-ob-features > div {
+  display: flex;
+  min-height: 6.25rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 1rem 0.75rem;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 18px;
+  background: var(--sob-canvas);
+  color: var(--sob-muted);
+  font-size: 12px;
+  font-weight: 620;
+  line-height: 1.45;
+  text-align: center;
+}
+
+.cg-ob-features svg {
+  width: 1.3rem;
+  height: 1.3rem;
+  color: var(--sob-accent);
+}
+
+/* ---------- 字段 ---------- */
+
+.cg-ob-field {
+  display: grid;
+  gap: var(--sob-label-gap, 10px);
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.cg-ob-field__label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--sob-muted);
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
+.cg-ob-field__optional {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sob-muted) 14%, transparent);
+  font-size: 10.5px;
+  font-style: normal;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.cg-ob-field__hint {
+  color: var(--sob-muted);
+  font-size: 11.5px;
   line-height: 1.5;
 }
 
-.dark .section-warning {
-  background: rgba(245, 158, 11, 0.08);
-  border-color: rgba(245, 158, 11, 0.25);
-}
-
-.section-warning-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 28px;
-  height: 28px;
-  margin-top: 0;
-  border-radius: 8px;
-  color: var(--config-warning);
-  background: rgba(245, 158, 11, 0.12);
-  border: 1px solid rgba(245, 158, 11, 0.22);
-}
-
-.section-warning-icon svg {
-  display: block;
-}
-
-.section-warning-content {
-  flex: 1;
-  min-width: 0;
-}
-
-.section-warning-title {
-  display: block;
-  font-weight: 600;
-  color: var(--config-warning);
-  margin-bottom: 4px;
-}
-
-/* ========================================
-   Form Controls
-   ======================================== */
-
-.form-group {
-  margin-bottom: 16px;
-}
-
-.form-group:last-child {
-  margin-bottom: 0;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 8px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--config-text);
-}
-
+.cg-ob-input,
 .form-input {
   width: 100%;
   padding: 12px 14px;
-  background: var(--config-input-bg);
-  border: 1px solid var(--config-border);
-  border-radius: var(--config-radius-xs);
-  color: var(--config-text);
-  font-size: 14px;
-  font-family: 'SF Mono', Monaco, 'Consolas', monospace;
-  transition: var(--config-transition);
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 14px;
+  outline: 0;
+  background: color-mix(in srgb, var(--config-primary) 5%, var(--sob-canvas));
+  color: inherit;
+  font: inherit;
+  font-size: 13.5px;
+  transition: var(--sob-t-control);
   box-sizing: border-box;
 }
 
-.form-input:focus {
-  outline: none;
-  border-color: var(--config-primary);
-  box-shadow: 0 0 0 3px rgba(var(--config-primary-rgb), 0.15);
-}
-
+.cg-ob-input::placeholder,
 .form-input::placeholder {
-  color: var(--config-text-muted);
+  color: color-mix(in srgb, var(--sob-muted) 70%, transparent);
 }
 
-.form-hint {
-  display: block;
-  margin-top: 6px;
-  font-size: 12px;
-  color: var(--config-text-muted);
+.cg-ob-input:focus,
+.form-input:focus {
+  border-color: var(--sob-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--sob-accent) 22%, transparent);
 }
 
-/* Form Row - 两列 / 三列布局 */
-.form-row {
+.cg-ob-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.form-row-3 {
-  grid-template-columns: 1fr 1fr 1fr;
+.cg-ob-grid > .is-wide {
+  grid-column: 1 / -1;
 }
 
-.form-group-half,
-.form-group-third {
-  margin-bottom: 0;
+.cg-ob-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--sob-ink) 5%, transparent);
+  color: var(--sob-muted);
+  font-size: 12.5px;
+  line-height: 1.5;
 }
 
-@media (max-width: 640px) {
-  .form-row-3 {
-    grid-template-columns: 1fr;
-  }
+.cg-ob-note.is-error {
+  background: color-mix(in srgb, #ef4444 11%, transparent);
+  color: color-mix(in srgb, #ef4444 72%, var(--sob-ink));
 }
 
-@media (max-width: 500px) {
-  .form-row {
-    grid-template-columns: 1fr;
-  }
-  
-  .form-group-half,
-  .form-group-third {
-    margin-bottom: 16px;
-  }
-  
-  .form-group-half:last-child,
-  .form-group-third:last-child {
-    margin-bottom: 0;
-  }
-}
+/* ---------- 高级 ---------- */
 
-/* 版本刷新状态行 */
 .tag-status-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin: -4px 0 14px;
-  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .tag-status {
   font-size: 12px;
-  color: var(--config-text-secondary);
-  line-height: 1.4;
-  flex: 1;
-  min-width: 160px;
+  color: var(--sob-muted);
 }
 
-.tag-status.is-loading {
-  color: var(--config-text-muted);
-}
-
-.tag-status.is-ok {
-  color: var(--config-success);
-}
-
-.tag-status.is-error {
-  color: var(--config-error);
-}
+.tag-status.is-ok { color: color-mix(in srgb, #22c55e 66%, var(--sob-ink)); }
+.tag-status.is-err { color: color-mix(in srgb, #ef4444 72%, var(--sob-ink)); }
 
 .btn-secondary {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  background: var(--config-input-bg);
-  border: 1px solid var(--config-border);
-  border-radius: var(--config-radius-xs);
-  color: var(--config-text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: var(--config-transition);
-  white-space: nowrap;
-}
-
-.btn-secondary:hover:not(:disabled) {
-  background: rgba(var(--config-primary-rgb), 0.1);
-  color: var(--config-primary);
-  border-color: rgba(var(--config-primary-rgb), 0.3);
-}
-
-.btn-secondary:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
-/* 信息提示框 */
-.section-info {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  margin: 0 0 20px;
-  padding: 12px 14px;
-  background: rgba(var(--config-primary-rgb), 0.08);
-  border: 1px solid rgba(var(--config-primary-rgb), 0.22);
-  border-radius: var(--config-radius-sm);
-  font-size: 12px;
-  color: var(--config-text-secondary);
-  line-height: 1.55;
-}
-
-.section-info-icon {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
-  flex-shrink: 0;
-  width: 28px;
-  height: 28px;
-  margin-top: 0;
-  border-radius: 8px;
-  color: var(--config-primary);
-  background: rgba(var(--config-primary-rgb), 0.12);
-  border: 1px solid rgba(var(--config-primary-rgb), 0.18);
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 999px;
+  background: var(--sob-fill-strong);
+  color: var(--sob-ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  transition: var(--sob-t-fill), transform var(--sob-dur-fast) var(--sob-ease-out);
 }
 
-.section-info-icon svg {
-  display: block;
+.btn-secondary:hover {
+  border-color: color-mix(in srgb, var(--sob-accent) 28%, var(--sob-liq-border));
 }
 
-.section-info-content {
-  flex: 1;
+.btn-secondary:active {
+  transform: scale(var(--sob-scale-press));
+}
+
+.resource-group {
+  padding: 12px;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 14px;
+  background: var(--sob-canvas);
+}
+
+.resource-label {
+  margin-bottom: 8px;
+  color: var(--sob-ink);
+  font-size: 12.5px;
+  font-weight: 640;
+}
+
+.cg-limit-custom {
+  display: grid;
+  gap: 18px;
+  padding-top: 4px;
+}
+
+.cg-setting-block {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.cg-setting-block__title {
+  margin: 0;
+  color: var(--sob-ink);
+  font-size: 13px;
+  font-weight: 680;
+}
+
+.cg-setting-block__desc {
+  margin: 0;
+  color: var(--sob-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.cg-setting-row {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.cg-setting-item {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+.cg-setting-item > span {
+  color: var(--sob-muted);
+  font-size: 12px;
+  font-weight: 640;
+}
+
+.cg-switch-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 14px;
+  background: var(--sob-canvas);
+}
+
+.cg-switch-item__text {
+  display: grid;
+  gap: 4px;
   min-width: 0;
 }
 
-.section-info-title {
-  display: block;
-  font-weight: 600;
-  color: var(--config-primary);
-  margin-bottom: 4px;
+.cg-switch-item__label {
+  color: var(--sob-ink);
+  font-size: 13.5px;
+  font-weight: 680;
 }
 
-.section-info code,
-.section-warning code {
-  font-family: 'SF Mono', Monaco, 'Consolas', monospace;
-  font-size: 11px;
-  padding: 1px 5px;
-  border-radius: 4px;
-  background: var(--config-code-bg);
-  color: var(--config-text);
+.cg-switch-item__desc {
+  color: var(--sob-muted);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
-/* 数据库模式切换：内置 / 外置 */
-.form-label-text {
-  display: block;
+.cg-toggle {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  flex: 0 0 auto;
+}
+
+.cg-toggle input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+}
+
+.cg-toggle__slider {
+  position: absolute;
+  inset: 0;
+  border: 1.5px solid color-mix(in srgb, var(--sob-muted) 55%, transparent);
+  border-radius: 28px;
+  background: color-mix(in srgb, var(--sob-muted) 28%, var(--sob-canvas));
+  box-shadow: inset 0 1px 2px rgb(0 0 0 / 14%);
+  cursor: pointer;
+  box-sizing: border-box;
+  transition:
+    background-color var(--sob-dur-fast) var(--sob-ease-glide),
+    border-color var(--sob-dur-fast) var(--sob-ease-glide);
+}
+
+.cg-toggle__slider::before {
+  content: '';
+  position: absolute;
+  bottom: 2.5px;
+  left: 2.5px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 28%);
+  transition: transform var(--sob-dur-base) var(--sob-ease-spring);
+}
+
+.cg-toggle input:checked + .cg-toggle__slider {
+  border-color: color-mix(in srgb, var(--sob-accent) 50%, transparent);
+  background: var(--sob-accent);
+}
+
+.cg-toggle input:checked + .cg-toggle__slider::before {
+  transform: translateX(18px);
+}
+
+.cg-toggle input:focus-visible + .cg-toggle__slider {
+  outline: 2px solid var(--sob-accent);
+  outline-offset: 2px;
+}
+
+.cg-ob-bar__text {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  padding: 0 2px 0 0;
+  border: 0;
+  background: none;
+  color: var(--sob-accent);
+  cursor: pointer;
+  font: inherit;
   font-size: 13px;
-  font-weight: 500;
-  color: var(--config-text);
-  margin-bottom: 8px;
+  font-weight: 620;
+  line-height: 1;
+  white-space: nowrap;
+  transition: color var(--sob-dur-fast) var(--sob-ease-glide);
 }
 
-.db-mode-toggle {
+.cg-ob-bar__text:hover {
+  color: var(--sob-ink);
+}
+
+@media (width <= 640px) {
+  .cg-setting-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.input-with-action {
+  display: flex;
+  gap: 8px;
+}
+
+.input-with-action .form-input {
+  flex: 1;
+}
+
+.btn-generate,
+.btn-copy-field {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 999px;
+  background: var(--sob-fill-strong);
+  color: var(--sob-ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 620;
+  line-height: 1;
+  white-space: nowrap;
+  transition: var(--sob-t-fill), transform var(--sob-dur-fast) var(--sob-ease-out);
+}
+
+.btn-generate:hover,
+.btn-copy-field:hover {
+  border-color: color-mix(in srgb, var(--sob-accent) 28%, var(--sob-liq-border));
+}
+
+.btn-generate:active,
+.btn-copy-field:active {
+  transform: scale(var(--sob-scale-press));
+}
+
+.btn-generate {
+  width: 32px;
+  padding: 0;
+  color: var(--sob-accent);
+}
+
+.btn-generate.is-spinning svg {
+  animation: cg-ob-spin var(--sob-dur-slow) var(--sob-ease-out);
+}
+
+@keyframes cg-ob-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(180deg); }
+}
+
+/* ---------- 上传 ---------- */
+
+.cg-site-domain {
+  margin: 0;
+  color: var(--sob-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.cg-site-domain strong {
+  color: var(--sob-ink);
+  font-weight: 650;
+}
+
+.cg-site-steps {
   display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 6px 0 8px;
+  list-style: none;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.cg-site-steps li {
+  position: relative;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding-right: 28px;
+  color: var(--sob-ink);
+  font-size: 13.5px;
+  letter-spacing: -0.01em;
+  line-height: 1.5;
+}
+
+.cg-site-steps li:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  z-index: 0;
+  top: 13px;
+  left: 36px;
+  right: 10px;
+  height: 1px;
+  background: color-mix(in srgb, var(--sob-accent) 22%, var(--sob-liq-border));
+}
+
+.cg-site-steps b {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  border: 1px solid color-mix(in srgb, var(--sob-accent) 38%, var(--sob-liq-border));
+  border-radius: 50%;
+  background: var(--sob-canvas);
+  color: var(--sob-accent);
+  font-size: 12px;
+  font-weight: 680;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  place-items: center;
+}
+
+.cg-site-steps span {
+  color: color-mix(in srgb, var(--sob-ink) 78%, var(--sob-muted));
+}
+
+[data-step='site'] .upload-group {
+  margin-top: 4px;
+}
+
+[data-step='site'] .upload-box {
+  min-height: 168px;
+  justify-content: center;
+  background: var(--sob-canvas);
+}
+
+[data-step='site'] .upload-placeholder {
+  justify-content: center;
+  text-align: center;
+}
+
+.upload-group {
+  display: grid;
+  gap: 12px;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
 }
 
-/* 面板选择：三列（1Panel / 宝塔 / 通用） */
-.panel-mode-toggle {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 10px;
+.upload-group.is-single {
+  grid-template-columns: minmax(0, 1fr);
 }
 
-.panel-mode-option {
-  position: relative;
+.upload-box {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 12px 14px;
-  border-radius: var(--config-radius-sm);
-  border: 1px solid var(--config-border);
-  background: var(--config-input-bg);
-  cursor: pointer;
-  transition: var(--config-transition);
-  user-select: none;
-}
-
-.panel-mode-option input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.panel-mode-option:hover {
-  border-color: rgba(var(--config-primary-rgb), 0.35);
-  background: rgba(var(--config-primary-rgb), 0.06);
-}
-
-.panel-mode-option.is-active {
-  border-color: rgba(var(--config-primary-rgb), 0.55);
-  background: rgba(var(--config-primary-rgb), 0.12);
-  box-shadow: 0 0 0 1px rgba(var(--config-primary-rgb), 0.2);
-}
-
-.panel-mode-option-title {
+  min-height: 112px;
+  align-items: center;
+  padding: 16px;
+  border: 1px dashed var(--sob-liq-border);
+  border-radius: 16px;
+  background: var(--sob-canvas);
+  color: var(--sob-muted);
   font-size: 13px;
-  font-weight: 600;
-  color: var(--config-text);
+  cursor: pointer;
+  transition: var(--sob-t-control);
 }
 
-.panel-mode-option.is-active .panel-mode-option-title {
-  color: var(--config-primary);
+.upload-box.dragover {
+  border-color: var(--sob-accent);
+  background: var(--sob-canvas);
+  color: var(--sob-ink);
 }
 
-.panel-mode-option-desc {
-  font-size: 11px;
-  color: var(--config-text-muted);
-  line-height: 1.4;
-}
-
-@media (max-width: 640px) {
-  .panel-mode-toggle {
-    grid-template-columns: 1fr;
-  }
-}
-
-.db-mode-option {
-  position: relative;
+.upload-placeholder,
+.upload-success {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 12px 14px;
-  border-radius: var(--config-radius-sm);
-  border: 1px solid var(--config-border);
-  background: var(--config-input-bg);
-  cursor: pointer;
-  transition: var(--config-transition);
-  user-select: none;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
-.db-mode-option input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.db-mode-option:hover {
-  border-color: rgba(var(--config-primary-rgb), 0.35);
-  background: rgba(var(--config-primary-rgb), 0.06);
-}
-
-.db-mode-option.is-active {
-  border-color: rgba(var(--config-primary-rgb), 0.55);
-  background: rgba(var(--config-primary-rgb), 0.12);
-  box-shadow: 0 0 0 1px rgba(var(--config-primary-rgb), 0.2);
-}
-
-.db-mode-option-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--config-text);
-}
-
-.db-mode-option.is-active .db-mode-option-title {
-  color: var(--config-primary);
-}
-
-.db-mode-option-desc {
-  font-size: 11px;
-  color: var(--config-text-muted);
-  line-height: 1.4;
-}
-
-.form-hint-block {
+.upload-item > label {
   display: block;
-  margin: -4px 0 14px;
+  margin-bottom: 6px;
+  color: var(--sob-muted);
+  font-size: 12px;
+  font-weight: 640;
 }
 
-@media (max-width: 520px) {
-  .db-mode-toggle {
-    grid-template-columns: 1fr;
+.btn-remove {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+/* ---------- 结果 ---------- */
+
+.setup-secret-reminder-row {╭638395
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.setup-secret-reminder-row code {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  height: 32px;
+  overflow: hidden;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: var(--sob-fill-strong);
+  font-size: 12px;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cg-guide-overview {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 2px 0 8px;
+  list-style: none;
+  grid-template-columns: repeat(var(--cg-guide-cols, 5), minmax(0, 1fr));
+}
+
+.cg-guide-overview li {
+  position: relative;
+  display: grid;
+  gap: 10px;
+  align-content: start;
+  padding-right: 16px;
+  color: var(--sob-ink);
+  font-size: 12.5px;
+  letter-spacing: -0.01em;
+  line-height: 1.45;
+}
+
+.cg-guide-overview li:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  z-index: 0;
+  top: 13px;
+  left: 36px;
+  right: 6px;
+  height: 1px;
+  background: color-mix(in srgb, var(--sob-accent) 22%, var(--sob-liq-border));
+}
+
+.cg-guide-overview b {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  border: 1px solid color-mix(in srgb, var(--sob-accent) 38%, var(--sob-liq-border));
+  border-radius: 50%;
+  background: var(--sob-canvas);
+  color: var(--sob-accent);
+  font-size: 12px;
+  font-weight: 680;
+  font-variant-numeric: tabular-nums;
+  place-items: center;
+}
+
+.cg-guide-overview span {
+  color: color-mix(in srgb, var(--sob-ink) 78%, var(--sob-muted));
+}
+
+.cg-guide-list {
+  display: grid;
+  gap: 0;
+}
+
+.cg-guide-card {
+  display: grid;
+  gap: 10px;
+  padding: 16px 0;
+  border-top: 1px solid var(--sob-liq-border);
+}
+
+.cg-guide-card > header {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.cg-guide-card > header b {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  border: 1px solid color-mix(in srgb, var(--sob-accent) 38%, var(--sob-liq-border));
+  border-radius: 50%;
+  background: var(--sob-canvas);
+  color: var(--sob-accent);
+  font-size: 12px;
+  font-weight: 680;
+  font-variant-numeric: tabular-nums;
+  place-items: center;
+}
+
+.cg-guide-card h2 {
+  margin: 0;
+  color: var(--sob-ink);
+  font-size: 15px;
+  font-weight: 720;
+  letter-spacing: -0.02em;
+}
+
+.cg-guide-card > p {
+  margin: 0 0 0 40px;
+  color: var(--sob-muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.cg-guide-card .setup-secret-reminder-row,
+.cg-guide-actions,
+.cg-guide-cmd {
+  margin-left: 40px;
+}
+
+.cg-guide-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.cg-guide-cmd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cg-guide-cmd code {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  height: 32px;
+  overflow: auto;
+  padding: 0 10px;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 999px;
+  background: var(--sob-canvas);
+  color: var(--sob-ink);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.cg-files-kicker {
+  margin: 18px 0 0;
+  color: var(--sob-muted);
+  font-size: 12px;
+  font-weight: 640;
+}
+
+.cg-files {
+  display: grid;
+  gap: 10px;
+}
+
+@media (width <= 900px) {
+  .cg-guide-overview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cg-guide-overview li {
+    grid-template-columns: 28px minmax(0, 1fr);
+    gap: 12px;
+    padding-right: 0;
+    padding-bottom: 14px;
+  }
+
+  .cg-guide-overview li:last-child {
+    padding-bottom: 0;
+  }
+
+  .cg-guide-overview li:not(:last-child)::after {
+    top: 28px;
+    right: auto;
+    bottom: 4px;
+    left: 13px;
+    width: 1px;
+    height: auto;
+  }
+
+  .cg-guide-card > p,
+  .cg-guide-card .setup-secret-reminder-row,
+  .cg-guide-actions,
+  .cg-guide-cmd {
+    margin-left: 0;
   }
 }
 
-/* ========================================
-   自定义下拉（替代系统 <select> option 列表）
-   ======================================== */
+.result-card {
+  overflow: hidden;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 16px;
+  background: var(--sob-canvas);
+}
+
+.result-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-height: 48px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.result-name {
+  font-size: 13px;
+  font-weight: 680;
+}
+
+.result-badge {
+  margin-right: auto;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sob-muted) 12%, transparent);
+  color: var(--sob-muted);
+  font-size: 11px;
+}
+
+.btn-copy,
+.btn-download {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--sob-ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  transition: var(--sob-t-fill), transform var(--sob-dur-fast) var(--sob-ease-out);
+}
+
+.btn-copy:hover,
+.btn-download:hover {
+  border-color: color-mix(in srgb, var(--sob-accent) 28%, var(--sob-liq-border));
+}
+
+.btn-copy:active,
+.btn-download:active {
+  transform: scale(var(--sob-scale-press));
+}
+
+.btn-copy svg,
+.btn-download svg,
+.btn-copy-field svg,
+.btn-secondary svg,
+.btn-generate svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.btn-copy.copied {
+  color: color-mix(in srgb, #22c55e 70%, var(--sob-ink));
+}
+
+.result-card:not(.is-open) .result-content {
+  display: none;
+}
+
+.result-content {
+  max-height: 180px;
+  margin: 0;
+  padding: 0 12px 12px;
+  overflow: auto;
+  color: var(--sob-muted);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
+.result-content code {
+  font-family: ui-monospace, sfmono-regular, menlo, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ---------- 自定义下拉 ---------- */
 
 .cg-select {
   position: relative;
   width: 100%;
 }
 
-/* 原生 select 仅作值载体，不展示系统菜单 */
 .cg-select > select.form-select,
 .cg-select > select.form-input {
   position: absolute !important;
@@ -788,7 +1560,6 @@
   margin: -1px !important;
   overflow: hidden !important;
   clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
   border: 0 !important;
   opacity: 0 !important;
   pointer-events: none !important;
@@ -802,90 +1573,67 @@
   width: 100%;
   min-height: 44px;
   padding: 10px 12px 10px 14px;
-  background: var(--config-input-bg);
-  border: 1px solid var(--config-border);
-  border-radius: var(--config-radius-xs);
-  color: var(--config-text);
-  font-size: 14px;
-  font-family: inherit;
-  line-height: 1.35;
-  text-align: left;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 14px;
+  background: var(--sob-fill-strong);
+  color: inherit;
   cursor: pointer;
-  transition: border-color var(--config-transition), box-shadow var(--config-transition),
-    background var(--config-transition);
-  box-sizing: border-box;
+  font: inherit;
+  font-size: 13.5px;
+  text-align: left;
+  transition: var(--sob-t-control);
 }
 
-.cg-select-trigger:hover {
-  border-color: var(--config-border-strong);
-  background: color-mix(in srgb, var(--config-input-bg) 65%, var(--config-surface-elevated));
-}
-
-.cg-select.is-open .cg-select-trigger,
-.cg-select-trigger:focus {
-  outline: none;
-  border-color: var(--config-primary);
-  box-shadow: 0 0 0 3px rgba(var(--config-primary-rgb), 0.15);
-  background: var(--config-surface-elevated);
-}
-
-.cg-select-label {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.cg-select-trigger:focus-visible,
+.cg-select.is-open .cg-select-trigger {
+  border-color: var(--sob-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--sob-accent) 22%, transparent);
 }
 
 .cg-select-label.is-placeholder {
-  color: var(--config-text-muted);
+  color: color-mix(in srgb, var(--sob-muted) 70%, transparent);
 }
 
 .cg-select-chevron {
-  flex-shrink: 0;
-  width: 18px;
-  height: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--config-text-muted);
-  transition: transform var(--config-transition), color var(--config-transition);
+  display: grid;
+  flex: 0 0 auto;
+  color: var(--sob-muted);
+  place-items: center;
+  transition: transform var(--sob-dur-fast) var(--sob-ease-out);
 }
 
 .cg-select.is-open .cg-select-chevron {
   transform: rotate(180deg);
-  color: var(--config-primary);
+}
+
+.cg-select.is-up .cg-select-menu {
+  top: auto;
+  bottom: calc(100% + 6px);
+  transform-origin: bottom center;
 }
 
 .cg-select-menu {
   position: absolute;
-  left: 0;
-  right: 0;
-  top: calc(100% + 6px);
   z-index: 40;
+  top: calc(100% + 6px);
+  right: 0;
+  left: 0;
+  max-height: 240px;
   margin: 0;
   padding: 6px;
+  overflow: auto;
+  border: 1px solid var(--sob-liq-border);
+  border-radius: 14px;
+  background: var(--sob-canvas);
   list-style: none;
-  max-height: 240px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  background: var(--config-surface-elevated);
-  border: 1px solid var(--config-border);
-  border-radius: var(--config-radius-sm);
-  box-shadow: var(--config-shadow-lg), 0 0 0 1px rgba(var(--config-primary-rgb), 0.04);
-  -webkit-backdrop-filter: blur(18px) saturate(160%);
-  backdrop-filter: blur(18px) saturate(160%);
-  animation: cg-select-pop 0.16s cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.cg-select-menu[hidden] {
-  display: none !important;
+  transform-origin: top center;
+  animation: cg-select-pop var(--sob-dur-base) var(--sob-ease-out);
 }
 
 @keyframes cg-select-pop {
   from {
     opacity: 0;
-    transform: translateY(-4px) scale(0.98);
+    transform: translate3d(0, -6px, 0) scale(0.98);
   }
   to {
     opacity: 1;
@@ -893,663 +1641,145 @@
   }
 }
 
+.cg-select-menu[hidden] {
+  display: none !important;
+}
+
 .cg-select-option {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
   width: 100%;
   padding: 10px 12px;
-  border: none;
-  border-radius: 8px;
+  border: 0;
+  border-radius: 10px;
   background: transparent;
-  color: var(--config-text);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
   font-size: 13px;
-  font-family: inherit;
-  line-height: 1.35;
   text-align: left;
-  cursor: pointer;
-  transition: background var(--config-transition), color var(--config-transition);
-  box-sizing: border-box;
 }
 
-.cg-select-option:hover,
-.cg-select-option.is-active {
-  background: rgba(var(--config-primary-rgb), 0.1);
-  color: var(--config-primary);
+.cg-select-option.is-selected,
+.cg-select-option.is-active,
+.cg-select-option:hover {
+  background: color-mix(in srgb, var(--sob-accent) 12%, transparent);
+  color: var(--sob-accent);
 }
 
-.cg-select-option.is-selected {
-  background: rgba(var(--config-primary-rgb), 0.14);
-  color: var(--config-primary);
-  font-weight: 600;
-}
-
-.cg-select-option-check {
-  flex-shrink: 0;
-  width: 16px;
-  height: 16px;
-  opacity: 0;
-  color: var(--config-primary);
-}
-
-.cg-select-option.is-selected .cg-select-option-check {
-  opacity: 1;
-}
-
-.cg-select-menu::-webkit-scrollbar {
-  width: 6px;
-}
-
-.cg-select-menu::-webkit-scrollbar-thumb {
-  background: rgba(var(--config-primary-rgb), 0.22);
-  border-radius: 3px;
-}
-
-.dark .cg-select-menu {
-  background: rgba(23, 23, 23, 0.96);
-  border-color: rgba(255, 255, 255, 0.12);
-}
-
-/* 未增强前的原生 select 兜底（隐藏 option 系统菜单尽量一致） */
 select.form-select:not(.cg-select-native) {
-  -webkit-appearance: none;
   appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 12px center;
   padding-right: 36px;
-  cursor: pointer;
 }
 
-.dark select.form-select:not(.cg-select-native) {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
-}
+/* ---------- 响应式 ---------- */
 
-/* 资源配置分组 */
-.resource-group {
-  padding: 14px;
-  margin-bottom: 16px;
-  background: var(--config-input-bg);
-  border-radius: var(--config-radius-sm);
-  border: 1px solid var(--config-border);
-}
+@media (width >= 800px) {
+  [data-step='domain'] .cg-ob-body {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px 20px;
+  }
 
-.resource-group:last-child {
-  margin-bottom: 0;
-}
+  .cg-choice__card {
+    min-height: 7.2rem;
+  }
 
-.resource-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--config-text);
-  margin-bottom: 8px;
-}
-
-.resource-label-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-  border-radius: 7px;
-  color: var(--config-primary);
-  background: rgba(var(--config-primary-rgb), 0.1);
-  border: 1px solid rgba(var(--config-primary-rgb), 0.12);
-}
-
-.resource-label-icon svg {
-  display: block;
-}
-
-.resource-group .form-row {
-  margin-bottom: 0;
-}
-
-.resource-group .form-group {
-  margin-bottom: 0;
-}
-
-.resource-group .form-hint {
-  display: block;
-  margin-top: 6px;
-}
-
-.resource-desc {
-  margin: -4px 0 12px;
-  font-size: 12px;
-  color: var(--config-text-muted);
-  line-height: 1.5;
-}
-
-.result-badge {
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--config-text-muted);
-  background: var(--config-input-bg);
-  border: 1px solid var(--config-border);
-  border-radius: 999px;
-  padding: 3px 8px;
-  white-space: nowrap;
-  margin-right: 4px;
-}
-
-@media (max-width: 640px) {
-  .result-badge {
-    order: 2;
-    width: 100%;
-    text-align: center;
-    margin: 0 0 4px;
+  .limit-preset-toggle .cg-choice__card {
+    min-height: 4.8rem;
   }
 }
 
-/* Input with action button */
-.input-with-action {
-  display: flex;
-  gap: 8px;
-}
-
-.input-with-action .form-input {
-  flex: 1;
-}
-
-.btn-generate {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  background: linear-gradient(135deg, var(--config-primary), var(--config-secondary));
-  border: none;
-  border-radius: var(--config-radius-xs);
-  color: white;
-  cursor: pointer;
-  transition: var(--config-transition);
-  box-shadow: 0 4px 12px rgba(var(--config-primary-rgb), 0.3);
-}
-
-.btn-generate:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(var(--config-primary-rgb), 0.4);
-}
-
-.btn-generate:active {
-  transform: translateY(0);
-}
-
-.btn-copy-field {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 44px;
-  padding: 0 14px;
-  border: 1px solid var(--config-border);
-  border-radius: var(--config-radius-xs);
-  background: var(--config-input-bg);
-  color: var(--config-text);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: var(--config-transition);
-}
-
-.btn-copy-field:hover {
-  border-color: var(--config-primary);
-  color: var(--config-primary);
-}
-
-.btn-copy-field.copied {
-  border-color: var(--config-primary);
-  color: var(--config-primary);
-}
-
-.setup-secret-reminder-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 8px;
-  flex-wrap: wrap;
-}
-
-.setup-secret-reminder-row code {
-  flex: 1;
-  min-width: 0;
-  overflow-wrap: anywhere;
-  font-size: 12px;
-}
-
-/* ========================================
-   File Upload
-   ======================================== */
-
-.upload-group {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-@media (max-width: 600px) {
-  .upload-group {
-    grid-template-columns: 1fr;
+@media (width >= 880px) {
+  .cg-ob-grid {
+    gap: 16px 20px;
   }
 }
 
-.upload-item label {
-  display: block;
-  margin-bottom: 8px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--config-text);
-}
-
-.upload-box {
-  position: relative;
-  border: 2px dashed var(--config-border);
-  border-radius: var(--config-radius-sm);
-  padding: 24px 16px;
-  text-align: center;
-  cursor: pointer;
-  transition: var(--config-transition);
-  background: var(--config-input-bg);
-}
-
-.upload-box:hover {
-  border-color: var(--config-primary);
-  background: rgba(var(--config-primary-rgb), 0.05);
-}
-
-.upload-box.dragover {
-  border-color: var(--config-primary);
-  background: rgba(var(--config-primary-rgb), 0.1);
-  border-style: solid;
-}
-
-.upload-placeholder {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  color: var(--config-text-muted);
-  font-size: 13px;
-}
-
-.upload-placeholder svg {
-  opacity: 0.6;
-  color: var(--config-text-secondary);
-}
-
-.upload-success {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  color: var(--config-success);
-  font-size: 13px;
-}
-
-.upload-success .file-name {
-  max-width: 150px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.upload-success .btn-remove {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  background: none;
-  border: none;
-  border-radius: 6px;
-  color: var(--config-text-muted);
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
-  transition: var(--config-transition);
-}
-
-.upload-success .btn-remove svg {
-  display: block;
-}
-
-.upload-success .btn-remove:hover {
-  color: var(--config-error);
-  background: rgba(239, 68, 68, 0.1);
-}
-
-/* ========================================
-   Action Buttons
-   ======================================== */
-
-.form-actions {
-  display: flex;
-  justify-content: center;
-  padding-top: 4px;
-  position: sticky;
-  bottom: 12px;
-  z-index: 5;
-}
-
-.btn-primary {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px 32px;
-  background: linear-gradient(135deg, var(--config-primary), var(--config-secondary));
-  border: none;
-  border-radius: var(--config-radius-sm);
-  color: white;
-  font-size: 15px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: var(--config-transition);
-  box-shadow: 0 8px 24px rgba(var(--config-primary-rgb), 0.35), 0 2px 8px rgba(0, 0, 0, 0.08);
-}
-
-.btn-primary svg {
-  stroke: white;
-  flex-shrink: 0;
-}
-
-.btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(var(--config-primary-rgb), 0.4);
-}
-
-.btn-primary:active {
-  transform: translateY(0);
-}
-
-.btn-primary:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-/* ========================================
-   Results Section
-   ======================================== */
-
-.results-section {
-  margin-top: 28px;
-  animation: fadeSlideIn 0.4s ease-out;
-}
-
-.results-intro {
-  margin: -4px 0 16px !important;
-  padding: 0 4px;
-}
-
-@keyframes fadeSlideIn {
-  from {
-    opacity: 0;
-    transform: translateY(16px);
+@media (width <= 800px) {
+  .cg-site-steps {
+    grid-template-columns: minmax(0, 1fr);
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+
+  .cg-site-steps li {
+    grid-template-columns: 28px minmax(0, 1fr);
+    gap: 12px;
+    align-items: start;
+    padding-right: 0;
+    padding-bottom: 16px;
+  }
+
+  .cg-site-steps li:last-child {
+    padding-bottom: 0;
+  }
+
+  .cg-site-steps li:not(:last-child)::after {
+    top: 28px;
+    right: auto;
+    bottom: 4px;
+    left: 13px;
+    width: 1px;
+    height: auto;
   }
 }
 
-.results-title {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  margin: 0 0 12px;
-  padding: 10px 16px 10px 12px;
-  background: var(--config-surface-elevated);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
-  border: 1px solid var(--config-border);
-  border-radius: 50px;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--config-text);
-}
-
-.results-title-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  color: #fff;
-  background: linear-gradient(135deg, var(--config-primary), var(--config-secondary));
-  box-shadow: 0 3px 10px rgba(var(--config-primary-rgb), 0.28);
-}
-
-.results-title-icon svg {
-  display: block;
-}
-
-.result-card {
-  background: var(--config-surface);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
-  border: 1px solid var(--config-border);
-  border-radius: var(--config-radius);
-  margin-bottom: 14px;
-  overflow: hidden;
-  box-shadow: var(--config-shadow);
-  animation: fadeSlideIn 0.4s ease-out backwards;
-}
-
-.result-card:last-child {
-  margin-bottom: 0;
-}
-
-.result-card:nth-child(3) {
-  animation-delay: 0.05s;
-}
-
-.result-card:nth-child(4) {
-  animation-delay: 0.1s;
-}
-
-.result-card:nth-child(5) {
-  animation-delay: 0.15s;
-}
-
-.result-card:nth-child(6) {
-  animation-delay: 0.2s;
-}
-
-.result-header {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  padding: 12px 14px;
-  background: rgba(var(--config-primary-rgb), 0.04);
-  border-bottom: 1px solid var(--config-border);
-}
-
-.dark .result-header {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.result-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-  border-radius: 8px;
-  color: var(--config-primary);
-  background: rgba(var(--config-primary-rgb), 0.1);
-  border: 1px solid rgba(var(--config-primary-rgb), 0.14);
-}
-
-.result-icon svg {
-  display: block;
-}
-
-.result-name {
-  flex: 1;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--config-text);
-  font-family: 'SF Mono', Monaco, 'Consolas', monospace;
-  min-width: 0;
-}
-
-.btn-copy,
-.btn-download {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
-  background: var(--config-input-bg);
-  border: 1px solid var(--config-border);
-  border-radius: var(--config-radius-xs);
-  color: var(--config-text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: var(--config-transition);
-}
-
-.btn-copy:hover,
-.btn-download:hover {
-  background: rgba(var(--config-primary-rgb), 0.1);
-  color: var(--config-primary);
-  border-color: rgba(var(--config-primary-rgb), 0.3);
-}
-
-.btn-copy.copied {
-  background: var(--config-success);
-  border-color: var(--config-success);
-  color: white;
-}
-
-.result-content {
-  margin: 0;
-  padding: 16px;
-  max-height: 350px;
-  overflow: auto;
-  background: var(--config-code-bg);
-}
-
-.result-content code {
-  display: block;
-  font-family: 'SF Mono', Monaco, 'Consolas', monospace;
-  font-size: 12px;
-  line-height: 1.6;
-  color: var(--config-text);
-  white-space: pre;
-}
-
-/* Scrollbar for result content */
-.result-content::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-.result-content::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.result-content::-webkit-scrollbar-thumb {
-  background: rgba(var(--config-primary-rgb), 0.2);
-  border-radius: 3px;
-}
-
-.result-content::-webkit-scrollbar-thumb:hover {
-  background: rgba(var(--config-primary-rgb), 0.4);
-}
-
-/* ========================================
-   Responsive
-   ======================================== */
-
-@media (max-width: 640px) {
-  .page-content {
-    padding: 16px 12px 40px;
+@media (width >= 1100px) {
+  [data-step='advanced'] .cg-ob-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  
-  .page-header {
-    padding: 10px 14px 10px 10px;
-    gap: 10px;
-    max-width: 100%;
-  }
-  
-  .header-icon {
-    width: 32px;
-    height: 32px;
+}
+
+@media (width <= 640px) {
+  .cg-ob__card {
+    height: 100%;
+    border-radius: 0;
   }
 
-  .header-icon svg {
-    width: 16px;
-    height: 16px;
-  }
-  
-  .header-title {
-    font-size: 14px;
-  }
-  
-  .header-subtitle {
-    font-size: 11px;
-  }
-  
-  .form-section {
-    padding: 16px;
-    border-radius: var(--config-radius-sm);
-  }
-  
-  .section-title {
-    font-size: 14px;
+  .cg-choice,
+  .cg-ob-features,
+  .upload-group,
+  .cg-ob-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .section-icon {
-    width: 28px;
-    height: 28px;
-    border-radius: 8px;
-  }
-  
-  .form-input {
-    padding: 10px 12px;
-    font-size: 13px;
-  }
-  
-  .btn-generate {
-    width: 40px;
-    height: 40px;
-  }
-  
-  .btn-primary {
-    width: 100%;
-    justify-content: center;
-    padding: 12px 24px;
-    font-size: 14px;
+  .cg-ob-features > div {
+    min-height: 2.9rem;
+    flex-direction: row;
+    justify-content: flex-start;
+    padding: 0.6rem 1rem;
+    text-align: left;
   }
 
-  .form-actions {
-    bottom: 8px;
+  .cg-ob-top__step b {
+    display: none;
   }
-  
-  .result-header {
-    flex-wrap: wrap;
-    gap: 8px;
+
+  .cg-ob-welcome__mark {
+    width: 64px;
+    height: 64px;
+    border-radius: 20px;
   }
-  
-  .result-name {
-    width: 100%;
-    order: -1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cg-ob {
+    --sob-dur-fast: 1ms;
+    --sob-dur-base: 1ms;
+    --sob-dur-slow: 1ms;
+    --sob-dur-enter: 1ms;
+    --sob-stagger: 0ms;
+    --sob-shift-sm: 0px;
+    --sob-shift-x: 0px;
+    --sob-scale-press: 1;
+    --sob-scale-hover: 1;
+    --sob-lift: 0px;
   }
-  
-  .btn-copy,
-  .btn-download {
-    flex: 1;
-    justify-content: center;
+
+  .cg-ob__pane,
+  .cg-ob-bar,
+  .cg-ob-welcome__mark,
+  .cg-ob-hero > *,
+  .cg-ob-body > *,
+  .cg-select-menu,
+  .btn-generate.is-spinning svg {
+    animation: none !important;
   }
 }

--- a/apps/com.myriad.config-generator/page.html
+++ b/apps/com.myriad.config-generator/page.html
@@ -1,704 +1,542 @@
-<div id="tapp-background">
-  <div class="page-bg-base"></div>
-  <div class="page-bg-glow page-bg-glow-1"></div>
-  <div class="page-bg-glow page-bg-glow-2"></div>
-</div>
+<div id="tapp-background" aria-hidden="true"></div>
 
 <div id="tapp-content">
-  <div class="page-content">
-    <header class="page-header">
-      <div class="header-icon" aria-hidden="true">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-          <polyline points="14 2 14 8 20 8"/>
-          <path d="M12 18v-6M9 15l3 3 3-3"/>
-        </svg>
-      </div>
-      <div class="header-info">
-        <h1 class="header-title">Myriad 安装配置生成</h1>
-        <p class="header-subtitle">Compose · .env · Nginx · 部署说明</p>
-      </div>
-    </header>
+  <section class="cg-ob" aria-label="Myriad 安装配置">
+    <div class="cg-ob__card" id="cg-card">
+      <header class="cg-ob-top">
+        <div class="cg-ob-top__side" id="cg-top-side"></div>
+        <p class="cg-ob-top__step" id="cg-top-step" hidden>
+          <b id="cg-top-name"></b>
+          <span id="cg-top-progress"></span>
+        </p>
+      </header>
 
-    <div class="section-info">
-      <span class="section-info-icon" aria-hidden="true">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="12" cy="12" r="10"/>
-          <path d="M12 16v-4M12 8h.01"/>
-        </svg>
-      </span>
-      <div class="section-info-content">
-        <span class="section-info-title">说明</span>
-        按面板生成 Compose / .env / Nginx 与部署步骤。密钥勿提交。
-      </div>
-    </div>
-
-    <div class="config-form">
-      <section class="form-section">
-        <h2 class="section-title">
-          <span class="section-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="2" y="3" width="20" height="14" rx="2"/>
-              <path d="M8 21h8M12 17v4"/>
-            </svg>
-          </span>
-          面板
-        </h2>
-        <div class="form-group">
-          <span class="form-label-text" id="panel-mode-label">部署面板</span>
-          <div class="panel-mode-toggle" role="radiogroup" aria-labelledby="panel-mode-label">
-            <label class="panel-mode-option is-active">
-              <input type="radio" name="panel-mode" value="1panel" checked>
-              <span class="panel-mode-option-title">1Panel</span>
-              <span class="panel-mode-option-desc">编排粘贴 YAML · 环境变量框</span>
-            </label>
-            <label class="panel-mode-option">
-              <input type="radio" name="panel-mode" value="baota">
-              <span class="panel-mode-option-title">宝塔面板</span>
-              <span class="panel-mode-option-desc">可粘贴编排 · 注意 pgdata 属主</span>
-            </label>
-            <label class="panel-mode-option">
-              <input type="radio" name="panel-mode" value="generic">
-              <span class="panel-mode-option-title">通用 / CLI</span>
-              <span class="panel-mode-option-desc">标准路径 · docker compose</span>
-            </label>
-          </div>
-          <span class="form-hint" id="panel-mode-hint">1Panel：docker-compose.yml →「容器 / 编排」；.env →「环境变量」。站点整站反代到 HTTP_BIND:HTTP_PORT。</span>
-        </div>
-      </section>
-
-      <section class="form-section">
-        <h2 class="section-title">
-          <span class="section-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="10"/>
-              <path d="M2 12h20"/>
-              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
-            </svg>
-          </span>
-          域名
-        </h2>
-        <div class="form-group">
-          <label for="main-domain">主域名</label>
-          <input type="text" id="main-domain" class="form-input" placeholder="myriad.example.com" autocomplete="off">
-          <span class="form-hint">不要带 <code>https://</code>。会写入 <code>BASE_URL</code>/<code>FRONTEND_URL</code>（联邦 Actor URL）；外层 Nginx 须<strong>整站</strong>反代到 proxy，勿只反代 <code>/api</code>。</span>
-        </div>
-        <div class="form-group">
-          <label for="extra-domain">额外域名（可选）</label>
-          <input type="text" id="extra-domain" class="form-input" placeholder="www.example.com" autocomplete="off">
-        </div>
-      </section>
-
-      <section class="form-section">
-        <h2 class="section-title">
-          <span class="section-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <ellipse cx="12" cy="5" rx="9" ry="3"/>
-              <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>
-              <path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3"/>
-            </svg>
-          </span>
-          数据库
-        </h2>
-
-        <div class="form-group">
-          <span class="form-label-text" id="db-mode-label">部署方式</span>
-          <div class="db-mode-toggle" role="radiogroup" aria-labelledby="db-mode-label">
-            <label class="db-mode-option is-active">
-              <input type="radio" name="db-mode" value="bundled" checked>
-              <span class="db-mode-option-title">内置 Postgres</span>
-              <span class="db-mode-option-desc">compose 内 postgres · 默认</span>
-            </label>
-            <label class="db-mode-option">
-              <input type="radio" name="db-mode" value="external">
-              <span class="db-mode-option-title">外置 Postgres</span>
-              <span class="db-mode-option-desc">面板 / 托管库 · 无 postgres 服务</span>
-            </label>
-          </div>
-          <span class="form-hint">写入 <code>MYRIAD_DB_MODE=bundled|external</code>。外置时 updater 不快照数据库，备份自负。</span>
-        </div>
-
-        <div id="db-mode-bundled-fields">
-          <div class="form-group">
-            <label for="db-version">PostgreSQL 版本</label>
-            <input type="number" id="db-version" class="form-input" value="18" min="18" max="20" step="1">
-            <span class="form-hint">主版本 18–20（与当前 alpine 镜像线一致）</span>
-            <span class="form-hint">内置镜像 <code>postgres:VERSION-alpine</code>，主版本 ≥18</span>
-          </div>
-        </div>
-
-        <div id="db-mode-external-fields" hidden>
-          <div class="form-row">
-            <div class="form-group form-group-half">
-              <label for="db-host">主机</label>
-              <input type="text" id="db-host" class="form-input" placeholder="host.docker.internal 或 IP" autocomplete="off">
+      <div class="cg-ob__viewport">
+        <!-- 1. 欢迎 -->
+        <div class="cg-ob__pane is-welcome" data-step="welcome">
+          <div class="cg-ob-welcome">
+            <div class="cg-ob-welcome__mark" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                <polyline points="14 2 14 8 20 8"/>
+                <path d="M12 18v-6M9 15l3 3 3-3"/>
+              </svg>
             </div>
-            <div class="form-group form-group-half">
-              <label for="db-port">端口</label>
-              <input type="number" id="db-port" class="form-input" value="5432" min="1" max="65535">
+            <div class="cg-ob-hero">
+              <h1>先把安装文件准备好</h1>
+              <p class="cg-ob-hero__lead">选面板、填域名，先在服务器建好网站和证书。密钥和版本会自动填。</p>
+            </div>
+            <div class="cg-ob-body">
+              <div class="cg-ob-features">
+                <div>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+                  <span>选面板</span>
+                </div>
+                <div>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                  <span>填域名</span>
+                </div>
+                <div>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+                  <span>建站点</span>
+                </div>
+                <div>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+                  <span>拿走文件</span>
+                </div>
+              </div>
             </div>
           </div>
-          <div class="form-group">
-            <label for="db-sslmode">sslmode（可选）</label>
-            <select id="db-sslmode" class="form-input form-select">
-              <option value="" selected>不设置</option>
-              <option value="disable">disable</option>
-              <option value="allow">allow</option>
-              <option value="prefer">prefer</option>
-              <option value="require">require</option>
-              <option value="verify-ca">verify-ca</option>
-              <option value="verify-full">verify-full</option>
-            </select>
-          </div>
-          <span class="form-hint form-hint-block">容器访问宿主机上的库：常用 <code>host.docker.internal</code>（Docker Desktop）、宿主 IP，或 docker bridge 网关（如 <code>172.17.0.1</code>）。托管库填公网/VPC 主机名即可。</span>
-          <div class="form-group">
-            <label for="db-extra-network">为 backend 附加 docker 子网（可选）</label>
-            <input type="text" id="db-extra-network" class="form-input" placeholder="1panel-network" autocomplete="off">
-            <span class="form-hint">如果你的数据库同为容器但是与 myriad 不在同一个子网，你可能需要这个选项。对于 1Panel 部署，它通常为 <code>1panel-network</code>。这可能会增加后端容器的安全风险。</span>
-          </div>
-        </div>
-
-        <div class="form-row">
-          <div class="form-group form-group-half">
-            <label for="db-name">数据库名</label>
-            <input type="text" id="db-name" class="form-input" value="myriad" autocomplete="off">
-            <span class="form-hint">小写字母/数字/_，字母开头</span>
-          </div>
-          <div class="form-group form-group-half">
-            <label for="db-user">用户名</label>
-            <input type="text" id="db-user" class="form-input" value="myriad" autocomplete="off">
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="db-password">密码</label>
-          <div class="input-with-action">
-            <input type="text" id="db-password" class="form-input" placeholder="内置 ≥32 可生成；外置填真实密码" autocomplete="off">
-            <button type="button" id="gen-db-password" class="btn-generate" title="生成随机密码">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
-              </svg>
-            </button>
-          </div>
-          <span class="form-hint">写入 <code>DATABASE_URL</code> 时会对密码做 URL 编码</span>
-        </div>
-      </section>
-
-      <section class="form-section">
-        <h2 class="section-title">
-          <span class="section-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-              <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-            </svg>
-          </span>
-          密钥
-        </h2>
-        <p class="section-desc">写入 <code>.env</code>（未加引号）。仅允许 <code>A-Za-z0-9_-</code>，≥32 位；禁止换行 / 空格 / <code>#</code> / <code>=</code>。勿提交、勿外传。</p>
-        <div class="form-group">
-          <label for="jwt-secret">JWT_SECRET</label>
-          <div class="input-with-action">
-            <input type="text" id="jwt-secret" class="form-input" placeholder="[A-Za-z0-9_-] ≥32" autocomplete="off" spellcheck="false">
-            <button type="button" id="gen-jwt-secret" class="btn-generate" title="生成随机密钥">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
-              </svg>
+          <div class="cg-ob-bar is-split">
+            <p class="cg-ob-bar__note">只生成文件，不会动你的服务器。</p>
+            <button type="button" class="cg-ob-cta" data-wizard-next title="开始" aria-label="开始">
+              <span>开始</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
             </button>
           </div>
         </div>
-        <div class="form-group">
-          <label for="update-token">UPDATE_TOKEN</label>
-          <div class="input-with-action">
-            <input type="text" id="update-token" class="form-input" placeholder="[A-Za-z0-9_-] ≥32" autocomplete="off" spellcheck="false">
-            <button type="button" id="gen-update-token" class="btn-generate" title="生成 UPDATE_TOKEN">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
-              </svg>
-            </button>
-          </div>
-          <span class="form-hint">updater / gateway / guard</span>
-        </div>
-        <div class="form-group">
-          <label for="updater-gateway-secret">UPDATER_GATEWAY_SECRET</label>
-          <div class="input-with-action">
-            <input type="text" id="updater-gateway-secret" class="form-input" placeholder="[A-Za-z0-9_-] ≥32" autocomplete="off" spellcheck="false">
-            <button type="button" id="gen-updater-gateway-secret" class="btn-generate" title="生成 UPDATER_GATEWAY_SECRET">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
-              </svg>
-            </button>
-          </div>
-          <span class="form-hint">backend ↔ gateway</span>
-        </div>
-        <div class="form-group">
-          <label for="setup-secret">MYRIAD_SETUP_SECRET</label>
-          <div class="input-with-action">
-            <input type="text" id="setup-secret" class="form-input" placeholder="[A-Za-z0-9_-] ≥32" autocomplete="off" spellcheck="false">
-            <button type="button" id="gen-setup-secret" class="btn-generate" title="生成安装暗号">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
-              </svg>
-            </button>
-            <button type="button" id="copy-setup-secret" class="btn-copy-field" title="复制安装暗号">复制</button>
-          </div>
-          <span class="form-hint">首次打开站点<strong>创建所有者时要填</strong>。先点「复制」存下来，或从生成结果的 .env 里找 <code>MYRIAD_SETUP_SECRET</code>。不要发到群里。</span>
-        </div>
-      </section>
 
-      <section class="form-section">
-        <h2 class="section-title">
-          <span class="section-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
-              <path d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
-              <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
-              <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
-            </svg>
-          </span>
-          镜像 tag
-        </h2>
-        <p class="section-desc">Docker Hub versioned tag，禁止 <code>:latest</code>。生产可写 <code>vX.Y.Z@sha256:&lt;64hex&gt;</code> pin digest。</p>
-        <div class="tag-status-row">
-          <span id="tag-status" class="tag-status">正在获取最新版本…</span>
-          <button type="button" id="btn-refresh-tags" class="btn-secondary" title="从 Docker Hub 刷新">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/>
-            </svg>
-            刷新
-          </button>
-        </div>
-        <div class="form-row form-row-3">
-          <div class="form-group form-group-third">
-            <label for="myriad-tag">MYRIAD_TAG</label>
-            <input type="text" id="myriad-tag" class="form-input" value="" placeholder="自动获取…" autocomplete="off">
+        <!-- 2. 面板 -->
+        <div class="cg-ob__pane" data-step="panel" hidden>
+          <div class="cg-ob-hero">
+            <h1>你用什么装？</h1>
+            <p class="cg-ob-hero__lead">选你已经在用的面板。没有面板，就选「命令行」。</p>
           </div>
-          <div class="form-group form-group-third">
-            <label for="proxy-tag">PROXY_TAG</label>
-            <input type="text" id="proxy-tag" class="form-input" value="" placeholder="自动获取…" autocomplete="off">
-            <span class="form-hint">与 MYRIAD_TAG 独立；proxy 有 AP 路由/联邦变更时单独 bump</span>
-          </div>
-          <div class="form-group form-group-third">
-            <label for="updater-tag">UPDATER_TAG</label>
-            <input type="text" id="updater-tag" class="form-input" value="" placeholder="自动获取…" autocomplete="off">
-          </div>
-        </div>
-      </section>
-
-      <section class="form-section">
-        <h2 class="section-title">
-          <span class="section-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="2" y="7" width="20" height="10" rx="2"/>
-              <circle cx="12" cy="12" r="3"/>
-              <path d="M5 7V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v2"/>
-            </svg>
-          </span>
-          网络
-        </h2>
-        <p class="section-desc">自定义 compose 子网名</p>
-        <div class="form-row">
-          <div class="form-group form-group-third">
-            <label for="net-myriad">MYRIAD_DOCKER_NETWORK</label>
-            <input type="text" id="net-myriad" class="form-input" value="myriad-net" placeholder="myriad-net" autocomplete="off">
-            <span class="form-hint">myriad-net</span>
-          </div>
-          <div class="form-group form-group-third">
-            <label for="net-admin">MYRIAD_ADMIN_NETWORK</label>
-            <input type="text" id="net-admin" class="form-input" value="myriad-admin-net" placeholder="myriad-admin-net" autocomplete="off">
-            <span class="form-hint">myriad-admin-net</span>
-          </div>
-          <div class="form-group form-group-third">
-            <label for="net-guard">MYRIAD_DOCKER_GUARD_NETWORK</label>
-            <input type="text" id="net-guard" class="form-input" value="myriad-docker-guard-net" placeholder="myriad-docker-guard-net" autocomplete="off">
-            <span class="form-hint">myriad-docker-guard-net(internal)</span>
-          </div>
-        </div>
-      </section>
-
-      <details class="advanced-panel form-section">
-        <summary class="advanced-summary">
-          <span class="advanced-summary-main">
-            <span class="section-icon" aria-hidden="true">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="3"/>
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
-              </svg>
-            </span>
-            <span class="advanced-summary-text">
-              <span class="advanced-summary-title">高级</span>
-              <span class="advanced-summary-sub">通道 · 签名 · 端口 · 资源</span>
-            </span>
-          </span>
-          <span class="advanced-chevron" aria-hidden="true">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="6 9 12 15 18 9"/>
-            </svg>
-          </span>
-        </summary>
-        <div class="advanced-body">
-          <h3 class="advanced-subtitle">通道与签名</h3>
-          <div class="form-row">
-            <div class="form-group form-group-half">
-              <label for="channel">CHANNEL</label>
-              <select id="channel" class="form-input form-select">
-                <option value="stable" selected>stable</option>
-                <option value="preview">preview</option>
-              </select>
-            </div>
-            <div class="form-group form-group-half">
-              <label for="cosign-verify">COSIGN_VERIFY</label>
-              <select id="cosign-verify" class="form-input form-select">
-                <option value="strict" selected>strict</option>
-                <option value="soft">soft</option>
-                <option value="off">off（需双钥匙）</option>
-              </select>
-            </div>
-          </div>
-
-          <h3 class="advanced-subtitle">宿主入口</h3>
-          <div class="form-row">
-            <div class="form-group form-group-half">
-              <label for="http-bind-address">绑定</label>
-              <select id="http-bind-address" class="form-input form-select">
-                <option value="127.0.0.1" selected>127.0.0.1</option>
-                <option value="0.0.0.0">0.0.0.0</option>
-              </select>
-            </div>
-            <div class="form-group form-group-half">
-              <label for="http-port">HTTP_PORT</label>
-              <input type="number" id="http-port" class="form-input" value="8080" min="1" max="65535">
-            </div>
-          </div>
-
-          <div class="section-warning">
-            <span class="section-warning-icon" aria-hidden="true">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
-                <circle cx="12" cy="10" r="3"/>
-              </svg>
-            </span>
-            <div class="section-warning-content">
-              <span class="section-warning-title">内网端口（勿映射公网）</span>
-              <code>1102</code> <code>1103</code> <code>1101</code> <code>1104</code> <code>2375</code> <code>5432</code>
-            </div>
-          </div>
-
-          <h3 class="advanced-subtitle">资源上限</h3>
-          <div class="resource-group" id="db-resource-group">
-            <div class="resource-label"><span>PostgreSQL（仅内置）</span></div>
-            <div class="form-row">
-              <div class="form-group form-group-half">
-                <label for="db-cpu-limit">CPU</label>
-                <input type="text" id="db-cpu-limit" class="form-input" value="2.0" placeholder="2.0">
-              </div>
-              <div class="form-group form-group-half">
-                <label for="db-mem-limit">内存</label>
-                <input type="text" id="db-mem-limit" class="form-input" value="2G" placeholder="2G">
-              </div>
-            </div>
-          </div>
-          <div class="resource-group">
-            <div class="resource-label"><span>Backend</span></div>
-            <div class="form-row">
-              <div class="form-group form-group-half">
-                <label for="backend-cpu-limit">CPU</label>
-                <input type="text" id="backend-cpu-limit" class="form-input" value="2.0" placeholder="2.0">
-              </div>
-              <div class="form-group form-group-half">
-                <label for="backend-mem-limit">内存</label>
-                <input type="text" id="backend-mem-limit" class="form-input" value="4G" placeholder="4G">
-              </div>
-            </div>
-          </div>
-          <div class="resource-group">
-            <div class="resource-label"><span>Frontend</span></div>
-            <div class="form-row">
-              <div class="form-group form-group-half">
-                <label for="frontend-cpu-limit">CPU</label>
-                <input type="text" id="frontend-cpu-limit" class="form-input" value="2.0" placeholder="2.0">
-              </div>
-              <div class="form-group form-group-half">
-                <label for="frontend-mem-limit">内存</label>
-                <input type="text" id="frontend-mem-limit" class="form-input" value="2G" placeholder="2G">
-              </div>
-            </div>
-          </div>
-        </div>
-      </details>
-
-      <section class="form-section">
-        <h2 class="section-title">
-          <span class="section-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-              <polyline points="14 2 14 8 20 8"/>
-              <line x1="16" y1="13" x2="8" y2="13"/>
-              <line x1="16" y1="17" x2="8" y2="17"/>
-              <line x1="10" y1="9" x2="8" y2="9"/>
-            </svg>
-          </span>
-          Nginx（可选）
-        </h2>
-        <p class="section-desc">反代到 <code>127.0.0.1:HTTP_PORT</code>。可上传站点 .conf 保留 SSL。</p>
-        <div class="upload-group">
-          <div class="upload-item">
-            <label>主域名 .conf</label>
-            <div class="upload-box" id="upload-nginx-conf">
-              <input type="file" id="file-nginx-conf" accept=".conf" hidden>
-              <div class="upload-placeholder">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
-                </svg>
-                <span>上传 / 拖拽</span>
-              </div>
-              <div class="upload-success" hidden>
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
-                  <polyline points="22 4 12 14.01 9 11.01"/>
-                </svg>
-                <span class="file-name"></span>
-                <button type="button" class="btn-remove" title="移除" aria-label="移除">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <line x1="18" y1="6" x2="6" y2="18"/>
-                    <line x1="6" y1="6" x2="18" y2="18"/>
+          <div class="cg-ob-body">
+            <div class="panel-mode-toggle cg-choice" role="radiogroup" aria-label="部署面板">
+              <label class="panel-mode-option cg-choice__card is-active">
+                <input type="radio" name="panel-mode" value="1panel" checked>
+                <span class="cg-choice__logo" aria-hidden="true">
+                  <svg class="cg-logo-1panel" viewBox="0 0 33 33" fill="#0052D9" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M19.4207 4.84191L7.78421 11.5601V21.6237L15.323 25.9772L12.4016 27.6635L4.86277 23.3101V9.87373L16.4993 3.15553L19.4207 4.84191Z"/>
+                    <path d="M25.2158 21.6251L13.5779 28.3419L16.4993 30.0283L28.1372 23.3115L25.2158 21.6251Z"/>
+                    <path d="M20.5983 5.52166L17.6769 7.20806L25.2157 11.5601V21.6237L28.1358 23.3101V9.87372L20.5983 5.52166Z"/>
+                    <path d="M16.9219 9.32801L17.8136 9.86003V23.5262L16.9219 24.0405V9.32801Z"/>
+                    <path d="M12.5233 11.8624L16.9219 9.32801L16.9205 24.0418L14.0716 22.3979V13.5775H12.5233V11.8624Z"/>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M3 8.79596L16.4993 1L30 8.79596V24.3879L16.4993 32.1838L3 24.3879V8.79596ZM29.6403 9.00384L16.4993 1.41714V1.41031L3.35834 8.99701V24.1786L16.4993 31.7722L29.6403 24.1854V9.00384Z"/>
                   </svg>
+                </span>
+                <span class="panel-mode-option-title cg-choice__title">1Panel</span>
+                <span class="panel-mode-option-desc cg-choice__desc">编排里贴 YAML，环境变量里贴 .env</span>
+              </label>
+              <label class="panel-mode-option cg-choice__card">
+                <input type="radio" name="panel-mode" value="baota">
+                <span class="cg-choice__logo" aria-hidden="true">
+                  <img class="cg-logo-baota" alt="" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADsAAABACAYAAACkwA+xAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAO6ADAAQAAAABAAAAQAAAAACXb5jZAAABZGlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIEltYWdlUmVhZHk8L3htcDpDcmVhdG9yVG9vbD4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CgQ+9BsAAA9NSURBVGgF7VtpcFTHte7l3jsz0mhBAkkIsAUW2EaADbJZAgghx85LquIsFZQUJk6lkoqzlJ3tRyqOKxme40riVy+VOD9S5L3y8mKnEkjsylJZSCFkIyQDFg44YLCFkYQsAwIsIWnWe7vfd1qaYSTQRWILUblhZu7S9/T5znf6nL7dLc6uZYkwq9xa+EVREHjQyrOfG8wJ/LinvnHgWqkgrlVD1E5JckGx4vpWJtlcbot5gVRs+rVs/5qCFY4uZpacxgXnjLNSoZ2SSQtWS1bGNC8FUBRdyrkqnbRgmWAlnAGgAlTFpwqmp15LsPJaNFYemTc1fNeMGsbFBpB6B7OFLYMiyDgPFnxiVqxwfUVv3/zOKGtk+mrqYxzqijewjsmZS6pmu0qs0pq9nwu2AsBmoTFbg1WZbzOr0GHCBreMe9pT7yB47NKc/10psaOzTb7BIo3uldbryoGNVDk3OKwyrqwayb17GONrtORFHLGIeYoBNHwXH5xLALUKbHRd3KP/VMfiQ3U81ceZaNJabeVKvCiLjx9q+1Bb4koARyuXXHjRE8vyRG90sW2x9yvN6qDzAkTafEIAtobAkXgBWNRhNK4rPYgc229PCYSZI8JkAK1Q1xvWA0K4hWMygMcGIOd1oVmDJ9lWrftf7Vz/Wi+JH649oZ+JgYV7Ft92W5kj9XLlsQ8Irmu0YHO4FDbzNAE5B1BCaYCE23pcqXcAZw9ubrcd9qIO5bwdKrLL4KermFJ1ALYUdWcwyW0DPoXaVAg4GQmytKs9oXS74ryJMfU3rnnz0XLnbbZ2/O5+DuwXqu3yCm+pEurr3NXHpKse7YocOMPgnjOYV+HawVrB3P9AH1sOpqYTEAZwGYDodOYaFIRiSQB7FVdeYszdrpjYezL1iR4Wieiyxxask/nOfVZe4A/hnLO/PLDuQGreL2qLE3nJRULzWphrDfx5KXcQwAzrAEteguaMfGLdo7ZVj9b8FZz9nUveoGNdh9s/2x6vfHL1NDeoPg+zLRcu33ZWvvtkT/0BM0o7Bxayir9/W3lA6Md1UH5SR91DsOxhrXWZEOxWAJxCLRpwxCCVNHsaDqfUKVh7L+5s19x9yQ4W7O/6RktsqOLQN+TPgFdErKLA5xGgnk0l1cauT7e0ZdepfOKDAa/k9C3KlauEJdbCY5ainen4WOTqme6R7hrk7i4bRB8/iPZ3w/xLZJ59pxd3O3RCf6EjltjBHmhNURvZYE2b4chNJflO7k+1zT9F+dCwR9gIYDZ7KRWFMQ5BwA7FWYOteGvXI/u6UXPYEkZc9hcve6yqlknru3ahUwt2d2kt/7Nj/Ut/IRtmV8w+rty8ehpLeotdwWu5VjXwrIXc5nlQnWvq52nWYXhjfPKslN4nFPvcEbvpH6w+Ew3OB0sNFX9n3gw7HPw/uE0dmIVYCPA0pYIugN7DpW5AimiyQ7lHRrNHz6dLeaQ6xw3G5wpXroRytRgxLUd6KYflJZjV6OvdUPkV5fKd3PJeOuvp189s2HU2/fzo36rIOie24MSNKp58HxeyDiyugG43AqRjiEH/hgEO8hRbfzTQ9M9soCTrPGaHG+Dljy1arLR+VAteAEJfVFI25Hlsf9vDr/aMViJzHmFiJqsqTEl5OwzyMa7YSjw/FwP/MFyM+hm6I1JPOs9KSKY+SNR6LAaW2gG+mVvieRW197bnNvaMVjjTFg5uf6q28ExOvEqmRC2zRC26mGVxb2Pb8y/vYFvOMZp+ZiywmfvVm6qt1mGfT18c8ftEZWBmrzUvKQIrLaHqlOLoY2wmvEIODQvRF8hJqW9RNwBAi8BOcQxw44bD903kpQjuGq/uhtu2ai4apOY7Yvmx17s/3Bod0Xb2yeZ1kh3colnEcJx9J3N8MbCZipmDzUxOPbq41El6d3gWcqvSq+FK8wAkbBii0QP1b9I3HUSGWB0AqweRaxutQutN5NnZqAbX5gu4RbkZj9BzSGFUEGGNcYyRPB3DrSPwFLi72qZjek97RbBrImnHyDSS6Qtdk7wpc551UB4pz9FW6Xwm3BpYug5sVANcGdzNKJdJP/QMRWhiEeER/45zLnZrrrbJlLVDK/Fmd+QcOxVP1QZ1SM0WyluJ2HAXnl4OjzD5NhN8SCbEDaUdDC9hDO6pU7i6Dz7TKLloZFbstbfqW6mvX1B/sC2IcV72w0X3o8qX8OmVim18+5H9L9PNIrasPODEl2oOJTxdA0vfBKZCJM6AIxaokCLEAgUxpVNgtQPHLbj7W0+n9qydu+Dklvot6fHR0DMX+gaGW164qyg6GF8iLPZxyILHiEpu6QDUhGxAo+xAJe0x+GUpnUJs6RBMoE3VIFzR/Fao6Qj19Rt+tWoVutZXIHoud9nveOkPFs5BMn+aBfhquEcfGEE/IXZ0FYSWGosCmAGYtluaPeLPU2TRfUC7Hai3W8nka2YwYrQ6/4sitHOjyLdsEW3zi7yba8N9cbcKyq6BQesAq9qMtQUXF2YdbZnBBuuDUq0A2MG1vpeH7GKd9A5Irj/FGYaA5UtuWwQ3egFk32jUAygzcB/NHvm5Bnse60TdZtTd5nmp5p6SnPZ04j4PXoTmnRZM10zeoZiqwQBlpch3ZlsFzmkw9zLkbBeCt4iTxzvaHhpjwA/N5/xy1Szk/qVMeXfD9KuQem5CIATr5GmjWCfG0cNM7FDstNLuuo4BtwlXURBRy86G7gWLzwCMcVWqzKGZweeCPc72o+Z2ZlkNVtSfPSNz+Gv69xfWaIt/D695tQhO9E7HRNhiCFCMO+btgPr9K56rNnZuaPlT9rNjHd/8+5V5iT4+H2lrLcxfB7BLkHqmQP9zrBMyKTzhqQfjA4lnuh9ojVpGICzq/ujmv1qe818Yk34XoR8ksHa47k6os40rt7kU7PmloPJN5TnqTEmVFRDLrFLH5jz3V0fXbzsBUTmSyxzIE9od7nTEBkXdhGf6O4J1CPdDpEtF5PbCeK7e4EwJ5fKQ3O3Zal/XupZ3yehGV3wd/sjOfvzsMp9I5PHZc7fOgrwV8DgEOb0KQXKuCEipYt7/uKz/190PvGZS1hBYPHXqW4f7i56o/G+nL3gcfbXdSqld2X2vC3XOK+gCZdXzMY61vqxOIYhxr1JjDoIH7HbmxVpR/wTSCiGE5533dOYCSECYMPXYIEtVOMHgV3iI34LQ4dkp3lHx3MqX2bPsZ+1O715WfwAvGVklElFHGevAFfr8es6m6gIvL1Cto6lbkwWB33R/GK+EwyUDls7PPNRGwebnw/fO/4nUWjOmRgvCs+ykse6KmQ6PicXw9i9TuqEghmDAVNLz8I5rBt+Ya5JgBf1h7IIuKfG40UUKmDnhKp3Ay72DKTrJ58BgcyC69YZT4nAnY8mZP14RUup0bndeXt/oWPHWA619aKlh+DOiUfJsv8KLIsvyLGdgIVpdg6FfnQxbN2Mg3xL0cr506B+Ho6UlRR8Vnn4aroghEbp4UDKnJPSO15fa5PbGc9Fv6hDV5qORoViAA7wEmGkZE+mhAf4jfbAOnO9U0dRx92xyg1UYnEHTNnSTcjfc/BssOfhU7FRJSiS6fyKLgx+QYbsTMxzbkZoajLsfbOllyKdjARrB7OhKUyM3T7eD0W9qYT0IIDaNOvCfIM1UIR1kbhCjIoUpE9JoqOi4x5JvD9Lkd8QEIGKbXJg+Fyq4DkPZQvJKgKqUeZibQuCi9JcllmHomOyzA6posE8O2Bh4aLxTW2IWWMeAhH/bcvWWWRXve+QYaz5yoWbomi9YixxJ66lo1tZJGMxYGJMkuJA81TtreknuMkCpx8DDygZjgg9JHx760aFvIcBUN12fBg2jHgD4e/O5jCYrvP28C5qQDWlGA7mVOxzjITFVCNcZ9diIU1+wsBpIQeBIs4IzFVUilYhWe0n1VyZ1AaWn4YH7CMFX9ARGgC73gOp7pM36WVkI8PAyT+xTgX7QVMGl05oOXR/17Qt2RF2SC1EUgGBMB6Y3fdQk9BEVr87JkEGhgOB5ImRDEV9cF1Ri/GDTj6f9a+JtpSVc3i9iwKUW35RwqUKv1+d8wcJ1iMc0l9crhnHr5Q8WGQFdHh1kcpSJ99nrFDdSE6a1jSeOqaEvs2M+dR3eQF+zNV7M/VSbNGD9QKbvvQc2bYnJ9vses5ON0TSe95hNWwJzdxj7m0WJzKV/5wNfZlVC0fasSTPw8AX778zihXSfRGAxenKxTuJTJhFYGi5imsynXBysmXHykXAd3cI81qWDFQFsxsE053WEZ0xVgNLDvJTvNIYvs1Gd6sNE/T6zQDRmM9fBDeJTsFcxE/qunza+YPsfPnQmxfhWTG61moVnP0n/ontmbTjFOnWKP98Vajnup4YvWDyo5Wl+yBP6J5jTHcDMnp+sa38P6sBvPSbUz5TAGnHWNqALKUNrhr5lsPlEKndtyQnMDmOJla+mIZXvA+O4iRU2JrBMYrYjjKP+WFUwOU5rsE9jJ87PO+7b6csqybgoWKo02HBy0K6Z1mZLngsFq+na5ZTLBguMBqjHfp/0khuPbdg15pJHtp7jAksPxBt7+uzV0/ZbkofRT5aguawV02yRFz++LLAEFNt1ueIvJOLq292f2f3GxVscqjFusFSdAIdWT9sDdinMV+PX7CIdb2PpepcK1gQjattTT6E7PXzs/pZxMZpud0Jg6aFoY8+AfWd4jx1wOpDCFyFKF050KeJSwBq3ZfwUsuljSZF4/Nh9u99Jgxjv74TBkuD4zncT/TfN/Ge4ONWEba5l2HM8F2ur43briYAlNg2jiu3A+tZXedLeDEZp0XzC5bIja36kqijXsuqZpR5CZr+VWM4sWY6hzojF6DHqGIBEheKdytOb4p7+3xP3N58co/q4Ll8Ss9mSE409sYGaE3vzWPEfkQL6MVldgf2JhYbmMQZvfszSajy22FKGO85d/qQS7tc63gj8cfCrO2jTyGWVy2Z2ROvYUFJy54IKkZLrsWD6RWTkcmpgxIYxnJ/HLCqZLQdD2wl6wOQzFj5HYonDo/dMjGhvgidXFuy5xnn5o4uweZN/FH9793H05oU4DtEOVFpWpa0E5k9dHAzgcBMlAdc/jF11f8CS8u/a32zez3z2RpxrZmJHVwtsRospP5xTkKPD1fgDio9gO8LdYHAO/swlYOU7SS0kUofa6gn2Z+6JPZ33NfkO5DNCL/HgqoPN1ouCWSjHutsKWmusXKfVy2MvdNW3nMmuczWP/x9x+S4kY3+ZwQAAAABJRU5ErkJggg==">
+                </span>
+                <span class="panel-mode-option-title cg-choice__title">宝塔</span>
+                <span class="panel-mode-option-desc cg-choice__desc">粘编排，或放到网站目录</span>
+              </label>
+              <label class="panel-mode-option cg-choice__card">
+                <input type="radio" name="panel-mode" value="generic">
+                <span class="cg-choice__logo" aria-hidden="true">
+                  <svg class="cg-logo-cli" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="4" width="18" height="16" rx="3"/>
+                    <path d="M7 9l3 3-3 3M13 15h4"/>
+                  </svg>
+                </span>
+                <span class="panel-mode-option-title cg-choice__title">命令行</span>
+                <span class="panel-mode-option-desc cg-choice__desc">自己用 docker compose 启动</span>
+              </label>
+            </div>
+            <p class="cg-ob-note" id="panel-mode-hint">下一步会告诉你，文件该贴到面板的哪里。</p>
+          </div>
+          <div class="cg-ob-bar">
+            <button type="button" class="cg-ob-cta" data-wizard-next title="下一步" aria-label="下一步">
+              <span>下一步</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- 3. 域名 -->
+        <form class="cg-ob__pane" data-step="domain" hidden>
+          <div class="cg-ob-hero">
+            <h1>站点域名</h1>
+            <p class="cg-ob-hero__lead">以后用这个地址打开 Myriad。不用写 https://。</p>
+            <div class="cg-ob-hero__notes" id="cg-note-domain"></div>
+          </div>
+          <div class="cg-ob-body">
+            <label class="cg-ob-field">
+              <span class="cg-ob-field__label">主域名</span>
+              <input type="text" id="main-domain" class="form-input cg-ob-input" placeholder="myriad.example.com" autocomplete="off" spellcheck="false">
+              <span class="cg-ob-field__hint">写成 myriad.example.com 这样即可</span>
+            </label>
+            <label class="cg-ob-field">
+              <span class="cg-ob-field__label">额外域名 <i class="cg-ob-field__optional">可选</i></span>
+              <input type="text" id="extra-domain" class="form-input cg-ob-input" placeholder="www.example.com" autocomplete="off" spellcheck="false">
+              <span class="cg-ob-field__hint">没有就留空</span>
+            </label>
+          </div>
+          <div class="cg-ob-bar">
+            <button type="button" class="cg-ob-cta" data-wizard-next title="下一步" aria-label="下一步">
+              <span>下一步</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+            </button>
+          </div>
+        </form>
+
+        <!-- 4. 站点 Nginx -->
+        <div class="cg-ob__pane" data-step="site" hidden>
+          <div class="cg-ob-hero">
+            <h1>先建好网站和证书</h1>
+            <p class="cg-ob-hero__lead">先去服务器创建站点、把 SSL 配好，再把站点 .conf 丢到这里。我们会尽量留住证书，只改成整站反代。</p>
+          </div>
+          <div class="cg-ob-body">
+            <p class="cg-site-domain" id="cg-site-domain-note">当前域名还没填。</p>
+            <ol class="cg-site-steps" id="cg-site-steps"></ol>
+            <div class="upload-group is-single" id="site-upload-group">
+              <div class="upload-item">
+                <label id="site-main-upload-label">主域名 .conf</label>
+                <div class="upload-box" id="upload-nginx-conf">
+                  <input type="file" id="file-nginx-conf" accept=".conf,.txt" hidden>
+                  <div class="upload-placeholder"><span>把配好 SSL 的 .conf 拖到这里</span></div>
+                  <div class="upload-success" hidden>
+                    <span class="file-name"></span>
+                    <button type="button" class="btn-remove" title="移除" aria-label="移除">×</button>
+                  </div>
+                </div>
+              </div>
+              <div class="upload-item" id="site-extra-upload" hidden>
+                <label id="site-extra-upload-label">额外域名 .conf</label>
+                <div class="upload-box" id="upload-extra-nginx-conf">
+                  <input type="file" id="file-extra-nginx-conf" accept=".conf,.txt" hidden>
+                  <div class="upload-placeholder"><span>把额外域名的 .conf 拖到这里</span></div>
+                  <div class="upload-success" hidden>
+                    <span class="file-name"></span>
+                    <button type="button" class="btn-remove" title="移除" aria-label="移除">×</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p class="cg-ob-field__hint" id="cg-site-path" hidden></p>
+            <p class="cg-ob-field__hint">没有现成文件也能继续，我们会生成一份默认配置，证书要之后自己贴。</p>
+          </div>
+          <div class="cg-ob-bar">
+            <button type="button" class="cg-ob-cta" data-wizard-next title="下一步" aria-label="下一步">
+              <span>下一步</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- 5. 数据库 -->
+        <form class="cg-ob__pane" data-step="database" hidden>
+          <div class="cg-ob-hero">
+            <h1>数据库怎么放？</h1>
+            <p class="cg-ob-hero__lead">第一次装，用内置的就行。已经有 Postgres，再选外置。</p>
+            <div class="cg-ob-hero__notes" id="cg-note-database"></div>
+          </div>
+          <div class="cg-ob-body">
+            <div class="db-mode-toggle cg-choice cg-choice--two" role="radiogroup" aria-labelledby="db-mode-label">
+              <span class="visually-hidden" id="db-mode-label">数据库方式</span>
+              <label class="db-mode-option cg-choice__card is-active">
+                <input type="radio" name="db-mode" value="bundled" checked>
+                <span class="cg-choice__logo" aria-hidden="true">
+                  <svg class="cg-logo-cli" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <ellipse cx="12" cy="5" rx="8" ry="3"/>
+                    <path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/>
+                    <path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>
+                  </svg>
+                </span>
+                <span class="db-mode-option-title cg-choice__title">内置</span>
+                <span class="db-mode-option-desc cg-choice__desc">一起装好，不用自己建库</span>
+              </label>
+              <label class="db-mode-option cg-choice__card">
+                <input type="radio" name="db-mode" value="external">
+                <span class="cg-choice__logo" aria-hidden="true">
+                  <svg class="cg-logo-cli" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"/>
+                    <path d="M12 12l8-4.5M12 12v9M12 12L4 7.5"/>
+                  </svg>
+                </span>
+                <span class="db-mode-option-title cg-choice__title">外置</span>
+                <span class="db-mode-option-desc cg-choice__desc">填你现有库的地址</span>
+              </label>
+            </div>
+
+            <p class="cg-ob-note" id="db-bundled-hint">库名、用户、密码都会自动写好。你不用记这些。</p>
+
+            <div id="db-mode-external-fields" hidden>
+              <div class="cg-ob-grid">
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">主机</span>
+                  <input type="text" id="db-host" class="form-input cg-ob-input" placeholder="host.docker.internal 或 IP" autocomplete="off">
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">端口</span>
+                  <input type="number" id="db-port" class="form-input cg-ob-input" value="5432" min="1" max="65535">
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">数据库名</span>
+                  <input type="text" id="db-name" class="form-input cg-ob-input" value="myriad" autocomplete="off">
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">用户名</span>
+                  <input type="text" id="db-user" class="form-input cg-ob-input" value="myriad" autocomplete="off">
+                </label>
+                <label class="cg-ob-field is-wide">
+                  <span class="cg-ob-field__label">sslmode <i class="cg-ob-field__optional">可选</i></span>
+                  <select id="db-sslmode" class="form-input form-select">
+                    <option value="" selected>不设置</option>
+                    <option value="disable">disable</option>
+                    <option value="allow">allow</option>
+                    <option value="prefer">prefer</option>
+                    <option value="require">require</option>
+                    <option value="verify-ca">verify-ca</option>
+                    <option value="verify-full">verify-full</option>
+                  </select>
+                </label>
+                <label class="cg-ob-field is-wide">
+                  <span class="cg-ob-field__label">附加 Docker 子网 <i class="cg-ob-field__optional">可选</i></span>
+                  <input type="text" id="db-extra-network" class="form-input cg-ob-input" placeholder="1panel-network" autocomplete="off">
+                  <span class="cg-ob-field__hint">库和 Myriad 不在同一个 Docker 网络时才需要。1Panel 常见值是 1panel-network。</span>
+                </label>
+              </div>
+            </div>
+
+            <div class="cg-ob-field" id="db-password-field" hidden>
+              <span class="cg-ob-field__label">数据库密码</span>
+              <div class="input-with-action">
+                <input type="text" id="db-password" class="form-input cg-ob-input" placeholder="填外置库的真实密码" autocomplete="off" spellcheck="false">
+                <button type="button" id="gen-db-password" class="btn-generate" title="生成随机密码" aria-label="生成随机密码">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16"/></svg>
                 </button>
               </div>
             </div>
           </div>
-          <div class="upload-item">
-            <label>额外域名 .conf</label>
-            <div class="upload-box" id="upload-extra-nginx-conf">
-              <input type="file" id="file-extra-nginx-conf" accept=".conf" hidden>
-              <div class="upload-placeholder">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
-                </svg>
-                <span>可选</span>
+          <div class="cg-ob-bar">
+            <button type="button" class="cg-ob-cta" data-wizard-next title="下一步" aria-label="下一步">
+              <span>下一步</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+            </button>
+          </div>
+        </form>
+
+        <!-- 6. 限额 -->
+        <div class="cg-ob__pane" data-step="limits" hidden>
+          <div class="cg-ob-hero">
+            <h1>给机器留多少资源？</h1>
+            <p class="cg-ob-hero__lead">按你服务器大概有多大来选。不确定就用推荐。</p>
+          </div>
+          <div class="cg-ob-body">
+            <div class="limit-preset-toggle cg-choice" role="radiogroup" aria-label="资源档">
+              <label class="cg-choice__card">
+                <input type="radio" name="limit-preset" value="small">
+                <span class="cg-choice__title">小型</span>
+                <span class="cg-choice__desc">大约 1–2G</span>
+              </label>
+              <label class="cg-choice__card is-active">
+                <input type="radio" name="limit-preset" value="standard" checked>
+                <span class="cg-choice__title">推荐</span>
+                <span class="cg-choice__desc">大约 2–4G</span>
+              </label>
+              <label class="cg-choice__card">
+                <input type="radio" name="limit-preset" value="large">
+                <span class="cg-choice__title">宽裕</span>
+                <span class="cg-choice__desc">4G 以上</span>
+              </label>
+            </div>
+            <button type="button" id="limit-preset-custom" class="cg-limit-custom-btn" aria-pressed="false">自定义数额</button>
+            <p class="cg-ob-note" id="limit-preset-hint">推荐档：数据库 1 核 / 1G，后端 2 核 / 2G，前端 1 核 / 512M。</p>
+
+            <div id="limit-custom-fields" class="cg-limit-custom" hidden>
+              <div class="cg-setting-block" id="db-resource-group">
+                <p class="cg-setting-block__title">数据库</p>
+                <p class="cg-setting-block__desc">内置 Postgres 用。外置库不会生成这个容器。</p>
+                <div class="cg-setting-row">
+                  <label class="cg-setting-item" for="db-cpu-limit"><span>CPU（核）</span><input type="text" id="db-cpu-limit" class="form-input cg-ob-input" value="1.0" inputmode="decimal"></label>
+                  <label class="cg-setting-item" for="db-mem-limit"><span>内存</span><input type="text" id="db-mem-limit" class="form-input cg-ob-input" value="1G"></label>
+                </div>
               </div>
-              <div class="upload-success" hidden>
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
-                  <polyline points="22 4 12 14.01 9 11.01"/>
-                </svg>
-                <span class="file-name"></span>
-                <button type="button" class="btn-remove" title="移除" aria-label="移除">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <line x1="18" y1="6" x2="6" y2="18"/>
-                    <line x1="6" y1="6" x2="18" y2="18"/>
-                  </svg>
-                </button>
+              <div class="cg-setting-block">
+                <p class="cg-setting-block__title">后端</p>
+                <p class="cg-setting-block__desc">API 和后台任务。</p>
+                <div class="cg-setting-row">
+                  <label class="cg-setting-item" for="backend-cpu-limit"><span>CPU（核）</span><input type="text" id="backend-cpu-limit" class="form-input cg-ob-input" value="2.0" inputmode="decimal"></label>
+                  <label class="cg-setting-item" for="backend-mem-limit"><span>内存</span><input type="text" id="backend-mem-limit" class="form-input cg-ob-input" value="2G"></label>
+                </div>
+              </div>
+              <div class="cg-setting-block">
+                <p class="cg-setting-block__title">前端</p>
+                <p class="cg-setting-block__desc">网站页面。</p>
+                <div class="cg-setting-row">
+                  <label class="cg-setting-item" for="frontend-cpu-limit"><span>CPU（核）</span><input type="text" id="frontend-cpu-limit" class="form-input cg-ob-input" value="1.0" inputmode="decimal"></label>
+                  <label class="cg-setting-item" for="frontend-mem-limit"><span>内存</span><input type="text" id="frontend-mem-limit" class="form-input cg-ob-input" value="512M"></label>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="cg-ob-bar">
+            <button type="button" id="btn-goto-advanced" class="cg-ob-bar__text">进行高级设置</button>
+            <button type="button" id="btn-generate-all" class="cg-ob-cta js-generate" title="生成配置" aria-label="生成配置">
+              <span>生成配置</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 18v-6M9 15l3 3 3-3"/><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- 7. 高级 -->
+        <div class="cg-ob__pane" data-step="advanced" hidden>
+          <div class="cg-ob-hero">
+            <h1>高级选项</h1>
+            <p class="cg-ob-hero__lead">默认已经能用。没有特殊需求，直接生成就行。</p>
+          </div>
+          <div class="cg-ob-body">
+            <div class="cg-switch-item">
+              <div class="cg-switch-item__text">
+                <span class="cg-switch-item__label" id="memory-saver-label">内存节约</span>
+                <span class="cg-switch-item__desc">小主机收紧缓存、连接池和联邦并发。选「小型」会自动打开。</span>
+              </div>
+              <label class="cg-toggle">
+                <input type="checkbox" id="memory-saver" aria-labelledby="memory-saver-label">
+                <span class="cg-toggle__slider" aria-hidden="true"></span>
+              </label>
+            </div>
+
+            <div class="resource-group">
+              <div class="resource-label"><span>镜像版本</span></div>
+              <div class="tag-status-row">
+                <span id="tag-status" class="tag-status">正在获取最新版本…</span>
+                <button type="button" id="btn-refresh-tags" class="btn-secondary" title="从 Docker Hub 刷新">刷新</button>
+              </div>
+              <div class="cg-ob-grid">
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">应用</span>
+                  <input type="text" id="myriad-tag" class="form-input cg-ob-input" value="" placeholder="自动获取…" autocomplete="off">
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">反代</span>
+                  <input type="text" id="proxy-tag" class="form-input cg-ob-input" value="" placeholder="自动获取…" autocomplete="off">
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">更新器</span>
+                  <input type="text" id="updater-tag" class="form-input cg-ob-input" value="" placeholder="自动获取…" autocomplete="off">
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">通道</span>
+                  <select id="channel" class="form-input form-select">
+                    <option value="stable" selected>stable</option>
+                    <option value="preview">preview</option>
+                  </select>
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">签名校验</span>
+                  <select id="cosign-verify" class="form-input form-select">
+                    <option value="strict" selected>strict</option>
+                    <option value="soft">soft</option>
+                    <option value="off">off（需双钥匙）</option>
+                  </select>
+                </label>
+              </div>
+            </div>
+
+            <div class="resource-group">
+              <div class="resource-label"><span>入口</span></div>
+              <div class="cg-ob-grid">
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">监听地址</span>
+                  <select id="http-bind-address" class="form-input form-select">
+                    <option value="127.0.0.1" selected>127.0.0.1</option>
+                    <option value="0.0.0.0">0.0.0.0</option>
+                  </select>
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">HTTP 端口</span>
+                  <input type="number" id="http-port" class="form-input cg-ob-input" value="8080" min="1" max="65535">
+                </label>
+              </div>
+            </div>
+
+            <div class="resource-group">
+              <div class="resource-label"><span>Docker 网络</span></div>
+              <div class="cg-ob-grid">
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">业务网</span>
+                  <input type="text" id="net-myriad" class="form-input cg-ob-input" value="myriad-net" autocomplete="off">
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">管理网</span>
+                  <input type="text" id="net-admin" class="form-input cg-ob-input" value="myriad-admin-net" autocomplete="off">
+                </label>
+                <label class="cg-ob-field">
+                  <span class="cg-ob-field__label">守卫网</span>
+                  <input type="text" id="net-guard" class="form-input cg-ob-input" value="myriad-docker-guard-net" autocomplete="off">
+                </label>
+              </div>
+            </div>
+
+            <label class="cg-ob-field" id="db-version-field">
+              <span class="cg-ob-field__label">PostgreSQL 版本</span>
+              <input type="number" id="db-version" class="form-input cg-ob-input" value="18" min="18" max="20" step="1">
+            </label>
+          </div>
+          <div class="cg-ob-bar">
+            <button type="button" id="btn-generate-advanced" class="cg-ob-cta js-generate" title="生成配置" aria-label="生成配置">
+              <span>生成配置</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 18v-6M9 15l3 3 3-3"/><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- 8. 完成 -->
+        <div class="cg-ob__pane" data-step="done" id="results-section" hidden>
+          <div class="cg-ob-hero">
+            <h1>按这个顺序装</h1>
+            <p class="cg-ob-hero__lead" id="results-intro">先收好暗号，再按面板把文件放进去。</p>
+          </div>
+          <div class="cg-ob-body">
+            <ol class="cg-guide-overview" id="cg-guide-overview"></ol>
+
+            <article class="cg-guide-card" id="setup-secret-reminder" hidden>
+              <header>
+                <b>1</b>
+                <h2>先收好安装暗号</h2>
+              </header>
+              <p>第一次打开站点、创建所有者时要填。也可以复制链接，打开后向导会自动填入。</p>
+              <div class="setup-secret-reminder-row">
+                <code id="setup-secret-reminder-value"></code>
+                <button type="button" id="copy-setup-secret-result" class="btn-copy-field">复制暗号</button>
+              </div>
+              <div class="setup-secret-reminder-row">
+                <code id="setup-secret-link-value"></code>
+                <button type="button" id="copy-setup-secret-link" class="btn-copy-field">复制链接</button>
+              </div>
+            </article>
+
+            <div class="cg-guide-list" id="cg-guide-list"></div>
+
+            <p class="cg-files-kicker">全部文件</p>
+            <div class="cg-files">
+              <div class="result-card cg-file" data-file="compose">
+                <div class="result-header">
+                  <span class="result-name">docker-compose.yml</span>
+                  <span class="result-badge" id="badge-compose">编排</span>
+                  <button type="button" class="btn-copy" data-target="docker-compose">复制</button>
+                  <button type="button" class="btn-download" data-filename="docker-compose.yml" data-target="docker-compose">下载</button>
+                </div>
+                <pre class="result-content"><code id="result-docker-compose"></code></pre>
+              </div>
+
+              <div class="result-card cg-file" data-file="env">
+                <div class="result-header">
+                  <span class="result-name">.env</span>
+                  <span class="result-badge" id="badge-env">密钥 · 勿公开</span>
+                  <button type="button" class="btn-copy" data-target="env">复制</button>
+                  <button type="button" class="btn-download" data-filename=".env" data-target="env">下载</button>
+                </div>
+                <pre class="result-content"><code id="result-env"></code></pre>
+              </div>
+
+              <div class="result-card cg-file" id="card-main-nginx" data-file="nginx">
+                <div class="result-header">
+                  <span class="result-name" id="name-main-nginx">site.conf</span>
+                  <span class="result-badge">反代</span>
+                  <button type="button" class="btn-copy" data-target="main-nginx">复制</button>
+                  <button type="button" class="btn-download" data-filename="main.conf" data-target="main-nginx">下载</button>
+                </div>
+                <pre class="result-content"><code id="result-main-nginx"></code></pre>
+              </div>
+
+              <div class="result-card cg-file" id="card-extra-nginx" data-file="nginx-extra" hidden>
+                <div class="result-header">
+                  <span class="result-name" id="name-extra-nginx">extra.conf</span>
+                  <span class="result-badge">额外域名</span>
+                  <button type="button" class="btn-copy" data-target="extra-nginx">复制</button>
+                  <button type="button" class="btn-download" data-filename="extra.conf" data-target="extra-nginx">下载</button>
+                </div>
+                <pre class="result-content"><code id="result-extra-nginx"></code></pre>
+              </div>
+
+              <div class="result-card cg-file" data-file="deploy">
+                <div class="result-header">
+                  <span class="result-name">DEPLOY.md</span>
+                  <span class="result-badge">步骤</span>
+                  <button type="button" class="btn-copy" data-target="deploy-notes">复制</button>
+                  <button type="button" class="btn-download" data-filename="DEPLOY.md" data-target="deploy-notes">下载</button>
+                </div>
+                <pre class="result-content"><code id="result-deploy-notes"></code></pre>
+              </div>
+
+              <div class="result-card cg-file" id="card-validation" data-file="check">
+                <div class="result-header">
+                  <span class="result-name">生成校验</span>
+                  <span class="result-badge">自检</span>
+                </div>
+                <pre class="result-content"><code id="result-validation"></code></pre>
               </div>
             </div>
           </div>
         </div>
-      </section>
-
-      <div class="form-actions">
-        <button type="button" id="btn-generate-all" class="btn-primary">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-            <polyline points="14 2 14 8 20 8"/>
-            <path d="M12 18v-6M9 15l3 3 3-3"/>
-          </svg>
-          生成配置文件
-        </button>
       </div>
     </div>
+  </section>
+</div>
 
-    <!-- 生成结果 -->
-    <div id="results-section" class="results-section" hidden>
-      <h2 class="results-title">
-        <span class="results-title-icon" aria-hidden="true">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
-            <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
-            <line x1="12" y1="22.08" x2="12" y2="12"/>
-          </svg>
-        </span>
-        生成结果
-      </h2>
-      <p class="section-desc results-intro" id="results-intro">
-        1Panel：复制 docker-compose.yml 到“编排”，复制 .env 到“环境变量”。
-      </p>
-
-      <div class="section-warning" id="setup-secret-reminder" hidden>
-        <span class="section-warning-icon" aria-hidden="true">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-          </svg>
-        </span>
-        <div class="section-warning-content">
-          <span class="section-warning-title">先复制安装暗号</span>
-          第一次打开站点、创建所有者时要填这一项。现在复制，或从下面的 .env 找 <code>MYRIAD_SETUP_SECRET</code>。
-          <div class="setup-secret-reminder-row">
-            <code id="setup-secret-reminder-value"></code>
-            <button type="button" id="copy-setup-secret-result" class="btn-copy-field">复制暗号</button>
-          </div>
-        </div>
-      </div>
-
-      <!-- Docker Compose -->
-      <div class="result-card">
-        <div class="result-header">
-          <span class="result-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="2" y="2" width="20" height="8" rx="2"/>
-              <rect x="2" y="14" width="20" height="8" rx="2"/>
-              <line x1="6" y1="6" x2="6.01" y2="6"/>
-              <line x1="6" y1="18" x2="6.01" y2="18"/>
-            </svg>
-          </span>
-          <span class="result-name">docker-compose.yml</span>
-          <span class="result-badge" id="badge-compose">服务编排 · 启动用</span>
-          <button type="button" class="btn-copy" data-target="docker-compose">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-            </svg>
-            复制
-          </button>
-          <button type="button" class="btn-download" data-filename="docker-compose.yml" data-target="docker-compose">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
-            </svg>
-            下载
-          </button>
-        </div>
-        <pre class="result-content"><code id="result-docker-compose"></code></pre>
-      </div>
-
-      <!-- 生成校验摘要 -->
-      <div class="result-card" id="card-validation">
-        <div class="result-header">
-          <span class="result-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M9 11l3 3L22 4"/>
-              <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
-            </svg>
-          </span>
-          <span class="result-name">生成校验摘要</span>
-          <span class="result-badge">dotenv · compose · nginx -t</span>
-        </div>
-        <pre class="result-content"><code id="result-validation"></code></pre>
-      </div>
-
-      <!-- .env -->
-      <div class="result-card">
-        <div class="result-header">
-          <span class="result-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/>
-            </svg>
-          </span>
-          <span class="result-name">环境变量（.env）</span>
-          <span class="result-badge" id="badge-env">1Panel 环境变量框 · 勿公开</span>
-          <button type="button" class="btn-copy" data-target="env">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-            </svg>
-            复制到 1Panel
-          </button>
-          <button type="button" class="btn-download" data-filename=".env" data-target="env">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
-            </svg>
-            下载
-          </button>
-        </div>
-        <pre class="result-content"><code id="result-env"></code></pre>
-      </div>
-
-      <!-- Main Nginx Config -->
-      <div class="result-card" id="card-main-nginx">
-        <div class="result-header">
-          <span class="result-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-              <polyline points="14 2 14 8 20 8"/>
-              <line x1="16" y1="13" x2="8" y2="13"/>
-              <line x1="16" y1="17" x2="8" y2="17"/>
-              <line x1="10" y1="9" x2="8" y2="9"/>
-            </svg>
-          </span>
-          <span class="result-name" id="name-main-nginx">example.com.conf</span>
-          <span class="result-badge">外层反代 · 主域名</span>
-          <button type="button" class="btn-copy" data-target="main-nginx">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-            </svg>
-            复制
-          </button>
-          <button type="button" class="btn-download" data-filename="main.conf" data-target="main-nginx">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
-            </svg>
-            下载
-          </button>
-        </div>
-        <pre class="result-content"><code id="result-main-nginx"></code></pre>
-      </div>
-
-      <!-- Extra Nginx Config -->
-      <div class="result-card" id="card-extra-nginx" hidden>
-        <div class="result-header">
-          <span class="result-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-              <polyline points="14 2 14 8 20 8"/>
-              <line x1="16" y1="13" x2="8" y2="13"/>
-              <line x1="16" y1="17" x2="8" y2="17"/>
-              <line x1="10" y1="9" x2="8" y2="9"/>
-            </svg>
-          </span>
-          <span class="result-name" id="name-extra-nginx">www.example.com.conf</span>
-          <span class="result-badge">外层反代 · 额外域名</span>
-          <button type="button" class="btn-copy" data-target="extra-nginx">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-            </svg>
-            复制
-          </button>
-          <button type="button" class="btn-download" data-filename="extra.conf" data-target="extra-nginx">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
-            </svg>
-            下载
-          </button>
-        </div>
-        <pre class="result-content"><code id="result-extra-nginx"></code></pre>
-      </div>
-
-      <!-- Deploy notes -->
-      <div class="result-card">
-        <div class="result-header">
-          <span class="result-icon" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
-            </svg>
-          </span>
-          <span class="result-name">DEPLOY.md</span>
-          <span class="result-badge">部署步骤 · 请先读</span>
-          <button type="button" class="btn-copy" data-target="deploy-notes">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-            </svg>
-            复制
-          </button>
-          <button type="button" class="btn-download" data-filename="DEPLOY.md" data-target="deploy-notes">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
-            </svg>
-            下载
-          </button>
-        </div>
-        <pre class="result-content"><code id="result-deploy-notes"></code></pre>
-      </div>
-    </div>
-  </div>
+<!-- 密钥自动生成，不进主路径 -->
+<div class="visually-hidden" aria-hidden="true">
+  <input type="text" id="jwt-secret" tabindex="-1" autocomplete="off">
+  <input type="text" id="update-token" tabindex="-1" autocomplete="off">
+  <input type="text" id="updater-gateway-secret" tabindex="-1" autocomplete="off">
+  <input type="text" id="setup-secret" tabindex="-1" autocomplete="off">
 </div>

--- a/apps/com.myriad.config-generator/preview.css
+++ b/apps/com.myriad.config-generator/preview.css
@@ -1,12 +1,39 @@
 :root {
   --tapp-primary: #7d70eb;
   --tapp-primary-rgb: 125, 112, 235;
+  --bg-primary: #0a0a0a;
+  --tapp-bg: #0a0a0a;
 }
 
-body { padding: 0 !important; background: #0a0a0a; }
-*, *::before, *::after { animation: none !important; }
-#tapp-content { overflow: hidden !important; }
-.page-content { max-width: 930px; padding-top: 28px; }
-.header-icon svg, .section-icon svg, .section-info-icon svg { width: 18px; height: 18px; }
-.preview-database-section { min-height: 280px; }
-input, button, select, textarea, label { pointer-events: none !important; }
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0 !important;
+  background: #0a0a0a;
+}
+
+*,
+*::before,
+*::after {
+  animation: none !important;
+}
+
+#tapp-content {
+  overflow: hidden !important;
+}
+
+.cg-ob,
+.cg-ob__card {
+  width: 100%;
+  height: 100%;
+}
+
+input,
+button,
+select,
+textarea,
+label {
+  pointer-events: none !important;
+}

--- a/apps/com.myriad.config-generator/preview.en-US.html
+++ b/apps/com.myriad.config-generator/preview.en-US.html
@@ -1,84 +1,61 @@
 <!doctype html>
 <html class="dark">
 <body>
-  <div id="tapp-background">
-    <div class="page-bg-base"></div>
-    <div class="page-bg-glow page-bg-glow-1"></div>
-    <div class="page-bg-glow page-bg-glow-2"></div>
-  </div>
+  <div id="tapp-background" aria-hidden="true"></div>
 
   <div id="tapp-content">
-    <div class="page-content">
-      <header class="page-header">
-        <div class="header-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="M12 18v-6M9 15l3 3 3-3"/>
-          </svg>
-        </div>
-        <div class="header-info">
-          <h1 class="header-title">Myriad Install Config Generator</h1>
-          <p class="header-subtitle">Compose · .env · Nginx · Deploy notes</p>
-        </div>
-      </header>
-
-      <div class="section-info">
-        <span class="section-info-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
-        </span>
-        <div class="section-info-content"><span class="section-info-title">Notes</span>Generate Compose / .env / Nginx and deploy steps for your panel. Do not commit secrets.</div>
-      </div>
-
-      <div class="config-form">
-        <section class="form-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-            </span>
-            Panel
-          </h2>
-          <div class="form-group">
-            <span class="form-label-text">Deploy panel</span>
-            <div class="panel-mode-toggle" role="radiogroup">
-              <label class="panel-mode-option is-active"><input type="radio" checked><span class="panel-mode-option-title">1Panel</span><span class="panel-mode-option-desc">Paste YAML into compose · env vars box</span></label>
-              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">Baota Panel</span><span class="panel-mode-option-desc">Paste compose · watch pgdata owner</span></label>
-              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">Generic / CLI</span><span class="panel-mode-option-desc">Standard paths · docker compose</span></label>
+    <section class="cg-ob">
+      <div class="cg-ob__card">
+        <header class="cg-ob-top">
+          <div class="cg-ob-top__side"><span class="cg-ob-brand">Config</span></div>
+          <p class="cg-ob-top__step" hidden><b>Welcome</b><span>1 / 5</span></p>
+        </header>
+        <div class="cg-ob__viewport">
+          <div class="cg-ob__pane is-welcome">
+            <div class="cg-ob-welcome">
+              <div class="cg-ob-welcome__mark" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                  <polyline points="14 2 14 8 20 8"/>
+                  <path d="M12 18v-6M9 15l3 3 3-3"/>
+                </svg>
+              </div>
+              <div class="cg-ob-hero">
+                <h1>Get your install files ready</h1>
+                <p class="cg-ob-hero__lead">Pick a panel, enter a domain, then create the site and SSL on your server first.</p>
+              </div>
+              <div class="cg-ob-body">
+                <div class="cg-ob-features">
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+                    <span>Panel</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                    <span>Domain</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+                    <span>Site</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+                    <span>Files</span>
+                  </div>
+                </div>
+              </div>
             </div>
-            <span class="form-hint">1Panel: docker-compose.yml → “Containers / Compose”; .env → “Environment”. Reverse-proxy the whole site to HTTP_BIND:HTTP_PORT.</span>
-          </div>
-        </section>
-
-        <section class="form-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-            </span>
-            Domain
-          </h2>
-          <div class="form-group"><label>Primary domain</label><input class="form-input" type="text" value="myriad.example.net"><span class="form-hint">Do not include <code>https://</code>. Written to <code>BASE_URL</code> and <code>FRONTEND_URL</code>.</span></div>
-          <div class="form-group"><label>Extra domains (optional)</label><input class="form-input" type="text" value="www.example.net"></div>
-        </section>
-
-        <section class="form-section preview-database-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/><path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3"/></svg>
-            </span>
-            Database
-          </h2>
-          <div class="form-group">
-            <span class="form-label-text">Deploy mode</span>
-            <div class="db-mode-toggle">
-              <label class="db-mode-option is-active"><input type="radio" checked><span class="db-mode-option-title">Bundled Postgres</span><span class="db-mode-option-desc">postgres in compose · default</span></label>
-              <label class="db-mode-option"><input type="radio"><span class="db-mode-option-title">External Postgres</span><span class="db-mode-option-desc">Panel / hosted DB · no postgres service</span></label>
+            <div class="cg-ob-bar is-split">
+              <p class="cg-ob-bar__note">This only generates files. It never touches your server.</p>
+              <button type="button" class="cg-ob-cta" title="Start" aria-label="Start">
+                <span>Start</span>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </button>
             </div>
           </div>
-          <div class="form-row">
-            <div class="form-group form-group-half"><label>Database name</label><input class="form-input" type="text" value="myriad"></div>
-            <div class="form-group form-group-half"><label>Username</label><input class="form-input" type="text" value="myriad"></div>
-          </div>
-        </section>
+        </div>
       </div>
-    </div>
+    </section>
   </div>
 </body>
 </html>

--- a/apps/com.myriad.config-generator/preview.html
+++ b/apps/com.myriad.config-generator/preview.html
@@ -1,84 +1,61 @@
 <!doctype html>
 <html class="dark">
 <body>
-  <div id="tapp-background">
-    <div class="page-bg-base"></div>
-    <div class="page-bg-glow page-bg-glow-1"></div>
-    <div class="page-bg-glow page-bg-glow-2"></div>
-  </div>
+  <div id="tapp-background" aria-hidden="true"></div>
 
   <div id="tapp-content">
-    <div class="page-content">
-      <header class="page-header">
-        <div class="header-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="M12 18v-6M9 15l3 3 3-3"/>
-          </svg>
-        </div>
-        <div class="header-info">
-          <h1 class="header-title">Myriad 安装配置生成</h1>
-          <p class="header-subtitle">Compose · .env · Nginx · 部署说明</p>
-        </div>
-      </header>
-
-      <div class="section-info">
-        <span class="section-info-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
-        </span>
-        <div class="section-info-content"><span class="section-info-title">说明</span>按面板生成 Compose / .env / Nginx 与部署步骤。密钥勿提交。</div>
-      </div>
-
-      <div class="config-form">
-        <section class="form-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-            </span>
-            面板
-          </h2>
-          <div class="form-group">
-            <span class="form-label-text">部署面板</span>
-            <div class="panel-mode-toggle" role="radiogroup">
-              <label class="panel-mode-option is-active"><input type="radio" checked><span class="panel-mode-option-title">1Panel</span><span class="panel-mode-option-desc">编排粘贴 YAML · 环境变量框</span></label>
-              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">宝塔面板</span><span class="panel-mode-option-desc">可粘贴编排 · 注意 pgdata 属主</span></label>
-              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">通用 / CLI</span><span class="panel-mode-option-desc">标准路径 · docker compose</span></label>
+    <section class="cg-ob">
+      <div class="cg-ob__card">
+        <header class="cg-ob-top">
+          <div class="cg-ob-top__side"><span class="cg-ob-brand">配置生成</span></div>
+          <p class="cg-ob-top__step" hidden><b>欢迎</b><span>1 / 5</span></p>
+        </header>
+        <div class="cg-ob__viewport">
+          <div class="cg-ob__pane is-welcome">
+            <div class="cg-ob-welcome">
+              <div class="cg-ob-welcome__mark" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                  <polyline points="14 2 14 8 20 8"/>
+                  <path d="M12 18v-6M9 15l3 3 3-3"/>
+                </svg>
+              </div>
+              <div class="cg-ob-hero">
+                <h1>先把安装文件准备好</h1>
+                <p class="cg-ob-hero__lead">选面板、填域名，先在服务器建好网站和证书。密钥和版本会自动填。</p>
+              </div>
+              <div class="cg-ob-body">
+                <div class="cg-ob-features">
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+                    <span>选面板</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                    <span>填域名</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+                    <span>建站点</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+                    <span>拿走文件</span>
+                  </div>
+                </div>
+              </div>
             </div>
-            <span class="form-hint">1Panel：docker-compose.yml →「容器 / 编排」；.env →「环境变量」。站点整站反代到 HTTP_BIND:HTTP_PORT。</span>
-          </div>
-        </section>
-
-        <section class="form-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-            </span>
-            域名
-          </h2>
-          <div class="form-group"><label>主域名</label><input class="form-input" type="text" value="myriad.example.net"><span class="form-hint">不要带 <code>https://</code>。会写入 <code>BASE_URL</code> 与 <code>FRONTEND_URL</code>。</span></div>
-          <div class="form-group"><label>额外域名（可选）</label><input class="form-input" type="text" value="www.example.net"></div>
-        </section>
-
-        <section class="form-section preview-database-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/><path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3"/></svg>
-            </span>
-            数据库
-          </h2>
-          <div class="form-group">
-            <span class="form-label-text">部署方式</span>
-            <div class="db-mode-toggle">
-              <label class="db-mode-option is-active"><input type="radio" checked><span class="db-mode-option-title">内置 Postgres</span><span class="db-mode-option-desc">compose 内 postgres · 默认</span></label>
-              <label class="db-mode-option"><input type="radio"><span class="db-mode-option-title">外置 Postgres</span><span class="db-mode-option-desc">面板 / 托管库 · 无 postgres 服务</span></label>
+            <div class="cg-ob-bar is-split">
+              <p class="cg-ob-bar__note">只生成文件，不会动你的服务器。</p>
+              <button type="button" class="cg-ob-cta" title="开始" aria-label="开始">
+                <span>开始</span>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </button>
             </div>
           </div>
-          <div class="form-row">
-            <div class="form-group form-group-half"><label>数据库名</label><input class="form-input" type="text" value="myriad"></div>
-            <div class="form-group form-group-half"><label>用户名</label><input class="form-input" type="text" value="myriad"></div>
-          </div>
-        </section>
+        </div>
       </div>
-    </div>
+    </section>
   </div>
 </body>
 </html>

--- a/apps/com.myriad.config-generator/preview.ja-JP.html
+++ b/apps/com.myriad.config-generator/preview.ja-JP.html
@@ -1,84 +1,61 @@
 <!doctype html>
 <html class="dark">
 <body>
-  <div id="tapp-background">
-    <div class="page-bg-base"></div>
-    <div class="page-bg-glow page-bg-glow-1"></div>
-    <div class="page-bg-glow page-bg-glow-2"></div>
-  </div>
+  <div id="tapp-background" aria-hidden="true"></div>
 
   <div id="tapp-content">
-    <div class="page-content">
-      <header class="page-header">
-        <div class="header-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><path d="M12 18v-6M9 15l3 3 3-3"/>
-          </svg>
-        </div>
-        <div class="header-info">
-          <h1 class="header-title">Myriad インストール設定ジェネレーター</h1>
-          <p class="header-subtitle">Compose · .env · Nginx · デプロイ手順</p>
-        </div>
-      </header>
-
-      <div class="section-info">
-        <span class="section-info-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
-        </span>
-        <div class="section-info-content"><span class="section-info-title">説明</span>パネル別に Compose / .env / Nginx とデプロイ手順を生成します。シークレットはコミットしないでください。</div>
-      </div>
-
-      <div class="config-form">
-        <section class="form-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-            </span>
-            パネル
-          </h2>
-          <div class="form-group">
-            <span class="form-label-text">デプロイパネル</span>
-            <div class="panel-mode-toggle" role="radiogroup">
-              <label class="panel-mode-option is-active"><input type="radio" checked><span class="panel-mode-option-title">1Panel</span><span class="panel-mode-option-desc">YAML を編成に貼り付け · 環境変数欄</span></label>
-              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">宝塔パネル</span><span class="panel-mode-option-desc">編成を貼り付け可 · pgdata の所有者に注意</span></label>
-              <label class="panel-mode-option"><input type="radio"><span class="panel-mode-option-title">汎用 / CLI</span><span class="panel-mode-option-desc">標準パス · docker compose</span></label>
+    <section class="cg-ob">
+      <div class="cg-ob__card">
+        <header class="cg-ob-top">
+          <div class="cg-ob-top__side"><span class="cg-ob-brand">設定生成</span></div>
+          <p class="cg-ob-top__step" hidden><b>ようこそ</b><span>1 / 5</span></p>
+        </header>
+        <div class="cg-ob__viewport">
+          <div class="cg-ob__pane is-welcome">
+            <div class="cg-ob-welcome">
+              <div class="cg-ob-welcome__mark" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                  <polyline points="14 2 14 8 20 8"/>
+                  <path d="M12 18v-6M9 15l3 3 3-3"/>
+                </svg>
+              </div>
+              <div class="cg-ob-hero">
+                <h1>先にインストールファイルを用意</h1>
+                <p class="cg-ob-hero__lead">パネルとドメインを選んだら、先にサーバーでサイトと証明書を用意します。</p>
+              </div>
+              <div class="cg-ob-body">
+                <div class="cg-ob-features">
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+                    <span>パネル</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                    <span>ドメイン</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+                    <span>サイト</span>
+                  </div>
+                  <div>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+                    <span>ファイル</span>
+                  </div>
+                </div>
+              </div>
             </div>
-            <span class="form-hint">1Panel：docker-compose.yml →「コンテナ / 編成」；.env →「環境変数」。サイト全体を HTTP_BIND:HTTP_PORT にリバースプロキシ。</span>
-          </div>
-        </section>
-
-        <section class="form-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-            </span>
-            ドメイン
-          </h2>
-          <div class="form-group"><label>メインドメイン</label><input class="form-input" type="text" value="myriad.example.net"><span class="form-hint"><code>https://</code> は付けないでください。<code>BASE_URL</code> と <code>FRONTEND_URL</code> に書き込まれます。</span></div>
-          <div class="form-group"><label>追加ドメイン（任意）</label><input class="form-input" type="text" value="www.example.net"></div>
-        </section>
-
-        <section class="form-section preview-database-section">
-          <h2 class="section-title">
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/><path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3"/></svg>
-            </span>
-            データベース
-          </h2>
-          <div class="form-group">
-            <span class="form-label-text">デプロイ方式</span>
-            <div class="db-mode-toggle">
-              <label class="db-mode-option is-active"><input type="radio" checked><span class="db-mode-option-title">内蔵 Postgres</span><span class="db-mode-option-desc">compose 内 postgres · デフォルト</span></label>
-              <label class="db-mode-option"><input type="radio"><span class="db-mode-option-title">外部 Postgres</span><span class="db-mode-option-desc">パネル / マネージドDB · postgres サービスなし</span></label>
+            <div class="cg-ob-bar is-split">
+              <p class="cg-ob-bar__note">ファイルを作るだけで、サーバーは変更しません。</p>
+              <button type="button" class="cg-ob-cta" title="はじめる" aria-label="はじめる">
+                <span>はじめる</span>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </button>
             </div>
           </div>
-          <div class="form-row">
-            <div class="form-group form-group-half"><label>データベース名</label><input class="form-input" type="text" value="myriad"></div>
-            <div class="form-group form-group-half"><label>ユーザー名</label><input class="form-input" type="text" value="myriad"></div>
-          </div>
-        </section>
+        </div>
       </div>
-    </div>
+    </section>
   </div>
 </body>
 </html>

--- a/apps/com.myriad.config-generator/scripts/security-smoke.mjs
+++ b/apps/com.myriad.config-generator/scripts/security-smoke.mjs
@@ -122,6 +122,7 @@ function buildCleanEnv(secrets, bundled) {
     'HTTP_PORT=8080',
     'PROXY_ALLOW_DIRECT_UPDATER=false',
     'COSIGN_VERIFY=strict',
+    'MYRIAD_MEMORY_PROFILE=default',
     'MYRIAD_DB_MODE=' + (bundled ? 'bundled' : 'external'),
   ]
   if (bundled) {


### PR DESCRIPTION
## 变更说明

把配置生成器改成铺满宿主窗口的分步向导：欢迎 → 面板 → 域名 → 站点 → 数据库 → 限额 → 完成，高级选项默认收起。顺带清掉改版残留的密钥按钮点击、空 note 节点和未接线动效，并修外置库密码预填、完成页返回来源、长页 FAB / 下拉裁切。

## 类型

- [x] 更新已有应用（版本 / 功能 / 修复）

## 检查清单

- [x] **一次 PR 只改一个 app**（`apps/com.myriad.config-generator/`）
- [x] **没有修改** 根目录 `index.json`
- [x] 非 README 类改动已 **bump `manifest.version`**（1.0.4 → 1.1.0）
- [x] `manifest.id` 与文件夹名一致
- [x] `category` 为稳定 ID：`developer`
- [x] 商店展示文案写在 `catalog.json`
- [x] `com.myriad.*` 无需 `catalog.securityReview`
- [x] 本地：

```bash
node scripts/check-pr-scope.mjs
node scripts/validate-app.mjs --app com.myriad.config-generator
node tapp-cli/bin/myriad-tapp.mjs check apps/com.myriad.config-generator --json
node scripts/validate-previews.mjs --app com.myriad.config-generator
node apps/com.myriad.config-generator/scripts/security-smoke.mjs
```

## 对齐说明

安装字段以 **`manifest.json` 为准**；合并后 bot 会重写 `index.json`。

## Test plan

- [ ] 走完欢迎 → 面板 → 域名 → 站点 → 数据库 → 限额 → 生成，完成页能复制暗号和文件
- [ ] 从限额进高级再生成，返回应回到高级
- [ ] 外置库密码框启动时为空，不会预填随机串
- [ ] 长页滚动时右下角按钮不下沉，靠近底部的下拉向上打开
- [ ] 商店预览欢迎页能看到圆形箭头按钮，不是空圆
