### PR TITLE
docs(tapp): update setup command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Manifest 若声明了 `pageStyles` / `pageTemplate`，索引必须提供对应 `
 > 安装相关字段以 `apps/<id>/manifest.json` 为唯一权威；商店展示字段写 `catalog.json`。
 
 1. Fork 本仓库，从 `main` 开分支。
-2. **只**在一个 `apps/{id}/` 下添加或修改完整包文件（建议先用仓库内 CLI 或 Myriad [`@myriad/tapp-cli`](https://github.com/Myriad-You/Myriad/tree/preview/tools/tapp-cli) 本地 `check` / `pack`）。可附带文档或脚本，但不可夹带第二个 app。
+2. **只**在一个 `apps/{id}/` 下添加或修改完整包文件（建议先用仓库内 CLI 或 Myriad [`@myriad-you/tapp-cli`](https://github.com/Myriad-You/Myriad/tree/preview/tools/tapp-cli) 本地 `check` / `pack`）。可附带文档或脚本，但不可夹带第二个 app。
 3. 确保 `manifest.id` === 文件夹名；**semver bump**；`category` 使用稳定 ID（见下）。
 4. （可选）写 `apps/{id}/catalog.json` 维护商店文案 / tags / preview / `locales` / featured（**不要**改根 `index.json`）。
 5. 本地校验：

--- a/apps/org.smcresearchhk.math/README.md
+++ b/apps/org.smcresearchhk.math/README.md
@@ -40,8 +40,8 @@ org.smcresearchhk.math/
 ## 本地校验与打包
 
 ```bash
-npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp check ./org.smcresearchhk.math --json
-npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp pack ./org.smcresearchhk.math --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.0 myriad-tapp check ./org.smcresearchhk.math --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.0 myriad-tapp pack ./org.smcresearchhk.math --json
 ```
 
 ## 表达式说明

--- a/development/tapp/QUICKSTART.md
+++ b/development/tapp/QUICKSTART.md
@@ -1,7 +1,7 @@
 # Tapp 快速入门
 
 Tapp (Third-party App) 是 Myriad 的扩展应用系统，允许开发者创建自定义小组件、工具和功能扩展。
-当前推荐使用 `@myriad/tapp-cli` 创建、校验和打包项目；Manifest 字段与 SDK 能力分别见
+当前推荐使用 `@myriad-you/tapp-cli` 创建、校验和打包项目；Manifest 字段与 SDK 能力分别见
 [Manifest 配置](MANIFEST.md)和 [API 参考](API_REFERENCE.md)。CLI 的完整命令契约见
 [Myriad Tapp CLI](../../../tools/tapp-cli/README.md)。
 
@@ -10,7 +10,9 @@ Tapp (Third-party App) 是 Myriad 的扩展应用系统，允许开发者创建�
 Agent 和 CI 应固定包版本、显式指定 `myriad-tapp` binary，并始终使用 `--json`：
 
 ```bash
-npx @myriad-you/tapp-cli
+npx --yes --package=@myriad-you/tapp-cli@0.1.0 myriad-tapp init ./my-tapp --type page
+npx --yes --package=@myriad-you/tapp-cli@0.1.0 myriad-tapp check ./my-tapp --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.0 myriad-tapp pack ./my-tapp --json
 ```
 
 任何非零退出状态都表示失败。`check` 返回状态 `1` 时，读取 `diagnostics`、修复项目并重新
@@ -23,7 +25,7 @@ npx @myriad-you/tapp-cli
 starter：
 
 ```bash
-npm install --global @myriad/tapp-cli@0.1.0
+npm install --global @myriad-you/tapp-cli@0.1.0
 myriad-tapp init ./my-tapp --type page
 ```
 

--- a/development/tapp/QUICKSTART.md
+++ b/development/tapp/QUICKSTART.md
@@ -10,9 +10,7 @@ Tapp (Third-party App) 是 Myriad 的扩展应用系统，允许开发者创建�
 Agent 和 CI 应固定包版本、显式指定 `myriad-tapp` binary，并始终使用 `--json`：
 
 ```bash
-npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp init ./my-tapp --type page
-npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp check ./my-tapp --json
-npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp pack ./my-tapp --json
+npx @myriad-you/tapp-cli
 ```
 
 任何非零退出状态都表示失败。`check` 返回状态 `1` 时，读取 `diagnostics`、修复项目并重新

--- a/development/tapp/STORE.md
+++ b/development/tapp/STORE.md
@@ -453,7 +453,7 @@ REST 商店安装仍是 body `source: "store"` + `storeSource: catalogRef`（源
 
 ### 开发者流程（官方源）
 
-1. 用 `@myriad/tapp-cli` 初始化、`check`、可选 `pack`（见 [QUICKSTART](QUICKSTART.md)）。
+1. 用 `@myriad-you/tapp-cli` 初始化、`check`、可选 `pack`（见 [QUICKSTART](QUICKSTART.md)）。
 2. 确认 `manifest.json`：`category`（稳定 ID）、`permissions`、`main`、模板/CSS/assets；**semver `version`**。
 3. 在商店仓库 **只改一个** `apps/{id}/`；**不要手改** 根 `index.json`。
 4. 可选：`apps/{id}/catalog.json` 写商店展示字段（`long_description` / `tags` / `preview` / `featured` / `locales`…）。`locales` 里的长介绍与预览由索引同步合并进 `index.json`；不要手改根索引。

--- a/tapp-cli/README.md
+++ b/tapp-cli/README.md
@@ -189,5 +189,5 @@ npm run pack:check
 npm publish
 ```
 
-Publishing requires an authenticated npm account with access to the `@myriad`
+Publishing requires an authenticated npm account with access to the `@myriad-you`
 scope. The package declares public scoped access in `publishConfig`.

--- a/tapp-cli/README.md
+++ b/tapp-cli/README.md
@@ -8,7 +8,7 @@ authority; this CLI catches common contract problems before upload.
 - Node.js 20 or newer;
 - access to a Myriad instance when you are ready to install the generated package.
 
-The examples pin `@myriad/tapp-cli` to `0.1.0`. Keep the version explicit in
+The examples pin `@myriad-you/tapp-cli` to `0.1.0`. Keep the version explicit in
 automation and upgrade it deliberately when a newer release is available.
 
 ## For agents
@@ -18,9 +18,9 @@ accepts npm's temporary-install prompt; `--package` makes the selected package a
 binary unambiguous in CI.
 
 ```bash
-npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp init ./my-tapp --type page
-npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp check ./my-tapp --json
-npx --yes --package=@myriad/tapp-cli@0.1.0 myriad-tapp pack ./my-tapp --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.0 myriad-tapp init ./my-tapp --type page
+npx --yes --package=@myriad-you/tapp-cli@0.1.0 myriad-tapp check ./my-tapp --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.0 myriad-tapp pack ./my-tapp --json
 ```
 
 Treat a non-zero status as failure. When `check --json` returns status `1`, repair
@@ -31,7 +31,7 @@ For a checked-in dependency, pin the package in the lockfile and invoke its bina
 through `npm exec`:
 
 ```bash
-npm install --save-dev --save-exact @myriad/tapp-cli@0.1.0
+npm install --save-dev --save-exact @myriad-you/tapp-cli@0.1.0
 npm exec -- myriad-tapp check . --json
 ```
 
@@ -43,7 +43,7 @@ exit status described in [Automation contract](#automation-contract).
 Install the pinned CLI globally when you want a short interactive command:
 
 ```bash
-npm install --global @myriad/tapp-cli@0.1.0
+npm install --global @myriad-you/tapp-cli@0.1.0
 ```
 
 Create a starter, edit its `manifest.json` and source files, then validate and

--- a/tapp-cli/package-lock.json
+++ b/tapp-cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@myriad/tapp-cli",
+  "name": "@myriad-you/tapp-cli",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@myriad/tapp-cli",
+      "name": "@myriad-you/tapp-cli",
       "version": "0.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {

--- a/tapp-cli/package.json
+++ b/tapp-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@myriad/tapp-cli",
+  "name": "@myriad-you/tapp-cli",
   "version": "0.1.0",
   "description": "Offline project tooling for Myriad Tapps",
   "type": "module",


### PR DESCRIPTION
## 变更说明

<!-- 简要说明这个 PR 做了什么 -->

## 类型

- [ ] 新应用（`apps/<id>/`）
- [ ] 更新已有应用（版本 / 功能 / 修复）
- [ ] 文档或脚本 / CI
- [ ] 其他

## 检查清单

- [ ] **一次 PR 只改一个 app**（`apps/<id>/`；多 app 请拆 PR）
- [ ] **没有修改** 根目录 `index.json`
- [ ] 非 README 类改动已 **bump `manifest.version`**（semver 升高）
- [ ] `manifest.id` 与文件夹名一致
- [ ] `category` 为稳定 ID：`ai` / `data` / `developer` / `game` / `media` / `productivity` / `social` / `utility`
- [ ] 商店展示文案（如需）写在 `apps/<id>/catalog.json`，不在 index
- [ ] 敏感权限（federation / platform / tappList:manage 等）已审阅，`catalog.securityReview: true`（`com.myriad.*` 除外）
- [ ] 本地：

```bash
node scripts/check-pr-scope.mjs
node scripts/validate-app.mjs --app <id>
node tapp-cli/bin/myriad-tapp.mjs check apps/<id> --json
node scripts/validate-previews.mjs --app <id>
```

## 对齐说明

安装字段以 **`manifest.json` 为准**；合并后 bot 会重写 `index.json` 的 version / category / permissions / download / size 等。  
展示字段以 **`catalog.json`**（可选）为准，否则保留原 index 条目或用 description 引导。
