### PR TITLE
feat(persona-stickers): 添加 Agent 单图表情工坊

### DIFF
--- a/apps/cn.echootaku.persona-stickers/README.md
+++ b/apps/cn.echootaku.persona-stickers/README.md
@@ -1,0 +1,47 @@
+# 人设表情工坊
+
+人设表情工坊是一款 Page Tapp：它以用户已经启用并生成图片的 Agent 人设为角色身份基准，通过 Emoji、颜文字或单张图片表情提示，生成一张独立的 PNG 表情图片。
+
+## 使用流程
+
+1. 调用 `Tapp.persona.get()` 读取 `enabled`、`name`、`moodBand`、`activity` 与 `portraitUrl`。
+2. 若没有已启用且带有效人设图的 Agent，人设门控会阻止生成，并提示用户先在 Myriad 中创建并生成人设图。
+3. 有可用人设后，用户从以下三种提示方式中选择一种：
+   - Emoji：从预设中选择或输入一个自定义 Emoji。
+   - 颜文字：从预设中选择或输入一个自定义颜文字。
+   - 图片表情：上传且仅上传一张 PNG、JPEG 或 WebP，解码后不超过 10 MiB。
+4. 用户还可以填写一段最多 800 字符的补充提示词。它在固定输出约束内拥有最高创意优先级，优先控制动作、表情、道具、构图和情绪强度，避免被模式提示稀释。
+5. 每次任务固定生成一张 1024×1024、单角色、无文字和水印的 PNG 表情。当前图片模型不会生成 Alpha 通道；提示词也会阻止模型把棋盘格画进图片来伪装透明效果。
+
+Emoji 与颜文字模式只把 Agent 人设图作为参考图。图片表情模式严格保持参考顺序：第 1 张是 Agent 人设图，用于固定身份与外观；第 2 张是用户上传的图片，仅用于表情、姿势和构图。
+
+## 权限与数据边界
+
+Manifest 仅申请 `ai:image`，用于图片任务。当前上游将 `Tapp.file.download()` 定义为公共宿主能力，因此下载不需要 `storage:read`；应用也不申请 `network:fetch`、Storage 写入或 Federation 权限。
+
+本地图片通过 `FileReader.readAsDataURL()` 读取，并检查 MIME、文件签名、数量与解码后字节数。它只存在于当前 Page 内存，不写入 `Tapp.storage`，不做独立上传，也不进入包；点击生成后才作为该次 `Tapp.ai.tasks.create()` 的第二张 `input.referenceImages` 提交。
+
+供应商若拒绝参考图，应用会保留原始错误码，不会移除人设图或表情参考图后静默降级为文生图。任务支持进度、取消、暂停/恢复和销毁清理；客户端等待上限为 315 秒。
+
+## 缓存与下载边界
+
+应用只接受同源 `/api/brew/image-cache/...png` 结果用于即时预览，并提供带 Escape、背景关闭、焦点循环、焦点返回和背景 `inert` 隔离的大图查看器。查看舞台使用中性实色底，不以棋盘格暗示结果含 Alpha 通道。
+
+“下载 PNG”把已校验的同源缓存路径交给 `Tapp.file.download()`。Myriad 宿主负责读取当前图片缓存并把真实 PNG 字节保存到用户设备；Page 不直接 `fetch` 图片、不创建 Blob，也不使用下载链接绕过宿主治理。下载源限于当前任务返回并通过校验的 `/api/brew/image-cache/...png` 路径，宿主还会执行路径白名单与 32 MiB 上限检查。用户应在缓存有效时完成下载。
+
+## 界面与可访问性
+
+提供简体中文、英文、日文，支持浅色/深色、Myriad 主色、安全区域、窄屏布局、键盘焦点和减少动画偏好。三种模式是互斥单选；图片上传控件不允许多选。大图查看器支持关闭按钮、点击背景、Escape、焦点循环与关闭后的焦点返回。
+
+## 开发验证
+
+```powershell
+$NODE = 'D:\SDK\NodeJS\node-versions\v24.16.0\installation\node.exe'
+& $NODE --test apps/cn.echootaku.persona-stickers/tests/*.test.cjs
+& $NODE scripts/validate-app.mjs --app cn.echootaku.persona-stickers
+& $NODE scripts/validate-previews.mjs --app cn.echootaku.persona-stickers
+& $NODE scripts/sync-index.mjs validate --app cn.echootaku.persona-stickers
+& $NODE tapp-cli/bin/myriad-tapp.mjs check apps/cn.echootaku.persona-stickers --json
+```
+
+提交前的真实 Myriad 验收范围包括：无/有 Persona、三种提示方式、三语、浅深主题、窄宽屏、文件格式与大小边界、生成成功、取消、超时、供应商失败和生命周期清理。

--- a/apps/cn.echootaku.persona-stickers/catalog.json
+++ b/apps/cn.echootaku.persona-stickers/catalog.json
@@ -1,0 +1,27 @@
+{
+  "long_description": "人设表情工坊以用户已启用且已生成图片的 Agent 人设作为角色身份基准。用户可在 Emoji、颜文字和图片表情三种方式中任选一种：前两种直接提供情绪提示；图片表情模式只允许上传单张 PNG、JPEG 或 WebP，用来参考表情、姿势和构图，不替换 Agent 的身份与外观。还可填写一段高优先级补充提示词，在固定身份和输出规则内优先控制动作、表情、道具、构图与情绪强度。每次通过受治理的 Myriad AI 图片任务生成单张 1024×1024 的独立 PNG 表情图片。若尚无人设图，应用会先提示用户在 Myriad 中创建并生成人设。本地参考图只保留在当前页面内存，不写入 Storage；结果可在宿主缓存有效期内查看大图，并由 Myriad 宿主读取当前缓存、下载为真实 PNG。",
+  "tags": ["AI 生图", "人设", "表情包", "贴纸", "角色一致性"],
+  "featured": false,
+  "verified": false,
+  "license": "MIT",
+  "homepage": "https://github.com/Myriad-You/tapp-store/tree/main/apps/cn.echootaku.persona-stickers",
+  "repository": "https://github.com/Myriad-You/tapp-store",
+  "preview": {
+    "version": 1,
+    "type": "snapshot",
+    "html": "preview.html",
+    "styles": ["page.css", "preview.css"],
+    "viewport": { "width": 1440, "height": 900 },
+    "fit": "cover",
+    "focus": { "x": 0.52, "y": 0.48 },
+    "theme": "light"
+  },
+  "locales": {
+    "en-US": {
+      "long_description": "Persona Sticker Lab uses the user's enabled Agent persona with a generated portrait as the character identity anchor. Choose exactly one cue mode: Emoji, kaomoji, or an expression image. The first two provide a direct emotional cue; image mode accepts exactly one PNG, JPEG, or WebP to guide only the expression, pose, and composition without replacing the Agent's identity or appearance. An optional high-priority prompt can direct the action, expression, props, framing, and emotional intensity while preserving the fixed identity and output rules. Each governed Myriad AI image task creates one standalone 1024×1024 PNG sticker. If no usable persona portrait exists, the app directs the user to create and generate one in Myriad first. A local cue image stays only in current-page memory and is never written to Storage. Results can be viewed full size while the host cache remains available, and Myriad can read the current cache and download the actual PNG."
+    },
+    "ja-JP": {
+      "long_description": "ペルソナスタンプ工房は、有効で画像が生成済みのユーザー Agent ペルソナをキャラクター本人の基準にします。Emoji、顔文字、表情画像から一つだけ選択します。前二つは感情を直接指示し、表情画像モードでは PNG・JPEG・WebP を一枚だけ受け付け、表情・ポーズ・構図だけを参考にして Agent の本人性や外見を置き換えません。任意の高優先度プロンプトで、固定された本人性と出力ルールを保ちながら、動き、表情、小物、構図、感情の強さを優先して指定できます。管理された Myriad AI 画像タスクごとに、独立した 1024×1024 PNG スタンプを一枚生成します。利用可能なペルソナ画像がない場合は、先に Myriad で作成・生成するよう案内します。ローカル参考画像は現在のページメモリだけに保持され、Storage には書き込みません。結果はホストキャッシュが有効な間拡大表示でき、Myriad ホストが現在のキャッシュを読み取って実際の PNG としてダウンロードできます。"
+    }
+  }
+}

--- a/apps/cn.echootaku.persona-stickers/core.js
+++ b/apps/cn.echootaku.persona-stickers/core.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// The catalog delivery contract still requires a Core entry. This shared layer
+// intentionally has no host interaction; all behavior belongs to the Page layer.
+module.exports = {};

--- a/apps/cn.echootaku.persona-stickers/i18n/en-US.json
+++ b/apps/cn.echootaku.persona-stickers/i18n/en-US.json
@@ -1,0 +1,125 @@
+{
+  "app": {
+    "eyebrow": "PERSONA STICKER LAB",
+    "title": "Persona Sticker Lab",
+    "subtitle": "Create stickers made for your Agent~",
+    "privacy": "The persona portrait and optional cue image are sent only with this governed image task."
+  },
+  "persona": {
+    "title": "Your Agent persona",
+    "loading": "Loading",
+    "ready": "Ready",
+    "disabled": "Not enabled",
+    "noPortrait": "No portrait",
+    "unavailable": "Unavailable",
+    "loadingDetail": "Reading the public persona card…",
+    "disabledDetail": "No Agent persona is currently enabled.",
+    "noPortraitDetail": "The Agent persona does not have a usable portrait yet.",
+    "unavailableDetail": "The Agent persona cannot be read right now.",
+    "requiredTitle": "Prepare an Agent persona first",
+    "requiredDetail": "Create an Agent persona and generate its portrait in Myriad, then reopen this app.",
+    "context": "Mood: {mood} · Status: {activity}",
+    "help": "The Agent portrait always defines the generated character's identity and appearance."
+  },
+  "mood": { "floor": "low", "sad": "sad", "tense": "tense", "calm": "calm", "excited": "excited" },
+  "activity": { "idle": "idle", "working": "working", "thinking": "thinking", "talking": "talking" },
+  "composer": {
+    "title": "Choose an expression cue",
+    "subtitle": "Pick one of three modes. Each task creates one standalone PNG sticker."
+  },
+  "mode": {
+    "legend": "Expression cue mode",
+    "emoji": "Emoji",
+    "emojiDetail": "Express an emotion with one symbol",
+    "kaomoji": "Kaomoji",
+    "kaomojiDetail": "Describe the face with characters",
+    "image": "Expression image",
+    "imageDetail": "Follow one existing reaction image"
+  },
+  "cue": { "customPriority": "A custom value takes priority when filled" },
+  "prompt": {
+    "title": "Additional prompt (high priority)",
+    "priority": "Takes priority for action, expression, props, framing, and emotional intensity",
+    "placeholder": "For example: crouching with both hands on the head, tears spraying sideways like fountains, extremely exaggerated motion.",
+    "boundary": "Optional. It cannot override the Agent identity or the fixed single-image, one-character, and no-text rules."
+  },
+  "emoji": {
+    "title": "Choose an Emoji",
+    "joy": "Happy",
+    "cry": "Crying",
+    "determined": "Determined",
+    "shy": "Shy",
+    "think": "Thinking",
+    "celebrate": "Celebrating",
+    "custom": "Custom Emoji (optional)",
+    "placeholder": "For example: 🥺"
+  },
+  "kaomoji": {
+    "title": "Choose a kaomoji",
+    "joy": "Delighted",
+    "sad": "Upset",
+    "shock": "Shocked",
+    "wave": "Greeting",
+    "custom": "Custom kaomoji (optional)",
+    "placeholder": "For example: (๑•̀ㅂ•́)و✧"
+  },
+  "image": {
+    "title": "Upload one expression image",
+    "formats": "PNG, JPEG, or WebP; up to 10 MiB",
+    "choose": "Choose one expression reference",
+    "hint": "It supplies only the expression, pose, and composition. The Agent persona still defines the character.",
+    "previewAlt": "Uploaded expression reference",
+    "remove": "Remove reference",
+    "localSize": "Local image · {size}"
+  },
+  "output": {
+    "title": "Output: standalone PNG sticker",
+    "detail": "1024 × 1024, one character, no text or watermark."
+  },
+  "action": {
+    "generate": "Generate one sticker",
+    "cancel": "Cancel task",
+    "dismiss": "Dismiss status",
+    "preview": "View full size",
+    "downloadPng": "Download PNG",
+    "closePreview": "Close full-size preview"
+  },
+  "status": {
+    "creating": "Creating the AI image task",
+    "creatingDetail": "The persona portrait and expression cue are being submitted through Myriad's governed Task API.",
+    "waiting": "Task created, waiting for the image",
+    "waitingDetail": "The client waits up to 315 seconds. You can cancel this task.",
+    "failed": "Generation did not finish",
+    "cancelled": "Task cancelled",
+    "success": "Single sticker generated",
+    "successDetail": "One standalone PNG sticker is ready to preview in this session."
+  },
+  "result": {
+    "title": "Your Agent's new expression is ready",
+    "alt": "Generated Agent PNG sticker",
+    "cacheBadge": "Temporary Myriad cache",
+    "cacheBoundary": "The result is a temporary host PNG cache entry. View it full size or download it now.",
+    "previewTitle": "Full-size sticker preview",
+    "previewAlt": "Full-size generated Agent PNG sticker",
+    "downloadBoundary": "Myriad reads the current cache and saves the actual PNG. Download it while the cache is still available.",
+    "downloadStarted": "The PNG was handed to Myriad for download."
+  },
+  "errors": {
+    "provider": "The image provider did not complete the task. The app will not silently discard the persona or cue image and retry as text-to-image.",
+    "permission": "The ai:image permission is not granted. Allow image generation in Myriad's Tapp permissions.",
+    "persona": "Create an Agent persona and generate a usable portrait in Myriad first.",
+    "expressionCue": "Choose or enter an Emoji or kaomoji.",
+    "expressionImage": "Expression image mode requires one uploaded reference.",
+    "timeout": "The client wait timed out. The app attempted to cancel the remote task.",
+    "cancelled": "The task was cancelled and produced no result.",
+    "reference": "The reference must be a PNG, JPEG, or WebP whose content matches its MIME type.",
+    "referenceLimit": "Choose exactly one expression reference no larger than 10 MiB after decoding.",
+    "inputLimit": "The prompt or task input exceeds the current AI Task limit. Shorten the custom value.",
+    "apiUnavailable": "Tapp.ai.tasks image generation is unavailable in this sandbox.",
+    "fileApiUnavailable": "The browser does not expose a usable FileReader.",
+    "downloadUnavailable": "This installation does not expose the host PNG download bridge. Update Myriad and try again.",
+    "fileRead": "The local image could not be read or the read was cancelled. Choose it again.",
+    "resultInvalid": "The task did not return a safe Myriad PNG image-cache path, so it cannot be previewed.",
+    "unknown": "The operation failed. Check the error code in the Myriad console before retrying."
+  }
+}

--- a/apps/cn.echootaku.persona-stickers/i18n/ja-JP.json
+++ b/apps/cn.echootaku.persona-stickers/i18n/ja-JP.json
@@ -1,0 +1,125 @@
+{
+  "app": {
+    "eyebrow": "PERSONA STICKER LAB",
+    "title": "ペルソナスタンプ工房",
+    "subtitle": "あなたのAgentだけのスタンプを作ろう〜",
+    "privacy": "ペルソナ画像と任意の参考画像は、今回の管理対象画像タスクにだけ送信されます。"
+  },
+  "persona": {
+    "title": "あなたの Agent ペルソナ",
+    "loading": "読込中",
+    "ready": "準備完了",
+    "disabled": "未設定",
+    "noPortrait": "画像なし",
+    "unavailable": "利用不可",
+    "loadingDetail": "公開ペルソナカードを読み込んでいます…",
+    "disabledDetail": "有効な Agent ペルソナがありません。",
+    "noPortraitDetail": "Agent ペルソナには利用可能な画像がまだありません。",
+    "unavailableDetail": "現在 Agent ペルソナを読み込めません。",
+    "requiredTitle": "先に Agent ペルソナを準備してください",
+    "requiredDetail": "Myriad で Agent ペルソナを作成して画像を生成し、このアプリを開き直してください。",
+    "context": "気分：{mood} · 状態：{activity}",
+    "help": "Agent の画像が、生成されるキャラクターの本人性と外見を常に決定します。"
+  },
+  "mood": { "floor": "低調", "sad": "悲しい", "tense": "緊張", "calm": "穏やか", "excited": "高揚" },
+  "activity": { "idle": "待機中", "working": "作業中", "thinking": "思考中", "talking": "会話中" },
+  "composer": {
+    "title": "表情の指示を選ぶ",
+    "subtitle": "三つの方法から一つを選び、毎回一枚の独立した PNG スタンプを生成します。"
+  },
+  "mode": {
+    "legend": "表情指示の方法",
+    "emoji": "Emoji",
+    "emojiDetail": "一つの記号で感情を表す",
+    "kaomoji": "顔文字",
+    "kaomojiDetail": "文字で表情を伝える",
+    "image": "表情画像",
+    "imageDetail": "既存の表情画像を一枚参考にする"
+  },
+  "cue": { "customPriority": "入力したカスタム値が優先されます" },
+  "prompt": {
+    "title": "追加プロンプト（高優先度）",
+    "priority": "動き、表情、小物、構図、感情の強さに優先して反映します",
+    "placeholder": "例：両手で頭を抱えてしゃがみ、噴水のような涙を左右へ飛ばす、とても大げさな動き。",
+    "boundary": "任意入力です。Agent の本人性、単一画像、1キャラクター、文字なしの固定条件は上書きできません。"
+  },
+  "emoji": {
+    "title": "Emoji を選ぶ",
+    "joy": "嬉しい",
+    "cry": "大泣き",
+    "determined": "本気",
+    "shy": "照れ",
+    "think": "考える",
+    "celebrate": "お祝い",
+    "custom": "カスタム Emoji（任意）",
+    "placeholder": "例：🥺"
+  },
+  "kaomoji": {
+    "title": "顔文字を選ぶ",
+    "joy": "大喜び",
+    "sad": "しょんぼり",
+    "shock": "びっくり",
+    "wave": "あいさつ",
+    "custom": "カスタム顔文字（任意）",
+    "placeholder": "例：(๑•̀ㅂ•́)و✧"
+  },
+  "image": {
+    "title": "表情画像を一枚アップロード",
+    "formats": "PNG、JPEG、WebP／最大 10 MiB",
+    "choose": "表情の参考画像を一枚選ぶ",
+    "hint": "表情、ポーズ、構図だけを参照します。キャラクターは Agent ペルソナが決めます。",
+    "previewAlt": "アップロードした表情の参考画像",
+    "remove": "参考画像を削除",
+    "localSize": "ローカル画像 · {size}"
+  },
+  "output": {
+    "title": "出力：独立した PNG スタンプ",
+    "detail": "1024 × 1024、1キャラクター、文字・透かしなし。"
+  },
+  "action": {
+    "generate": "スタンプを一枚生成",
+    "cancel": "タスクをキャンセル",
+    "dismiss": "状態を閉じる",
+    "preview": "大きく表示",
+    "downloadPng": "PNG をダウンロード",
+    "closePreview": "拡大プレビューを閉じる"
+  },
+  "status": {
+    "creating": "AI 画像タスクを作成中",
+    "creatingDetail": "ペルソナ画像と表情指示を Myriad の管理対象 Task API へ送信しています。",
+    "waiting": "タスク作成済み、画像を待っています",
+    "waitingDetail": "クライアントは最大315秒待機します。現在のタスクはキャンセルできます。",
+    "failed": "生成が完了しませんでした",
+    "cancelled": "タスクをキャンセルしました",
+    "success": "一枚のスタンプを生成しました",
+    "successDetail": "独立した PNG スタンプを、このセッションでプレビューできます。"
+  },
+  "result": {
+    "title": "Agent の新しい表情が完成しました",
+    "alt": "生成された Agent の PNG スタンプ",
+    "cacheBadge": "Myriad 一時キャッシュ",
+    "cacheBoundary": "結果はホストの一時 PNG キャッシュです。アプリ内で拡大表示するか、すぐにダウンロードできます。",
+    "previewTitle": "スタンプの拡大プレビュー",
+    "previewAlt": "生成された Agent PNG スタンプの拡大表示",
+    "downloadBoundary": "Myriad ホストが現在のキャッシュを読み取り、実際の PNG として保存します。キャッシュが有効な間にダウンロードしてください。",
+    "downloadStarted": "PNG を Myriad のダウンロード処理へ渡しました。"
+  },
+  "errors": {
+    "provider": "画像プロバイダーがタスクを完了できませんでした。ペルソナ画像や参考画像を捨て、文章だけの生成へ無断で切り替えることはありません。",
+    "permission": "ai:image 権限がありません。Myriad の Tapp 権限設定で画像生成を許可してください。",
+    "persona": "先に Myriad で Agent ペルソナを作成し、利用可能な画像を生成してください。",
+    "expressionCue": "Emoji または顔文字を選択・入力してください。",
+    "expressionImage": "表情画像モードでは参考画像を一枚アップロードしてください。",
+    "timeout": "クライアントの待機時間を超えました。リモートタスクのキャンセルを試みました。",
+    "cancelled": "タスクはキャンセルされ、結果は生成されませんでした。",
+    "reference": "参考画像は内容と MIME が一致する PNG、JPEG、WebP である必要があります。",
+    "referenceLimit": "表情の参考画像は一枚だけ選び、デコード後 10 MiB 以下にしてください。",
+    "inputLimit": "プロンプトまたはタスク入力が上限を超えています。カスタム値を短くしてください。",
+    "apiUnavailable": "このサンドボックスでは Tapp.ai.tasks の画像生成を利用できません。",
+    "fileApiUnavailable": "ブラウザーで利用可能な FileReader がありません。",
+    "downloadUnavailable": "このインストールではホストの PNG ダウンロード機能を利用できません。Myriad を更新してもう一度お試しください。",
+    "fileRead": "ローカル画像を読み込めないか、読み込みがキャンセルされました。もう一度選択してください。",
+    "resultInvalid": "安全な Myriad PNG 画像キャッシュパスが返されなかったため、プレビューできません。",
+    "unknown": "操作に失敗しました。再試行前に Myriad コンソールでエラーコードを確認してください。"
+  }
+}

--- a/apps/cn.echootaku.persona-stickers/i18n/zh-CN.json
+++ b/apps/cn.echootaku.persona-stickers/i18n/zh-CN.json
@@ -1,0 +1,125 @@
+{
+  "app": {
+    "eyebrow": "PERSONA STICKER LAB",
+    "title": "人设表情工坊",
+    "subtitle": "制作属于你 Agent 的表情包~",
+    "privacy": "人设图与可选参考图只随本次受治理的图片任务提交。"
+  },
+  "persona": {
+    "title": "你的 Agent 人设",
+    "loading": "读取中",
+    "ready": "已就绪",
+    "disabled": "未启用",
+    "noPortrait": "缺少人设图",
+    "unavailable": "不可用",
+    "loadingDetail": "正在读取公开人设名片…",
+    "disabledDetail": "当前没有启用的 Agent 人设。",
+    "noPortraitDetail": "Agent 人设尚未生成可用的人设图。",
+    "unavailableDetail": "当前无法读取 Agent 人设。",
+    "requiredTitle": "请先准备 Agent 人设",
+    "requiredDetail": "请先在 Myriad 中创建并生成 Agent 人设图，然后重新打开本应用。",
+    "context": "心情：{mood} · 状态：{activity}",
+    "help": "Agent 人设图始终决定生成角色的身份与外观。"
+  },
+  "mood": { "floor": "低落", "sad": "难过", "tense": "紧张", "calm": "平静", "excited": "兴奋" },
+  "activity": { "idle": "空闲", "working": "工作中", "thinking": "思考中", "talking": "交谈中" },
+  "composer": {
+    "title": "选择表情提示",
+    "subtitle": "三种方式任选其一，每次只生成一张独立 PNG 表情。"
+  },
+  "mode": {
+    "legend": "表情提示方式",
+    "emoji": "Emoji",
+    "emojiDetail": "用一个图形表达情绪",
+    "kaomoji": "颜文字",
+    "kaomojiDetail": "用字符描述神态",
+    "image": "图片表情",
+    "imageDetail": "参考一张现成表情图"
+  },
+  "cue": { "customPriority": "填写自定义内容时将优先使用它" },
+  "prompt": {
+    "title": "补充提示词（高优先级）",
+    "priority": "会优先影响动作、表情、道具、构图与情绪强度",
+    "placeholder": "例如：双手抱头蹲下，眼泪像喷泉一样向两侧飞出，动作非常夸张。",
+    "boundary": "可选填写；不会覆盖 Agent 身份、单张成图、单角色和无文字等固定要求。"
+  },
+  "emoji": {
+    "title": "选择 Emoji",
+    "joy": "开心",
+    "cry": "大哭",
+    "determined": "较真",
+    "shy": "害羞",
+    "think": "思考",
+    "celebrate": "庆祝",
+    "custom": "自定义 Emoji（可选）",
+    "placeholder": "例如：🥺"
+  },
+  "kaomoji": {
+    "title": "选择颜文字",
+    "joy": "雀跃",
+    "sad": "委屈",
+    "shock": "震惊",
+    "wave": "招呼",
+    "custom": "自定义颜文字（可选）",
+    "placeholder": "例如：(๑•̀ㅂ•́)و✧"
+  },
+  "image": {
+    "title": "上传一张图片表情",
+    "formats": "PNG、JPEG 或 WebP，最多 10 MiB",
+    "choose": "选择一张表情参考图",
+    "hint": "它只提供表情、姿势和构图，Agent 人设仍决定角色。",
+    "previewAlt": "上传的表情参考图",
+    "remove": "移除参考图",
+    "localSize": "本地图片 · {size}"
+  },
+  "output": {
+    "title": "输出：独立 PNG 表情",
+    "detail": "1024 × 1024，单角色，无文字与水印。"
+  },
+  "action": {
+    "generate": "生成一张表情",
+    "cancel": "取消任务",
+    "dismiss": "关闭状态提示",
+    "preview": "查看大图",
+    "downloadPng": "下载 PNG",
+    "closePreview": "关闭大图预览"
+  },
+  "status": {
+    "creating": "正在创建 AI 图片任务",
+    "creatingDetail": "人设图与表情提示正在通过受治理的 Myriad Task API 提交。",
+    "waiting": "任务已创建，等待生成结果",
+    "waitingDetail": "客户端最多等待 315 秒；你可以取消当前任务。",
+    "failed": "生成没有完成",
+    "cancelled": "任务已取消",
+    "success": "单张表情已生成",
+    "successDetail": "已生成一张独立 PNG 表情，可在本次会话中预览。"
+  },
+  "result": {
+    "title": "Agent 的新表情完成了",
+    "alt": "生成的 Agent PNG 表情",
+    "cacheBadge": "Myriad 临时缓存",
+    "cacheBoundary": "结果是宿主 PNG 临时缓存，可在应用内查看大图或立即下载。",
+    "previewTitle": "表情大图预览",
+    "previewAlt": "生成的 Agent PNG 表情大图",
+    "downloadBoundary": "下载由 Myriad 宿主读取当前缓存并保存为真实 PNG；请在缓存有效时完成下载。",
+    "downloadStarted": "PNG 已交给 Myriad 下载。"
+  },
+  "errors": {
+    "provider": "图片供应商未完成任务。应用不会丢弃人设图或参考图后静默改为文生图。",
+    "permission": "未授予 ai:image 权限；请在 Myriad 的 Tapp 权限配置中允许图片生成。",
+    "persona": "请先在 Myriad 中创建并生成可用的 Agent 人设图。",
+    "expressionCue": "请选择或填写一个 Emoji 或颜文字。",
+    "expressionImage": "图片表情模式必须上传一张参考图。",
+    "timeout": "客户端等待超时，应用已尝试取消远端任务。",
+    "cancelled": "任务已取消，没有生成结果。",
+    "reference": "参考图必须是内容与 MIME 匹配的 PNG、JPEG 或 WebP 图片。",
+    "referenceLimit": "每次只能选择一张表情参考图，且解码后不得超过 10 MiB。",
+    "inputLimit": "提示词或任务输入超过当前 AI Task 限制，请缩短自定义内容。",
+    "apiUnavailable": "当前沙箱没有可用的 Tapp.ai.tasks 图片任务 API。",
+    "fileApiUnavailable": "当前浏览器没有可用的本地 FileReader。",
+    "downloadUnavailable": "当前安装未提供宿主 PNG 下载接口，请更新 Myriad 后重试。",
+    "fileRead": "本地图片读取失败或已取消，请重新选择文件。",
+    "resultInvalid": "任务没有返回安全的 Myriad PNG 图片缓存路径，无法预览。",
+    "unknown": "操作失败，请查看 Myriad 控制台中的错误码后重试。"
+  }
+}

--- a/apps/cn.echootaku.persona-stickers/manifest.json
+++ b/apps/cn.echootaku.persona-stickers/manifest.json
@@ -1,0 +1,40 @@
+{
+  "id": "cn.echootaku.persona-stickers",
+  "name": "人设表情工坊",
+  "version": "0.3.3",
+  "description": "使用用户 Agent 人设，通过 Emoji、颜文字或单张参考图生成独立 PNG 表情图片",
+  "locales": {
+    "en-US": {
+      "name": "Persona Sticker Lab",
+      "description": "Turn your Agent Persona into a standalone PNG expression using an Emoji, kaomoji, or one image reference"
+    },
+    "ja-JP": {
+      "name": "ペルソナスタンプ工房",
+      "description": "Agent ペルソナと Emoji・顔文字・1枚の参考画像から、単体PNG表情画像を生成します"
+    }
+  },
+  "category": "ai",
+  "author": {
+    "name": "EchoOtaku",
+    "url": "https://github.com/EchoOtaku"
+  },
+  "repository": "https://github.com/Myriad-You/tapp-store",
+  "permissions": ["ai:image"],
+  "ai": {
+    "protocolVersion": 2,
+    "operations": ["image"],
+    "modelTier": "standard",
+    "contextSources": [],
+    "outputFormats": ["image"]
+  },
+  "iconSvg": "<svg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><rect x='4' y='3.5' width='15' height='15' rx='4' stroke='currentColor' stroke-width='1.7'/><path d='M8.2 10.3h.01M14.8 10.3h.01M8.5 14c1 .8 2.1 1.2 3.3 1.2 1.3 0 2.4-.4 3.4-1.2' stroke='currentColor' stroke-width='1.7' stroke-linecap='round'/><path d='m15.5 18.5 3.7 2-.7-4.2' stroke='currentColor' stroke-width='1.7' stroke-linejoin='round'/></svg>",
+  "themeColor": "#6558D9",
+  "core": {
+    "entry": "core.js"
+  },
+  "page": {
+    "entry": "page/index.js",
+    "template": "page.html",
+    "styles": "page.css"
+  }
+}

--- a/apps/cn.echootaku.persona-stickers/page.css
+++ b/apps/cn.echootaku.persona-stickers/page.css
@@ -1,0 +1,333 @@
+:root {
+  color-scheme: light dark;
+  font-family: Inter, "Noto Sans SC", "Noto Sans JP", "Microsoft YaHei UI", system-ui, sans-serif;
+  --ink: #182138;
+  --muted: #66708a;
+  --surface: rgba(250, 252, 255, .92);
+  --surface-solid: #fbfcff;
+  --surface-soft: rgba(224, 232, 255, .55);
+  --line: rgba(43, 59, 96, .16);
+  --shadow: 0 24px 70px rgba(44, 58, 91, .14);
+  --accent: var(--tapp-primary, #6558d9);
+  --accent-rgb: var(--tapp-primary-rgb, 101, 88, 217);
+  --signal: #ff805a;
+  --success: #218568;
+  --danger: #bb4c56;
+}
+
+html,
+body {
+  width: 100%;
+  min-width: 0;
+  min-height: 100%;
+  margin: 0;
+  background: transparent;
+  color: var(--ink);
+}
+
+* { box-sizing: border-box; }
+button, input, textarea { font: inherit; }
+button, label { -webkit-tap-highlight-color: transparent; }
+button { cursor: pointer; }
+button:disabled { cursor: not-allowed; opacity: .5; transform: none !important; }
+[hidden] { display: none !important; }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.studio-backdrop {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  background:
+    linear-gradient(118deg, rgba(var(--accent-rgb), .11), transparent 35%),
+    radial-gradient(circle at 88% 14%, rgba(255, 128, 90, .14), transparent 25%),
+    linear-gradient(155deg, #f4f7ff 0%, #e8edfb 48%, #f8f5ff 100%);
+}
+
+.paper-shape {
+  position: absolute;
+  border: 1px solid rgba(var(--accent-rgb), .12);
+  background: rgba(255, 255, 255, .26);
+}
+
+.paper-shape-a {
+  width: 36vw;
+  height: 36vw;
+  top: -23vw;
+  right: -4vw;
+  border-radius: 48% 52% 43% 57%;
+  transform: rotate(18deg);
+}
+
+.paper-shape-b {
+  width: 31vw;
+  height: 31vw;
+  left: -18vw;
+  bottom: -16vw;
+  border-radius: 54% 46% 62% 38%;
+  transform: rotate(-12deg);
+}
+
+.paper-dots {
+  position: absolute;
+  inset: 0;
+  opacity: .21;
+  background-image: radial-gradient(rgba(24, 33, 56, .25) .7px, transparent .7px);
+  background-size: 15px 15px;
+  mask-image: linear-gradient(90deg, transparent, #000 15%, #000 85%, transparent);
+}
+
+.studio-page {
+  position: relative;
+  z-index: 0;
+  width: 100%;
+  min-height: 100%;
+  padding:
+    calc(var(--tapp-safe-inset-top, 0px) + clamp(20px, 4vw, 46px))
+    calc(var(--tapp-safe-inset-right, 0px) + clamp(15px, 4vw, 54px))
+    calc(var(--tapp-safe-inset-bottom, 0px) + clamp(28px, 5vw, 62px))
+    calc(var(--tapp-safe-inset-left, 0px) + clamp(15px, 4vw, 54px));
+}
+
+.studio-hero {
+  max-width: 1420px;
+  margin: 0 auto clamp(20px, 3vw, 36px);
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 26px;
+}
+
+.brand-lockup { display: flex; align-items: center; gap: clamp(14px, 2vw, 22px); min-width: 0; }
+.brand-stamp {
+  position: relative;
+  flex: none;
+  width: 72px;
+  height: 72px;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--ink);
+  border-radius: 22px 22px 29px 18px;
+  background: var(--surface-solid);
+  box-shadow: 6px 7px 0 rgba(var(--accent-rgb), .26);
+  transform: rotate(-4deg);
+}
+.brand-stamp::after {
+  content: "";
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  width: 21px;
+  height: 21px;
+  border: 2px solid var(--ink);
+  border-width: 2px 0 0 2px;
+  border-radius: 16px 0 20px 0;
+  background: #dbe3fb;
+}
+.brand-stamp span { font: 850 32px/1 ui-rounded, "Arial Rounded MT Bold", sans-serif; }
+.brand-stamp i { position: absolute; top: 9px; right: 9px; width: 8px; height: 8px; border-radius: 50%; background: var(--signal); }
+.eyebrow, .section-index { margin: 0 0 6px; color: var(--accent); font-size: 10px; line-height: 1.2; font-weight: 900; letter-spacing: .19em; }
+.studio-hero h1 { margin: 0; font: 850 clamp(30px, 4.1vw, 52px)/1.05 ui-rounded, "Arial Rounded MT Bold", "Microsoft YaHei UI", sans-serif; letter-spacing: -.045em; }
+.hero-copy { margin: 9px 0 0; color: var(--muted); font-size: clamp(14px, 1.5vw, 17px); }
+.privacy-note { max-width: 430px; display: flex; align-items: flex-start; gap: 10px; color: var(--muted); font-size: 12px; line-height: 1.6; text-wrap: balance; }
+.privacy-dot { flex: none; width: 9px; height: 9px; margin-top: 5px; border: 2px solid var(--success); border-radius: 50%; box-shadow: 0 0 0 4px rgba(33, 133, 104, .12); }
+
+.studio-layout { max-width: 1420px; margin: 0 auto; display: grid; grid-template-columns: minmax(270px, .7fr) minmax(0, 1.55fr); align-items: start; gap: clamp(16px, 2.4vw, 30px); }
+.context-column { display: grid; gap: 18px; position: sticky; top: calc(var(--tapp-safe-inset-top, 0px) + 18px); }
+.panel { border: 1px solid var(--line); border-radius: 25px; background: var(--surface); box-shadow: var(--shadow); backdrop-filter: blur(18px) saturate(125%); -webkit-backdrop-filter: blur(18px) saturate(125%); }
+.persona-panel { padding: 20px; }
+.composer-panel { padding: clamp(20px, 3vw, 34px); }
+.panel-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; margin-bottom: 18px; }
+.panel-heading h2, .result-copy h2 { margin: 0; font: 820 clamp(20px, 2vw, 27px)/1.17 ui-rounded, "Arial Rounded MT Bold", "Microsoft YaHei UI", sans-serif; letter-spacing: -.025em; }
+.composer-heading { margin-bottom: 22px; }
+.helper-text { margin: 6px 0 0; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.status-chip, .cache-badge { flex: none; display: inline-flex; align-items: center; min-height: 28px; padding: 5px 10px; border-radius: 999px; font-size: 11px; font-weight: 850; letter-spacing: .02em; }
+.status-chip { color: var(--accent); background: rgba(var(--accent-rgb), .11); }
+.status-chip[data-tone="ready"] { color: var(--success); background: rgba(33, 133, 104, .11); }
+.status-chip[data-tone="off"], .status-chip[data-tone="error"] { color: var(--danger); background: rgba(187, 76, 86, .1); }
+
+.persona-card { display: flex; align-items: center; gap: 14px; padding: 13px; border: 1px solid rgba(var(--accent-rgb), .12); border-radius: 18px; background: var(--surface-soft); }
+.persona-portrait { flex: none; width: 64px; aspect-ratio: 1; overflow: hidden; display: grid; place-items: center; border: 1px solid rgba(var(--accent-rgb), .23); border-radius: 20px 20px 24px 16px; background: linear-gradient(135deg, rgba(var(--accent-rgb), .18), rgba(255, 128, 90, .12)); color: var(--accent); font: 850 16px/1 ui-rounded, sans-serif; }
+.persona-portrait img { width: 100%; height: 100%; object-fit: cover; }
+.persona-copy { min-width: 0; display: grid; gap: 5px; }
+.persona-copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; }
+.persona-copy span { color: var(--muted); font-size: 12px; line-height: 1.4; }
+
+.persona-gate { display: flex; align-items: flex-start; gap: 13px; margin-bottom: 18px; padding: 15px; border: 1px solid rgba(187, 76, 86, .23); border-radius: 17px; background: rgba(187, 76, 86, .075); }
+.persona-gate > span { width: 32px; height: 32px; display: grid; place-items: center; flex: none; border-radius: 50%; color: var(--danger); background: rgba(187, 76, 86, .1); font-size: 22px; }
+.persona-gate div { display: grid; gap: 3px; }
+.persona-gate strong { font-size: 13px; }
+.persona-gate p { margin: 0; color: var(--muted); font-size: 12px; line-height: 1.5; }
+
+fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
+.mode-switcher { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.mode-card { position: relative; min-height: 116px; display: grid; grid-template-rows: 43px auto auto; align-content: center; justify-items: start; gap: 4px; padding: 16px; overflow: hidden; border: 1px solid var(--line); border-radius: 19px; background: rgba(255, 255, 255, .52); cursor: pointer; }
+.mode-card::after { content: ""; position: absolute; right: -17px; bottom: -20px; width: 48px; height: 48px; border: 1px solid rgba(var(--accent-rgb), .2); border-radius: 50%; background: rgba(var(--accent-rgb), .06); }
+.mode-card input, .cue-grid input { position: absolute; opacity: 0; pointer-events: none; }
+.mode-card:has(input:checked) { border-color: rgba(var(--accent-rgb), .65); background: rgba(var(--accent-rgb), .1); box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb), .12); }
+.mode-card:has(input:checked)::before { content: "✓"; position: absolute; top: 9px; right: 10px; color: var(--accent); font-size: 12px; font-weight: 900; }
+.mode-card:has(input:focus-visible), .cue-grid label:has(input:focus-visible) { outline: 3px solid rgba(var(--accent-rgb), .27); outline-offset: 2px; }
+.mode-icon { display: inline-flex; min-width: 42px; min-height: 42px; align-items: center; justify-content: center; font-size: 30px; line-height: 1; }
+.mode-icon.kaomoji { font: 800 12px/1.15 ui-monospace, SFMono-Regular, Consolas, monospace; }
+.mode-card strong { font-size: 14px; }
+.mode-card small { position: relative; z-index: 1; color: var(--muted); font-size: 10px; line-height: 1.4; }
+
+.mode-panel { margin-top: 16px; padding: clamp(16px, 2.2vw, 22px); border: 1px solid var(--line); border-radius: 20px; background: rgba(255, 255, 255, .34); }
+.mode-panel-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 13px; }
+.mode-panel-heading h3 { margin: 0; font-size: 14px; }
+.mode-panel-heading span { color: var(--muted); font-size: 10px; }
+.cue-grid { display: grid; gap: 8px; }
+.emoji-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.kaomoji-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.cue-grid label { position: relative; min-height: 74px; display: grid; align-content: center; justify-items: center; gap: 6px; padding: 8px 5px; border: 1px solid var(--line); border-radius: 15px; background: rgba(255, 255, 255, .56); cursor: pointer; text-align: center; }
+.cue-grid label:has(input:checked) { border-color: rgba(var(--accent-rgb), .62); color: var(--accent); background: rgba(var(--accent-rgb), .1); box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb), .1); }
+.cue-grid span { font-size: 25px; line-height: 1; }
+.kaomoji-grid span { font: 750 clamp(10px, 1.1vw, 13px)/1.2 ui-monospace, SFMono-Regular, Consolas, monospace; }
+.cue-grid small { color: var(--muted); font-size: 10px; }
+.cue-input { display: grid; gap: 7px; margin-top: 13px; color: var(--muted); font-size: 11px; font-weight: 780; }
+.cue-input input { width: 100%; min-height: 45px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 13px; outline: 0; background: rgba(255, 255, 255, .65); color: var(--ink); }
+.cue-input input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(var(--accent-rgb), .15); }
+
+.priority-prompt { display: grid; gap: 9px; margin-top: 16px; padding: 16px; border: 1px solid rgba(var(--accent-rgb), .34); border-radius: 19px; background: linear-gradient(135deg, rgba(var(--accent-rgb), .09), rgba(255, 128, 90, .045)); }
+.priority-prompt-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; }
+.priority-prompt-heading strong { color: var(--ink); font-size: 13px; }
+.priority-prompt-heading small, .priority-prompt > small { color: var(--muted); font-size: 10px; line-height: 1.5; }
+.priority-prompt-heading small { color: var(--accent); font-weight: 760; text-align: right; }
+.priority-prompt textarea { width: 100%; min-height: 82px; resize: vertical; padding: 12px 13px; border: 1px solid var(--line); border-radius: 14px; outline: 0; background: rgba(255, 255, 255, .68); color: var(--ink); line-height: 1.55; }
+.priority-prompt textarea::placeholder { color: var(--muted); opacity: .82; }
+.priority-prompt textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(var(--accent-rgb), .15); }
+
+.file-picker { min-height: 142px; display: flex; align-items: center; justify-content: center; flex-direction: column; gap: 5px; padding: 18px; border: 1px dashed rgba(var(--accent-rgb), .48); border-radius: 18px; background: rgba(var(--accent-rgb), .045); text-align: center; cursor: pointer; }
+.file-picker:hover { background: rgba(var(--accent-rgb), .08); }
+.file-picker:focus-within { outline: 3px solid rgba(var(--accent-rgb), .25); outline-offset: 2px; }
+.file-picker input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+.file-picker-icon { width: 43px; height: 43px; display: grid; place-items: center; margin-bottom: 3px; border-radius: 15px; color: var(--accent); background: rgba(var(--accent-rgb), .11); font-size: 25px; }
+.file-picker strong { font-size: 13px; }
+.file-picker small { max-width: 450px; color: var(--muted); font-size: 10px; line-height: 1.5; }
+.expression-preview { display: grid; grid-template-columns: 62px minmax(0, 1fr) auto; gap: 12px; align-items: center; margin-top: 12px; padding: 10px; border: 1px solid var(--line); border-radius: 16px; background: rgba(255, 255, 255, .56); }
+.expression-preview img { width: 62px; aspect-ratio: 1; border-radius: 13px; object-fit: cover; background: rgba(var(--accent-rgb), .06); }
+.expression-preview div { min-width: 0; display: grid; gap: 4px; }
+.expression-preview strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+.expression-preview small { color: var(--muted); font-size: 10px; }
+
+.generation-bar { display: flex; align-items: center; justify-content: space-between; gap: 18px; margin-top: 20px; padding-top: 20px; border-top: 1px solid var(--line); }
+.generation-bar p { display: grid; gap: 5px; margin: 0; }
+.generation-bar p strong { font-size: 13px; }
+.generation-bar p small { color: var(--muted); font-size: 10px; line-height: 1.45; }
+.generate-button { min-height: 54px; display: inline-flex; align-items: center; justify-content: center; gap: 9px; flex: none; padding: 12px 21px; border: 0; border-radius: 16px 16px 21px 13px; background: var(--accent); color: white; box-shadow: 0 13px 30px rgba(var(--accent-rgb), .27); font-weight: 850; }
+.generate-button:hover { filter: brightness(1.07); transform: translateY(-1px) rotate(-.4deg); }
+.spark { color: #fff3a6; font-size: 18px; }
+
+.feedback { display: flex; align-items: center; gap: 12px; margin-top: 17px; padding: 13px 14px; border: 1px solid var(--line); border-radius: 16px; background: rgba(255, 255, 255, .5); }
+.feedback[data-tone="error"] { border-color: rgba(187, 76, 86, .3); background: rgba(187, 76, 86, .075); }
+.feedback[data-tone="success"] { border-color: rgba(33, 133, 104, .3); background: rgba(33, 133, 104, .075); }
+.feedback-copy { flex: 1; min-width: 0; display: grid; gap: 3px; overflow-wrap: anywhere; }
+.feedback-copy strong { font-size: 13px; }
+.feedback-copy span { color: var(--muted); font-size: 12px; line-height: 1.45; }
+.icon-button, .cancel-button { min-width: 40px; min-height: 40px; border: 1px solid var(--line); border-radius: 12px; background: rgba(255, 255, 255, .62); color: var(--ink); }
+.cancel-button { padding: 8px 13px; color: var(--danger); font-weight: 750; }
+.icon-button:hover, .cancel-button:hover { border-color: rgba(var(--accent-rgb), .46); background: rgba(var(--accent-rgb), .08); }
+.generate-button:focus-visible, .cancel-button:focus-visible, .icon-button:focus-visible, .result-image-wrap:focus-visible, .primary-action:focus-visible, .secondary-action:focus-visible, .viewer-download:focus-visible, .viewer-close:focus-visible { outline: 3px solid rgba(var(--accent-rgb), .3); outline-offset: 3px; }
+
+.result-panel { display: grid; grid-template-columns: minmax(220px, .84fr) minmax(250px, 1.16fr); gap: clamp(18px, 3vw, 34px); align-items: center; margin-top: 21px; padding: clamp(15px, 2vw, 23px); border: 1px solid rgba(var(--accent-rgb), .29); border-radius: 22px; background: rgba(var(--accent-rgb), .065); }
+.result-image-wrap { position: relative; min-width: 0; overflow: hidden; aspect-ratio: 1; padding: 0; border: 1px solid var(--line); border-radius: 20px 20px 27px 15px; background: rgba(255, 255, 255, .5); color: var(--ink); cursor: zoom-in; }
+.result-image-wrap::after { content: ""; position: absolute; right: -1px; bottom: -1px; width: 34px; height: 34px; border: 1px solid rgba(var(--accent-rgb), .18); border-width: 1px 0 0 1px; border-radius: 22px 0 24px 0; background: rgba(224, 232, 255, .76); }
+.result-image-wrap img { width: 100%; height: 100%; display: block; object-fit: contain; }
+.cache-badge { position: absolute; z-index: 1; left: 10px; bottom: 10px; color: white; background: rgba(24, 33, 56, .78); backdrop-filter: blur(8px); }
+.result-zoom-hint { position: absolute; z-index: 2; right: 11px; top: 11px; width: 34px; height: 34px; display: grid; place-items: center; border: 1px solid rgba(255, 255, 255, .55); border-radius: 11px; background: rgba(24, 33, 56, .72); color: #fff; font-size: 20px; line-height: 1; backdrop-filter: blur(8px); }
+.result-copy p:not(.section-index) { margin: 11px 0 0; color: var(--muted); font-size: 12px; line-height: 1.65; }
+.result-actions { display: flex; flex-wrap: wrap; gap: 9px; margin-top: 16px; }
+.primary-action, .secondary-action, .viewer-download, .viewer-close { min-height: 42px; border-radius: 13px; font-weight: 820; }
+.primary-action { padding: 9px 15px; border: 0; background: var(--accent); color: #fff; box-shadow: 0 8px 20px rgba(var(--accent-rgb), .22); }
+.secondary-action, .viewer-download { padding: 9px 15px; border: 1px solid rgba(var(--accent-rgb), .3); background: rgba(255, 255, 255, .64); color: var(--accent); }
+.primary-action:hover, .secondary-action:hover, .viewer-download:hover { filter: brightness(1.05); transform: translateY(-1px); }
+.download-boundary { padding-left: 10px; border-left: 3px solid rgba(255, 128, 90, .55); }
+.download-status { color: var(--success) !important; font-weight: 750; }
+
+body.result-viewer-open { overflow: hidden; }
+.result-viewer { position: fixed; z-index: 60; inset: 0; display: grid; place-items: center; padding: calc(var(--tapp-safe-inset-top, 0px) + 18px) calc(var(--tapp-safe-inset-right, 0px) + 18px) calc(var(--tapp-safe-inset-bottom, 0px) + 18px) calc(var(--tapp-safe-inset-left, 0px) + 18px); }
+.result-viewer-backdrop { position: absolute; inset: 0; background: rgba(9, 12, 22, .76); backdrop-filter: blur(14px) saturate(80%); -webkit-backdrop-filter: blur(14px) saturate(80%); }
+.result-viewer-card { position: relative; width: min(94vw, 900px); max-height: calc(100vh - var(--tapp-safe-inset-top, 0px) - var(--tapp-safe-inset-bottom, 0px) - 36px); display: grid; grid-template-rows: auto minmax(0, 1fr) auto; gap: 13px; overflow: hidden; padding: 18px; border: 1px solid rgba(255, 255, 255, .16); border-radius: 24px; background: var(--surface-solid); box-shadow: 0 34px 100px rgba(0, 0, 0, .45); }
+.result-viewer-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.result-viewer-toolbar h2 { margin: 0; font: 820 clamp(18px, 2.5vw, 25px)/1.2 ui-rounded, "Arial Rounded MT Bold", "Microsoft YaHei UI", sans-serif; }
+.result-viewer-actions { display: flex; align-items: center; gap: 9px; }
+.viewer-close { width: 42px; padding: 0; border: 1px solid var(--line); background: rgba(var(--accent-rgb), .08); color: var(--ink); font-size: 23px; }
+.result-viewer-stage { min-height: 0; overflow: hidden; display: grid; place-items: center; border: 1px solid var(--line); border-radius: 18px; background-color: #f7f8fc; }
+.result-viewer-stage img { display: block; width: 100%; height: 100%; max-height: min(68vh, 780px); object-fit: contain; }
+.result-viewer-footer { display: grid; gap: 5px; }
+.result-viewer-footer p { margin: 0; color: var(--muted); font-size: 11px; line-height: 1.55; }
+
+.dark, html.dark {
+  --ink: #fafafa;
+  --muted: #a3a3a3;
+  --surface: rgba(10, 10, 10, .9);
+  --surface-solid: #171717;
+  --surface-soft: rgba(101, 88, 217, .12);
+  --line: rgba(255, 255, 255, .12);
+  --shadow: 0 26px 80px rgba(0, 0, 0, .36);
+}
+.dark .studio-backdrop, html.dark .studio-backdrop { background: linear-gradient(118deg, rgba(var(--accent-rgb), .18), transparent 35%), radial-gradient(circle at 88% 14%, rgba(255, 128, 90, .11), transparent 25%), linear-gradient(155deg, #090909 0%, #171717 50%, #0a0a0a 100%); }
+.dark .paper-dots, html.dark .paper-dots { background-image: radial-gradient(rgba(255, 255, 255, .2) .7px, transparent .7px); }
+.dark .brand-stamp::after, html.dark .brand-stamp::after, .dark .result-image-wrap::after, html.dark .result-image-wrap::after { background: #262626; }
+.dark .mode-card, .dark .mode-panel, .dark .cue-grid label, .dark .cue-input input, .dark .priority-prompt textarea, .dark .file-picker, .dark .expression-preview, .dark .feedback, .dark .icon-button, .dark .cancel-button, .dark .result-image-wrap, .dark .secondary-action, .dark .viewer-download,
+html.dark .mode-card, html.dark .mode-panel, html.dark .cue-grid label, html.dark .cue-input input, html.dark .priority-prompt textarea, html.dark .file-picker, html.dark .expression-preview, html.dark .feedback, html.dark .icon-button, html.dark .cancel-button, html.dark .result-image-wrap, html.dark .secondary-action, html.dark .viewer-download { background: rgba(255, 255, 255, .045); }
+.dark .result-viewer-stage, html.dark .result-viewer-stage { background-color: #171717; }
+
+@media (max-width: 979px) {
+  .studio-hero { align-items: flex-start; flex-direction: column; }
+  .privacy-note { max-width: 650px; }
+  .studio-layout { grid-template-columns: 1fr; }
+  .context-column { position: static; grid-template-columns: minmax(0, .82fr) minmax(0, 1.18fr); }
+}
+
+@media (max-width: 680px) {
+  .studio-page { padding-top: calc(var(--tapp-safe-inset-top, 0px) + 18px); }
+  .brand-stamp { width: 56px; height: 56px; border-radius: 17px; box-shadow: 4px 5px 0 rgba(var(--accent-rgb), .24); }
+  .brand-stamp span { font-size: 26px; }
+  .studio-hero h1 { font-size: 31px; }
+  .context-column { grid-template-columns: 1fr; }
+  .mode-switcher { grid-template-columns: 1fr; }
+  .mode-card { min-height: 82px; grid-template-columns: 52px minmax(0, 1fr); grid-template-rows: auto auto; align-items: center; align-content: center; }
+  .mode-icon { grid-row: 1 / 3; }
+  .emoji-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .kaomoji-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .mode-panel-heading { align-items: flex-start; flex-direction: column; gap: 4px; }
+  .generation-bar { align-items: stretch; flex-direction: column; }
+  .generate-button { width: 100%; }
+  .feedback { align-items: stretch; flex-wrap: wrap; }
+  .feedback-copy { flex-basis: calc(100% - 54px); }
+  .result-panel { grid-template-columns: 1fr; }
+  .priority-prompt-heading { align-items: flex-start; flex-direction: column; gap: 4px; }
+  .priority-prompt-heading small { text-align: left; }
+  .result-viewer { padding: calc(var(--tapp-safe-inset-top, 0px) + 10px) calc(var(--tapp-safe-inset-right, 0px) + 10px) calc(var(--tapp-safe-inset-bottom, 0px) + 10px) calc(var(--tapp-safe-inset-left, 0px) + 10px); }
+  .result-viewer-card { width: 100%; max-height: calc(100vh - var(--tapp-safe-inset-top, 0px) - var(--tapp-safe-inset-bottom, 0px) - 20px); padding: 13px; border-radius: 19px; }
+  .result-viewer-toolbar { align-items: flex-start; }
+  .result-viewer-actions { flex-direction: row-reverse; }
+  .viewer-download { max-width: 145px; font-size: 11px; }
+}
+
+@media (max-width: 390px) {
+  .brand-lockup { align-items: flex-start; }
+  .brand-stamp { display: none; }
+  .composer-panel, .persona-panel { padding: 16px; border-radius: 20px; }
+  .emoji-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .expression-preview { grid-template-columns: 52px minmax(0, 1fr) auto; }
+  .expression-preview img { width: 52px; }
+  .result-actions { flex-direction: column; }
+  .primary-action, .secondary-action { width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; animation: none !important; }
+}

--- a/apps/cn.echootaku.persona-stickers/page.html
+++ b/apps/cn.echootaku.persona-stickers/page.html
@@ -1,0 +1,211 @@
+<div class="studio-backdrop" aria-hidden="true">
+  <span class="paper-shape paper-shape-a"></span>
+  <span class="paper-shape paper-shape-b"></span>
+  <span class="paper-dots"></span>
+</div>
+
+<main class="studio-page" data-page-root>
+  <div data-page-content>
+  <header class="studio-hero">
+    <div class="brand-lockup">
+      <div class="brand-stamp" aria-hidden="true"><span>☺</span><i></i></div>
+      <div>
+        <p class="eyebrow" data-i18n="app.eyebrow">PERSONA STICKER LAB</p>
+        <h1 data-i18n="app.title">人设表情工坊</h1>
+        <p class="hero-copy" data-i18n="app.subtitle">制作属于你 Agent 的表情包~</p>
+      </div>
+    </div>
+    <div class="privacy-note">
+      <span class="privacy-dot" aria-hidden="true"></span>
+      <span data-i18n="app.privacy">人设图与可选参考图只随本次受治理的图片任务提交。</span>
+    </div>
+  </header>
+
+  <div class="studio-layout">
+    <aside class="context-column">
+      <section class="panel persona-panel" aria-labelledby="persona-heading">
+        <div class="panel-heading">
+          <div>
+            <p class="section-index">01</p>
+            <h2 id="persona-heading" data-i18n="persona.title">你的 Agent 人设</h2>
+          </div>
+          <span class="status-chip" data-persona-status data-tone="loading">读取中</span>
+        </div>
+        <div class="persona-card">
+          <div class="persona-portrait" data-persona-portrait aria-hidden="true"><span>AG</span></div>
+          <div class="persona-copy">
+            <strong data-persona-name>Agent</strong>
+            <span data-persona-detail>正在读取公开人设名片…</span>
+          </div>
+        </div>
+        <p class="helper-text" data-persona-help data-i18n="persona.help">Agent 人设图始终决定生成角色的身份与外观。</p>
+      </section>
+    </aside>
+
+    <section class="panel composer-panel" data-composer aria-labelledby="composer-heading">
+      <div class="panel-heading composer-heading">
+        <div>
+          <p class="section-index">02</p>
+          <h2 id="composer-heading" data-i18n="composer.title">选择表情提示</h2>
+          <p class="helper-text" data-i18n="composer.subtitle">三种方式任选其一，每次只生成一张独立 PNG 表情。</p>
+        </div>
+      </div>
+
+      <section class="persona-gate" data-persona-gate role="status" aria-live="polite" hidden>
+        <span aria-hidden="true">◌</span>
+        <div>
+          <strong data-i18n="persona.requiredTitle">请先准备 Agent 人设</strong>
+          <p data-i18n="persona.requiredDetail">请先在 Myriad 中创建并生成 Agent 人设图，然后重新打开本应用。</p>
+        </div>
+      </section>
+
+      <fieldset class="mode-switcher">
+        <legend class="sr-only" data-i18n="mode.legend">表情提示方式</legend>
+        <label class="mode-card">
+          <input type="radio" name="expression-mode" value="emoji" checked>
+          <span class="mode-icon" aria-hidden="true">😄</span>
+          <strong data-i18n="mode.emoji">Emoji</strong>
+          <small data-i18n="mode.emojiDetail">用一个图形表达情绪</small>
+        </label>
+        <label class="mode-card">
+          <input type="radio" name="expression-mode" value="kaomoji">
+          <span class="mode-icon kaomoji" aria-hidden="true">(≧▽≦)</span>
+          <strong data-i18n="mode.kaomoji">颜文字</strong>
+          <small data-i18n="mode.kaomojiDetail">用字符描述神态</small>
+        </label>
+        <label class="mode-card">
+          <input type="radio" name="expression-mode" value="image">
+          <span class="mode-icon" aria-hidden="true">▧</span>
+          <strong data-i18n="mode.image">图片表情</strong>
+          <small data-i18n="mode.imageDetail">参考一张现成表情图</small>
+        </label>
+      </fieldset>
+
+      <div class="mode-panel" data-mode-panel="emoji">
+        <div class="mode-panel-heading">
+          <h3 data-i18n="emoji.title">选择 Emoji</h3>
+          <span data-i18n="cue.customPriority">填写自定义内容时将优先使用它</span>
+        </div>
+        <div class="cue-grid emoji-grid">
+          <label><input type="radio" name="emoji-preset" value="😀" checked><span>😀</span><small data-i18n="emoji.joy">开心</small></label>
+          <label><input type="radio" name="emoji-preset" value="😭"><span>😭</span><small data-i18n="emoji.cry">大哭</small></label>
+          <label><input type="radio" name="emoji-preset" value="😤"><span>😤</span><small data-i18n="emoji.determined">较真</small></label>
+          <label><input type="radio" name="emoji-preset" value="😳"><span>😳</span><small data-i18n="emoji.shy">害羞</small></label>
+          <label><input type="radio" name="emoji-preset" value="🤔"><span>🤔</span><small data-i18n="emoji.think">思考</small></label>
+          <label><input type="radio" name="emoji-preset" value="🥳"><span>🥳</span><small data-i18n="emoji.celebrate">庆祝</small></label>
+        </div>
+        <label class="cue-input">
+          <span data-i18n="emoji.custom">自定义 Emoji（可选）</span>
+          <input data-custom-cue="emoji" maxlength="32" type="text" inputmode="text" data-i18n-placeholder="emoji.placeholder" placeholder="例如：🥺">
+        </label>
+      </div>
+
+      <div class="mode-panel" data-mode-panel="kaomoji" hidden>
+        <div class="mode-panel-heading">
+          <h3 data-i18n="kaomoji.title">选择颜文字</h3>
+          <span data-i18n="cue.customPriority">填写自定义内容时将优先使用它</span>
+        </div>
+        <div class="cue-grid kaomoji-grid">
+          <label><input type="radio" name="kaomoji-preset" value="(≧▽≦)" checked><span>(≧▽≦)</span><small data-i18n="kaomoji.joy">雀跃</small></label>
+          <label><input type="radio" name="kaomoji-preset" value="(╥﹏╥)"><span>(╥﹏╥)</span><small data-i18n="kaomoji.sad">委屈</small></label>
+          <label><input type="radio" name="kaomoji-preset" value="(⊙o⊙)"><span>(⊙o⊙)</span><small data-i18n="kaomoji.shock">震惊</small></label>
+          <label><input type="radio" name="kaomoji-preset" value="(￣▽￣)ノ"><span>(￣▽￣)ノ</span><small data-i18n="kaomoji.wave">招呼</small></label>
+        </div>
+        <label class="cue-input">
+          <span data-i18n="kaomoji.custom">自定义颜文字（可选）</span>
+          <input data-custom-cue="kaomoji" maxlength="120" type="text" data-i18n-placeholder="kaomoji.placeholder" placeholder="例如：(๑•̀ㅂ•́)و✧">
+        </label>
+      </div>
+
+      <div class="mode-panel image-mode" data-mode-panel="image" hidden>
+        <div class="mode-panel-heading">
+          <h3 data-i18n="image.title">上传一张图片表情</h3>
+          <span data-i18n="image.formats">PNG、JPEG 或 WebP，最多 10 MiB</span>
+        </div>
+        <label class="file-picker">
+          <input data-file-input type="file" accept="image/png,image/jpeg,image/webp">
+          <span class="file-picker-icon" aria-hidden="true">＋</span>
+          <strong data-i18n="image.choose">选择一张表情参考图</strong>
+          <small data-i18n="image.hint">它只提供表情、姿势和构图，Agent 人设仍决定角色。</small>
+        </label>
+        <article class="expression-preview" data-expression-preview hidden>
+          <img data-expression-image alt="上传的表情参考图" data-i18n-alt="image.previewAlt">
+          <div>
+            <strong data-expression-name></strong>
+            <small data-expression-meta></small>
+          </div>
+          <button type="button" class="icon-button" data-action="remove-expression" data-i18n-aria-label="image.remove" aria-label="移除参考图">×</button>
+        </article>
+      </div>
+
+      <label class="priority-prompt">
+        <span class="priority-prompt-heading">
+          <strong data-i18n="prompt.title">补充提示词（高优先级）</strong>
+          <small data-i18n="prompt.priority">会优先影响动作、表情、道具、构图与情绪强度</small>
+        </span>
+        <textarea data-user-prompt maxlength="800" rows="3" data-i18n-placeholder="prompt.placeholder" placeholder="例如：双手抱头蹲下，眼泪像喷泉一样向两侧飞出，动作非常夸张。"></textarea>
+        <small data-i18n="prompt.boundary">可选填写；不会覆盖 Agent 身份、单张成图、单角色和无文字等固定要求。</small>
+      </label>
+
+      <div class="generation-bar">
+        <p><strong data-i18n="output.title">输出：独立 PNG 表情</strong><small data-i18n="output.detail">1024 × 1024，单角色，无文字与水印。</small></p>
+        <button class="generate-button" type="button" data-action="generate">
+          <span class="spark" aria-hidden="true">✦</span>
+          <span data-i18n="action.generate">生成一张表情</span>
+        </button>
+      </div>
+
+      <section class="feedback" data-feedback hidden>
+        <div class="feedback-copy" role="status" aria-live="polite" aria-atomic="true">
+          <strong data-feedback-title></strong>
+          <span data-feedback-message></span>
+        </div>
+        <button class="cancel-button" type="button" data-action="cancel" hidden data-i18n="action.cancel">取消任务</button>
+        <button class="icon-button" type="button" data-action="dismiss-error" hidden data-i18n-aria-label="action.dismiss" aria-label="关闭">×</button>
+      </section>
+
+      <section class="result-panel" data-result hidden aria-labelledby="result-heading">
+        <button type="button" class="result-image-wrap" data-action="open-preview" aria-haspopup="dialog" data-i18n-aria-label="action.preview">
+          <img data-result-image alt="生成的 Agent PNG 表情" data-i18n-alt="result.alt">
+          <span class="cache-badge" data-i18n="result.cacheBadge">Myriad 临时缓存</span>
+          <span class="result-zoom-hint" aria-hidden="true">⌕</span>
+        </button>
+        <div class="result-copy">
+          <p class="section-index">03</p>
+          <h2 id="result-heading" data-i18n="result.title">Agent 的新表情完成了</h2>
+          <p data-i18n="result.cacheBoundary">结果是宿主 PNG 临时缓存，可在应用内查看大图或立即下载。</p>
+          <div class="result-actions">
+            <button type="button" class="secondary-action" data-action="open-preview" data-i18n="action.preview">查看大图</button>
+            <button type="button" class="primary-action" data-action="download-png" data-i18n="action.downloadPng">下载 PNG</button>
+          </div>
+          <p class="download-boundary" data-i18n="result.downloadBoundary">下载由 Myriad 宿主读取当前缓存并保存为真实 PNG；请在缓存有效时完成下载。</p>
+          <span class="download-status" data-download-status role="status" aria-live="polite" hidden></span>
+        </div>
+      </section>
+    </section>
+  </div>
+  </div>
+
+  <section class="result-viewer" data-result-viewer role="dialog" aria-modal="true" aria-labelledby="result-viewer-title" aria-hidden="true" hidden>
+    <div class="result-viewer-backdrop" data-action="close-preview"></div>
+    <div class="result-viewer-card">
+      <header class="result-viewer-toolbar">
+        <div>
+          <p class="section-index">PREVIEW</p>
+          <h2 id="result-viewer-title" data-i18n="result.previewTitle">表情大图预览</h2>
+        </div>
+        <div class="result-viewer-actions">
+          <button type="button" class="viewer-download" data-action="download-png" data-i18n="action.downloadPng">下载 PNG</button>
+          <button type="button" class="viewer-close" data-action="close-preview" data-preview-close data-i18n-aria-label="action.closePreview" aria-label="关闭大图预览">×</button>
+        </div>
+      </header>
+      <div class="result-viewer-stage">
+        <img data-result-viewer-image alt="生成的 Agent PNG 表情大图" data-i18n-alt="result.previewAlt">
+      </div>
+      <div class="result-viewer-footer">
+        <p data-i18n="result.downloadBoundary">下载由 Myriad 宿主读取当前缓存并保存为真实 PNG；请在缓存有效时完成下载。</p>
+        <span class="download-status" data-download-status role="status" aria-live="polite" hidden></span>
+      </div>
+    </div>
+  </section>
+</main>

--- a/apps/cn.echootaku.persona-stickers/page/app-controller.js
+++ b/apps/cn.echootaku.persona-stickers/page/app-controller.js
@@ -1,0 +1,216 @@
+'use strict';
+
+var domain = require('./domain.js');
+var taskRunner = require('./task-runner.js');
+var fileReader = require('./file-reader.js');
+
+function defaultAttemptId() {
+  return Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 9);
+}
+
+function createPersonaStickerController(options) {
+  options = options || {};
+  var onChange = typeof options.onChange === 'function' ? options.onChange : function () {};
+  var personaGet = typeof options.personaGet === 'function' ? options.personaGet : null;
+  var readFile = typeof options.readFile === 'function' ? options.readFile : fileReader.readFileAsDataUrl;
+  var fileDownload = typeof options.fileDownload === 'function' ? options.fileDownload : null;
+  var hasImagePermission = typeof options.hasImagePermission === 'function' ? options.hasImagePermission : function () { return false; };
+  var attemptId = typeof options.attemptId === 'function' ? options.attemptId : defaultAttemptId;
+  var baseUrl = String(options.baseUrl || 'https://localhost/');
+  var state = {
+    mounted: false,
+    destroyed: false,
+    persona: domain.normalizePersona(null),
+    references: [],
+    task: { status: 'idle', taskId: '' },
+    latestResult: null,
+    error: null,
+  };
+  var referenceReadRevision = 0;
+  var runner = options.tasks ? taskRunner.createTaskRunner({
+    tasks: options.tasks,
+    onState: function (taskState) {
+      state.task = { status: taskState.status, taskId: taskState.taskId || '' };
+      publish();
+    },
+  }) : null;
+
+  function snapshot() {
+    return {
+      mounted: state.mounted,
+      destroyed: state.destroyed,
+      persona: Object.assign({}, state.persona),
+      references: state.references.map(function (item) { return Object.assign({}, item); }),
+      task: Object.assign({}, state.task),
+      latestResult: state.latestResult ? Object.assign({}, state.latestResult) : null,
+      error: state.error ? Object.assign({}, state.error) : null,
+    };
+  }
+
+  function publish() { onChange(snapshot()); }
+
+  function fail(error) {
+    if (state.destroyed) return error;
+    var classification = domain.classifyError(error);
+    state.error = { kind: classification.kind, code: classification.code, message: String(error && error.message || error || classification.code) };
+    publish();
+    return error;
+  }
+
+  async function mount() {
+    if (state.destroyed || state.mounted) return snapshot();
+    state.mounted = true;
+    if (!personaGet) {
+      state.persona = domain.normalizePersona(null);
+      publish();
+      return snapshot();
+    }
+    try {
+      var personaCard = await personaGet();
+      if (state.destroyed) return snapshot();
+      state.persona = domain.normalizePersona(personaCard);
+      if (state.persona.portraitUrl) {
+        state.references = [{
+          id: 'persona-primary',
+          source: 'persona',
+          name: state.persona.name,
+          value: state.persona.portraitUrl,
+          previewUrl: new URL(state.persona.portraitUrl, baseUrl).href,
+          bytes: 0,
+        }];
+      }
+    } catch (_) {
+      if (state.destroyed) return snapshot();
+      state.persona = domain.normalizePersona(null);
+    }
+    publish();
+    return snapshot();
+  }
+
+  async function addFiles(files) {
+    if (state.destroyed) throw fail(domain.codedError('PAGE_DESTROYED', 'Page has been destroyed'));
+    var readRevision = ++referenceReadRevision;
+    var list = Array.from(files || []);
+    if (list.length !== 1) {
+      throw fail(domain.codedError('AI_IMAGE_REFERENCE_LIMIT', 'Choose exactly one expression reference image', 'count'));
+    }
+    var selected = list[0];
+    if (Math.max(0, Number(selected && selected.size) || 0) > domain.MAX_REFERENCE_BYTES) {
+      throw fail(domain.codedError('AI_IMAGE_REFERENCE_LIMIT', 'Expression image exceeds 10 MiB', 'bytes'));
+    }
+    var dataUrl = await readFile(selected);
+    if (state.destroyed) throw domain.codedError('PAGE_DESTROYED', 'Page has been destroyed');
+    if (readRevision !== referenceReadRevision) return snapshot();
+    var checked = domain.validateLocalImageDataUrl(dataUrl);
+    if (checked.bytes > domain.MAX_REFERENCE_BYTES) {
+      throw fail(domain.codedError('AI_IMAGE_REFERENCE_LIMIT', 'Expression image exceeds 10 MiB', 'bytes'));
+    }
+    var personaReferences = state.references.filter(function (item) { return item.source === 'persona'; });
+    state.references = personaReferences.concat({
+      id: 'upload-' + attemptId(),
+      source: 'upload',
+      name: String(selected.name || 'expression-reference').slice(0, 120),
+      value: dataUrl,
+      previewUrl: dataUrl,
+      bytes: checked.bytes,
+      mime: checked.mime,
+    });
+    state.error = null;
+    publish();
+    return snapshot();
+  }
+
+  function removeReference(id) {
+    if (state.destroyed) return;
+    referenceReadRevision += 1;
+    state.references = state.references.filter(function (item) { return item.id !== id; });
+    publish();
+  }
+
+  async function generate(form) {
+    form = form || {};
+    if (!state.persona.enabled || !state.persona.portraitUrl) {
+      throw fail(domain.codedError('PERSONA_REQUIRED', 'Create and enable an Agent Persona portrait before generating a sticker'));
+    }
+    if (!options.tasks || !runner) throw fail(domain.codedError('AI_API_UNAVAILABLE', 'Myriad AI task API is unavailable'));
+    if (!hasImagePermission()) throw fail(domain.codedError('PERMISSION_DENIED', 'The ai:image permission is not granted'));
+    var mode = String(form.mode || '').trim();
+    var expressionReference = state.references.find(function (item) { return item.source === 'upload'; });
+    if (mode === 'image' && !expressionReference) {
+      throw fail(domain.codedError('EXPRESSION_IMAGE_REQUIRED', 'Choose one expression reference image'));
+    }
+    state.error = null;
+    publish();
+    var promptOptions = { persona: state.persona, mode: mode, cue: form.cue, userPrompt: form.userPrompt };
+    var requestReferences = [state.persona.portraitUrl];
+    if (mode === 'image') requestReferences.push(expressionReference.value);
+    var request = {
+      version: 2,
+      operation: 'image',
+      input: {
+        prompt: domain.buildPrompt(promptOptions),
+        width: 1024,
+        height: 1024,
+        referenceImages: requestReferences,
+      },
+      output: { format: 'image' },
+      delivery: 'result',
+      idempotencyKey: 'persona-stickers-' + attemptId(),
+    };
+    try {
+      var raw = await runner.run(request);
+      var result = domain.normalizeImageResult(raw, baseUrl);
+      if (!result.previewUrl || !result.referenceUrl) throw domain.codedError('AI_IMAGE_RESULT_INVALID', 'The image task did not return a safe Myriad cache path');
+      state.latestResult = Object.assign({ prompt: request.input.prompt, mode: mode, userPrompt: String(form.userPrompt || '').trim() }, result);
+      state.error = null;
+      publish();
+      return Object.assign({}, state.latestResult);
+    } catch (error) {
+      throw fail(error);
+    }
+  }
+
+  async function downloadPng() {
+    if (state.destroyed) throw fail(domain.codedError('PAGE_DESTROYED', 'Page has been destroyed'));
+    if (!state.latestResult) throw fail(domain.codedError('RESULT_REQUIRED', 'Generate a sticker before downloading PNG'));
+    if (!fileDownload) throw fail(domain.codedError('DOWNLOAD_API_UNAVAILABLE', 'The host file download bridge is unavailable'));
+    try {
+      await fileDownload(state.latestResult.referenceUrl, 'persona-sticker.png');
+      state.error = null;
+      publish();
+      return { filename: 'persona-sticker.png', format: 'image/png' };
+    } catch (error) {
+      throw fail(error);
+    }
+  }
+
+  function cancel() { return runner ? runner.cancel() : Promise.resolve(false); }
+  function pause() { if (runner) runner.pause(); }
+  function resume() { if (runner) runner.resume(); }
+  function clearError() { state.error = null; publish(); }
+  function destroy() {
+    if (state.destroyed) return;
+    state.destroyed = true;
+    referenceReadRevision += 1;
+    if (runner) runner.destroy();
+    state.references = [];
+    state.latestResult = null;
+    publish();
+  }
+
+  return {
+    mount: mount,
+    addFiles: addFiles,
+    removeReference: removeReference,
+    generate: generate,
+    downloadPng: downloadPng,
+    cancel: cancel,
+    pause: pause,
+    resume: resume,
+    clearError: clearError,
+    destroy: destroy,
+    getState: snapshot,
+  };
+}
+
+module.exports = { createPersonaStickerController: createPersonaStickerController };

--- a/apps/cn.echootaku.persona-stickers/page/dom-app.js
+++ b/apps/cn.echootaku.persona-stickers/page/dom-app.js
@@ -1,0 +1,413 @@
+'use strict';
+
+var controllerModule = require('./app-controller.js');
+var domain = require('./domain.js');
+var modalAccessibility = require('./modal-accessibility.js');
+
+function createDomApp(options) {
+  var tapp = options.Tapp;
+  var doc = options.document;
+  var root = doc.querySelector('[data-page-root]');
+  var aborter = new AbortController();
+  var unsubs = [];
+  var localError = null;
+  var lastState = null;
+  var previewReturnFocus = null;
+  var downloadStatusKey = '';
+  var lastResultUrl = '';
+
+  function t(key, params) {
+    try { return tapp.i18n.t(key, params); } catch (_) { return key; }
+  }
+
+  function query(selector) { return doc.querySelector(selector); }
+
+  function setText(selector, value) {
+    var node = query(selector);
+    if (node) node.textContent = value;
+  }
+
+  function applyTranslations() {
+    doc.querySelectorAll('[data-i18n]').forEach(function (node) { node.textContent = t(node.dataset.i18n); });
+    doc.querySelectorAll('[data-i18n-placeholder]').forEach(function (node) { node.setAttribute('placeholder', t(node.dataset.i18nPlaceholder)); });
+    doc.querySelectorAll('[data-i18n-aria-label]').forEach(function (node) { node.setAttribute('aria-label', t(node.dataset.i18nAriaLabel)); });
+    doc.querySelectorAll('[data-i18n-alt]').forEach(function (node) { node.setAttribute('alt', t(node.dataset.i18nAlt)); });
+    if (!lastState) {
+      setText('[data-persona-status]', t('persona.loading'));
+      setText('[data-persona-detail]', t('persona.loadingDetail'));
+    }
+  }
+
+  function element(tag, className, text) {
+    var node = doc.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  function personaReady(persona) {
+    return Boolean(persona && persona.enabled && persona.portraitUrl && persona.reason === 'ready');
+  }
+
+  function personaDetail(persona) {
+    if (persona.reason === 'unavailable') return t('persona.unavailableDetail');
+    if (persona.reason === 'disabled') return t('persona.disabledDetail');
+    if (persona.reason === 'no-portrait') return t('persona.noPortraitDetail');
+    return t('persona.context', { mood: t('mood.' + persona.moodBand), activity: t('activity.' + persona.activity) });
+  }
+
+  function renderPersona(state) {
+    var status = query('[data-persona-status]');
+    var portrait = query('[data-persona-portrait]');
+    var ready = personaReady(state.persona);
+    setText('[data-persona-name]', state.persona.name);
+    setText('[data-persona-detail]', personaDetail(state.persona));
+    if (status) {
+      status.dataset.tone = ready ? 'ready' : state.persona.reason === 'unavailable' ? 'error' : 'off';
+      status.textContent = ready ? t('persona.ready') : state.persona.reason === 'disabled' ? t('persona.disabled') : state.persona.reason === 'no-portrait' ? t('persona.noPortrait') : t('persona.unavailable');
+    }
+    if (portrait) {
+      portrait.replaceChildren();
+      if (state.persona.portraitUrl) {
+        var image = element('img');
+        image.src = new URL(state.persona.portraitUrl, doc.baseURI).href;
+        image.alt = '';
+        image.addEventListener('error', function () { portrait.replaceChildren(element('span', '', state.persona.name.slice(0, 2).toUpperCase())); }, { once: true });
+        portrait.appendChild(image);
+      } else {
+        portrait.appendChild(element('span', '', state.persona.name.slice(0, 2).toUpperCase()));
+      }
+    }
+    var gate = query('[data-persona-gate]');
+    if (gate) gate.hidden = ready;
+  }
+
+  function currentMode() {
+    var selected = query('input[name="expression-mode"]:checked');
+    return selected ? selected.value : 'emoji';
+  }
+
+  function syncModePanels() {
+    var mode = currentMode();
+    doc.querySelectorAll('[data-mode-panel]').forEach(function (panel) {
+      panel.hidden = panel.dataset.modePanel !== mode;
+    });
+  }
+
+  function expressionReference(state) {
+    return state.references.find(function (item) { return item.source === 'upload'; }) || null;
+  }
+
+  function formatBytes(bytes) {
+    return (bytes / (1024 * 1024)).toFixed(bytes >= 1024 * 1024 ? 2 : 3) + ' MiB';
+  }
+
+  function renderExpressionReference(state) {
+    var preview = query('[data-expression-preview]');
+    var image = query('[data-expression-image]');
+    var reference = expressionReference(state);
+    if (!preview || !image) return;
+    preview.hidden = !reference;
+    if (!reference) {
+      image.removeAttribute('src');
+      setText('[data-expression-name]', '');
+      setText('[data-expression-meta]', '');
+      return;
+    }
+    image.src = reference.previewUrl;
+    setText('[data-expression-name]', reference.name);
+    setText('[data-expression-meta]', t('image.localSize', { size: formatBytes(reference.bytes) }));
+  }
+
+  function errorMessage(error) {
+    var code = error && error.code || 'UNKNOWN_ERROR';
+    var key = 'errors.unknown';
+    if (error && error.kind === 'provider') key = 'errors.provider';
+    else if (error && error.kind === 'permission') key = 'errors.permission';
+    else if (error && error.kind === 'persona') key = 'errors.persona';
+    else if (error && error.kind === 'input') key = code === 'EXPRESSION_IMAGE_REQUIRED' ? 'errors.expressionImage' : 'errors.expressionCue';
+    else if (error && error.kind === 'timeout') key = 'errors.timeout';
+    else if (error && error.kind === 'cancelled') key = 'errors.cancelled';
+    else if (error && error.kind === 'reference') key = 'errors.reference';
+    else if (error && error.kind === 'reference-limit') key = 'errors.referenceLimit';
+    else if (error && error.kind === 'input-limit') key = 'errors.inputLimit';
+    else if (code === 'AI_API_UNAVAILABLE') key = 'errors.apiUnavailable';
+    else if (code === 'FILE_API_UNAVAILABLE') key = 'errors.fileApiUnavailable';
+    else if (code === 'DOWNLOAD_API_UNAVAILABLE') key = 'errors.downloadUnavailable';
+    else if (code === 'FILE_READ_FAILED' || code === 'FILE_READ_CANCELLED') key = 'errors.fileRead';
+    else if (code === 'AI_IMAGE_RESULT_INVALID') key = 'errors.resultInvalid';
+    return code + ': ' + t(key);
+  }
+
+  function renderFeedback(state) {
+    var box = query('[data-feedback]');
+    var cancel = query('[data-action="cancel"]');
+    var dismiss = query('[data-action="dismiss-error"]');
+    if (!box || !cancel || !dismiss) return;
+    var taskStatus = state.task.status;
+    var busy = taskStatus === 'creating' || taskStatus === 'waiting';
+    var error = localError || state.error;
+    if (busy) {
+      box.hidden = false;
+      box.dataset.tone = 'busy';
+      setText('[data-feedback-title]', taskStatus === 'creating' ? t('status.creating') : t('status.waiting'));
+      setText('[data-feedback-message]', taskStatus === 'creating' ? t('status.creatingDetail') : t('status.waitingDetail'));
+      cancel.hidden = false;
+      dismiss.hidden = true;
+      return;
+    }
+    if (error) {
+      box.hidden = false;
+      box.dataset.tone = error.kind === 'cancelled' ? 'neutral' : 'error';
+      setText('[data-feedback-title]', error.kind === 'cancelled' ? t('status.cancelled') : t('status.failed'));
+      setText('[data-feedback-message]', errorMessage(error));
+      cancel.hidden = true;
+      dismiss.hidden = false;
+      return;
+    }
+    if (state.latestResult) {
+      box.hidden = false;
+      box.dataset.tone = 'success';
+      setText('[data-feedback-title]', t('status.success'));
+      setText('[data-feedback-message]', t('status.successDetail'));
+      cancel.hidden = true;
+      dismiss.hidden = true;
+      return;
+    }
+    box.hidden = true;
+  }
+
+  function renderResult(state) {
+    var panel = query('[data-result]');
+    var image = query('[data-result-image]');
+    if (!panel || !image) return;
+    panel.hidden = !state.latestResult;
+    if (!state.latestResult) {
+      image.removeAttribute('src');
+      lastResultUrl = '';
+      downloadStatusKey = '';
+      renderDownloadStatus();
+      closePreview(false);
+      return;
+    }
+    if (lastResultUrl !== state.latestResult.previewUrl) {
+      lastResultUrl = state.latestResult.previewUrl;
+      downloadStatusKey = '';
+      renderDownloadStatus();
+    }
+    image.src = state.latestResult.previewUrl;
+    var viewerImage = query('[data-result-viewer-image]');
+    if (viewerImage && isPreviewOpen()) viewerImage.src = state.latestResult.previewUrl;
+  }
+
+  function renderDownloadStatus() {
+    doc.querySelectorAll('[data-download-status]').forEach(function (status) {
+      status.hidden = !downloadStatusKey;
+      status.textContent = downloadStatusKey ? t(downloadStatusKey) : '';
+    });
+  }
+
+  function isPreviewOpen() {
+    var viewer = query('[data-result-viewer]');
+    return Boolean(viewer && !viewer.hidden);
+  }
+
+  function openPreview(trigger) {
+    var state = controller.getState();
+    var viewer = query('[data-result-viewer]');
+    var image = query('[data-result-viewer-image]');
+    if (!viewer || !image || !state.latestResult) return;
+    previewReturnFocus = trigger || doc.activeElement || null;
+    image.src = state.latestResult.previewUrl;
+    modalAccessibility.hideBackground(query('[data-page-content]'));
+    viewer.hidden = false;
+    viewer.setAttribute('aria-hidden', 'false');
+    if (doc.body) doc.body.classList.add('result-viewer-open');
+    var close = query('[data-preview-close]');
+    if (close && typeof close.focus === 'function') close.focus();
+  }
+
+  function closePreview(restoreFocus) {
+    var viewer = query('[data-result-viewer]');
+    modalAccessibility.showBackground(query('[data-page-content]'));
+    if (!viewer || viewer.hidden) return;
+    viewer.hidden = true;
+    viewer.setAttribute('aria-hidden', 'true');
+    var image = query('[data-result-viewer-image]');
+    if (image) image.removeAttribute('src');
+    if (doc.body) doc.body.classList.remove('result-viewer-open');
+    if (restoreFocus !== false && previewReturnFocus && typeof previewReturnFocus.focus === 'function') {
+      try { previewReturnFocus.focus(); } catch (_) {}
+    }
+    previewReturnFocus = null;
+  }
+
+  function handlePreviewKeydown(event) {
+    if (!isPreviewOpen()) return;
+    if (event.key === 'Escape') {
+      closePreview(true);
+      event.preventDefault();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    var viewer = query('[data-result-viewer]');
+    var controls = Array.from(viewer.querySelectorAll('button:not([disabled])'));
+    if (!controls.length) return;
+    var first = controls[0];
+    var last = controls[controls.length - 1];
+    if (event.shiftKey && doc.activeElement === first) {
+      last.focus();
+      event.preventDefault();
+    } else if (!event.shiftKey && doc.activeElement === last) {
+      first.focus();
+      event.preventDefault();
+    } else if (!viewer.contains(doc.activeElement)) {
+      first.focus();
+      event.preventDefault();
+    }
+  }
+
+  function renderControls(state) {
+    var ready = personaReady(state.persona);
+    var busy = state.task.status === 'creating' || state.task.status === 'waiting';
+    var mode = currentMode();
+    var hasExpressionImage = Boolean(expressionReference(state));
+    var generate = query('[data-action="generate"]');
+    var fileInput = query('[data-file-input]');
+    doc.querySelectorAll('input[name="expression-mode"], input[name$="-preset"], [data-custom-cue], [data-user-prompt]').forEach(function (input) {
+      input.disabled = busy || !ready;
+    });
+    if (fileInput) fileInput.disabled = busy || !ready;
+    if (generate) generate.disabled = busy || !ready || (mode === 'image' && !hasExpressionImage);
+    doc.querySelectorAll('[data-action="download-png"]').forEach(function (button) { button.disabled = busy || !state.latestResult; });
+  }
+
+  function render(state) {
+    lastState = state;
+    renderPersona(state);
+    renderExpressionReference(state);
+    renderFeedback(state);
+    renderResult(state);
+    syncModePanels();
+    renderControls(state);
+  }
+
+  function localFailure(error) {
+    var classified = domain.classifyError(error);
+    localError = { kind: classified.kind, code: classified.code || 'UNKNOWN_ERROR', message: String(error && error.message || error || '') };
+    if (isPreviewOpen()) closePreview(true);
+    renderFeedback(lastState || controller.getState());
+  }
+
+  function collectForm() {
+    var mode = currentMode();
+    var prompt = query('[data-user-prompt]');
+    var userPrompt = prompt ? prompt.value.trim() : '';
+    if (mode === 'image') return { mode: mode, cue: '', userPrompt: userPrompt };
+    var custom = query('[data-custom-cue="' + mode + '"]');
+    var preset = query('input[name="' + mode + '-preset"]:checked');
+    return { mode: mode, cue: custom && custom.value.trim() ? custom.value.trim() : preset ? preset.value : '', userPrompt: userPrompt };
+  }
+
+  function hasImagePermission() {
+    try {
+      var info = tapp.lifecycle.getInfo();
+      return Boolean(info && Array.isArray(info.permissions) && info.permissions.indexOf('ai:image') >= 0);
+    } catch (_) {
+      return Array.isArray(tapp.permissions) && tapp.permissions.indexOf('ai:image') >= 0;
+    }
+  }
+
+  var tasks = tapp.ai && tapp.ai.tasks && typeof tapp.ai.tasks.create === 'function' ? tapp.ai.tasks : null;
+  var controller = controllerModule.createPersonaStickerController({
+    personaGet: tapp.persona && typeof tapp.persona.get === 'function' ? function () { return tapp.persona.get(); } : null,
+    tasks: tasks,
+    fileDownload: tapp.file && typeof tapp.file.download === 'function' ? function (content, filename, mimeType) { return tapp.file.download(content, filename, mimeType); } : null,
+    hasImagePermission: hasImagePermission,
+    baseUrl: doc.baseURI,
+    onChange: render,
+  });
+
+  async function handleFiles(input) {
+    var files = Array.from(input.files || []);
+    if (!files.length) return;
+    localError = null;
+    try { await controller.addFiles(files); }
+    catch (error) { localFailure(error); }
+    finally { input.value = ''; }
+  }
+
+  async function handleAction(action) {
+    localError = null;
+    if (action.dataset.action === 'generate') {
+      downloadStatusKey = '';
+      renderDownloadStatus();
+      controller.generate(collectForm()).catch(function () {});
+    } else if (action.dataset.action === 'cancel') {
+      await controller.cancel();
+    } else if (action.dataset.action === 'dismiss-error') {
+      localError = null;
+      controller.clearError();
+    } else if (action.dataset.action === 'remove-expression') {
+      var reference = expressionReference(controller.getState());
+      if (reference) controller.removeReference(reference.id);
+    } else if (action.dataset.action === 'open-preview') {
+      openPreview(action);
+    } else if (action.dataset.action === 'close-preview') {
+      closePreview(true);
+    } else if (action.dataset.action === 'download-png') {
+      await controller.downloadPng();
+      downloadStatusKey = 'result.downloadStarted';
+      renderDownloadStatus();
+    }
+  }
+
+  function bindEvents() {
+    var signal = aborter.signal;
+    root.addEventListener('click', function (event) {
+      var action = event.target.closest('[data-action]');
+      if (action && root.contains(action)) handleAction(action).catch(localFailure);
+    }, { signal: signal });
+    root.addEventListener('change', function (event) {
+      if (event.target.matches('input[name="expression-mode"]')) {
+        localError = null;
+        syncModePanels();
+        renderControls(controller.getState());
+      }
+    }, { signal: signal });
+    query('[data-file-input]').addEventListener('change', function (event) { handleFiles(event.currentTarget); }, { signal: signal });
+    doc.addEventListener('keydown', handlePreviewKeydown, { signal: signal });
+  }
+
+  async function syncTheme() {
+    try {
+      var theme = await tapp.ui.getTheme();
+      var dark = theme === 'dark' || Boolean(theme && theme.isDark) || Boolean(theme && theme.mode === 'dark');
+      doc.documentElement.classList.toggle('dark', dark);
+    } catch (_) {}
+  }
+
+  async function mount() {
+    applyTranslations();
+    bindEvents();
+    await syncTheme();
+    if (tapp.ui && typeof tapp.ui.onThemeChange === 'function') unsubs.push(tapp.ui.onThemeChange(syncTheme));
+    if (tapp.ui && typeof tapp.ui.onLocaleChange === 'function') {
+      unsubs.push(tapp.ui.onLocaleChange(function () { applyTranslations(); render(controller.getState()); }));
+    }
+    await controller.mount();
+  }
+
+  function pause() { controller.pause(); }
+  function resume() { controller.resume(); }
+  function destroy() {
+    closePreview(false);
+    aborter.abort();
+    unsubs.splice(0).forEach(function (off) { if (typeof off === 'function') { try { off(); } catch (_) {} } });
+    controller.destroy();
+  }
+
+  return { mount: mount, pause: pause, resume: resume, destroy: destroy };
+}
+
+module.exports = { createDomApp: createDomApp };

--- a/apps/cn.echootaku.persona-stickers/page/domain.js
+++ b/apps/cn.echootaku.persona-stickers/page/domain.js
@@ -1,0 +1,166 @@
+'use strict';
+
+var MAX_REFERENCE_BYTES = 10 * 1024 * 1024;
+var MAX_USER_PROMPT_LENGTH = 800;
+var CACHE_PATH = /^\/api\/brew\/image-cache\/[A-Za-z0-9._\/-]+$/;
+var ALLOWED_MOODS = ['floor', 'sad', 'tense', 'calm', 'excited'];
+var ALLOWED_ACTIVITIES = ['idle', 'working', 'thinking', 'talking'];
+
+function codedError(code, message, reason) {
+  var error = new Error(message || code);
+  error.code = code;
+  if (reason) error.reason = reason;
+  return error;
+}
+
+function decodeBase64(value) {
+  if (typeof Buffer !== 'undefined') return Uint8Array.from(Buffer.from(value, 'base64'));
+  var decoded = atob(value);
+  var bytes = new Uint8Array(decoded.length);
+  for (var index = 0; index < decoded.length; index += 1) bytes[index] = decoded.charCodeAt(index);
+  return bytes;
+}
+
+function parseDataUrl(value) {
+  var match = /^data:(image\/(?:png|jpeg|webp));base64,([A-Za-z0-9+/]*={0,2})$/.exec(String(value || ''));
+  if (!match || !match[2]) throw codedError('INVALID_AI_IMAGE_REFERENCE', 'Invalid image data URL', 'format');
+  var bytes;
+  try { bytes = decodeBase64(match[2]); } catch (_) { throw codedError('INVALID_AI_IMAGE_REFERENCE', 'Invalid base64 image data', 'format'); }
+  return { mime: match[1], bytes: bytes };
+}
+
+function hasSignature(mime, bytes) {
+  if (mime === 'image/png') {
+    var png = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    return png.every(function (value, index) { return bytes[index] === value; });
+  }
+  if (mime === 'image/jpeg') return bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  return bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+    bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50;
+}
+
+function validateLocalImageDataUrl(value) {
+  var parsed = parseDataUrl(value);
+  if (!hasSignature(parsed.mime, parsed.bytes)) {
+    throw codedError('INVALID_AI_IMAGE_REFERENCE', 'Image signature does not match its MIME type', 'signature');
+  }
+  return { mime: parsed.mime, bytes: parsed.bytes.length };
+}
+
+function isCachePath(value) {
+  return CACHE_PATH.test(String(value || '')) && String(value).indexOf('..') === -1;
+}
+
+function normalizePersona(card) {
+  if (!card || typeof card !== 'object') {
+    return { enabled: false, name: 'Agent', moodBand: 'calm', activity: 'idle', portraitUrl: null, reason: 'unavailable' };
+  }
+  var enabled = card.enabled === true;
+  var name = enabled && typeof card.name === 'string' && card.name.trim() ? card.name.trim().slice(0, 80) : (enabled ? 'Arael' : 'Agent');
+  var moodBand = ALLOWED_MOODS.indexOf(card.moodBand) >= 0 ? card.moodBand : 'calm';
+  var activity = ALLOWED_ACTIVITIES.indexOf(card.activity) >= 0 ? card.activity : 'idle';
+  var portraitUrl = enabled && isCachePath(card.portraitUrl) ? card.portraitUrl : null;
+  return { enabled: enabled, name: name, moodBand: moodBand, activity: activity, portraitUrl: portraitUrl, reason: enabled ? (portraitUrl ? 'ready' : 'no-portrait') : 'disabled' };
+}
+
+function buildPrompt(options) {
+  var persona = normalizePersona(options && options.persona);
+  var mode = String(options && options.mode || '').trim();
+  var cue = String(options && options.cue || '').trim();
+  var userPrompt = String(options && options.userPrompt || '').trim().replace(/\r\n?/g, '\n');
+  if (['emoji', 'kaomoji', 'image'].indexOf(mode) < 0) {
+    throw codedError('INVALID_EXPRESSION_MODE', 'Choose Emoji, kaomoji, or image reference mode');
+  }
+  if (mode !== 'image' && !cue) {
+    throw codedError('EXPRESSION_CUE_REQUIRED', 'Choose or enter an expression cue');
+  }
+  if (userPrompt.length > MAX_USER_PROMPT_LENGTH) {
+    throw codedError('USER_PROMPT_LIMIT', 'Keep the additional creative direction within 800 characters');
+  }
+  cue = cue.slice(0, mode === 'emoji' ? 32 : 120);
+  var parts = [];
+  parts.push('Create exactly one standalone sticker as clean PNG-style artwork.');
+  parts.push('Subject: ' + persona.name + '. Keep the same face, hair, outfit, colors, body proportions, and signature accessories. Do not redesign, replace, or age the character.');
+  parts.push('Reference image 1 is the canonical Agent appearance. Preserve it faithfully.');
+  if (userPrompt) {
+    parts.push('PRIMARY USER CREATIVE DIRECTION (highest priority within the fixed identity and output rules):');
+    parts.push(userPrompt);
+    parts.push('Treat this direction as the dominant creative instruction. Preserve its requested action, expression, staging, props, and intensity instead of replacing it with a generic reaction.');
+  }
+  if (mode === 'emoji') {
+    parts.push('Emoji cue: ' + cue + '. Translate its emotion into the Agent facial expression, body language, and pose; do not draw or print the emoji glyph.');
+  } else if (mode === 'kaomoji') {
+    parts.push('Kaomoji cue: ' + cue + '. Translate its emotion into the Agent facial expression, body language, and pose; do not draw or print the kaomoji characters.');
+  } else {
+    parts.push('Reference image 2 is only the expression, pose, and composition reference. It must not replace the Agent identity, clothing, colors, or signature features.');
+  }
+  parts.push('Current persona context: mood band ' + persona.moodBand + ', activity ' + persona.activity + '.');
+  parts.push('Use a polished chibi reaction-sticker treatment with a bold readable silhouette and clean edge separation.');
+  parts.push('Use a clean, unobtrusive background suited to the character. Do not draw a transparency checkerboard pattern.');
+  parts.push('Show one character depiction only, with no collage or repeated poses. No text, letters, logos, signatures, or watermarks.');
+  return parts.join('\n');
+}
+
+function errorCode(error) {
+  var current = error;
+  for (var depth = 0; depth < 6 && current; depth += 1) {
+    if (typeof current.code === 'string' && current.code) return current.code.toUpperCase();
+    current = current.error || current.details || current.data || current.cause;
+  }
+  var message = String(error && error.message || error || '');
+  var match = /\b(AI_PROVIDER_ERROR|INVALID_AI_IMAGE_REFERENCE|AI_IMAGE_REFERENCE_LIMIT|AI_TASK_INPUT_LIMIT|USER_PROMPT_LIMIT|RESULT_REQUIRED|FILE_API_UNAVAILABLE|DOWNLOAD_API_UNAVAILABLE|PERMISSION_DENIED|FORBIDDEN|PERSONA_REQUIRED|INVALID_EXPRESSION_MODE|EXPRESSION_CUE_REQUIRED|EXPRESSION_IMAGE_REQUIRED|AI_TASK_TIMEOUT|AI_TASK_CANCELLED|AI_TASK_DESTROYED)\b/i.exec(message);
+  return match ? match[1].toUpperCase() : '';
+}
+
+function classifyError(error) {
+  var code = errorCode(error) || 'UNKNOWN_ERROR';
+  var kind = 'unknown';
+  if (code === 'AI_PROVIDER_ERROR') kind = 'provider';
+  else if (/PERMISSION|FORBIDDEN|UNAUTHORIZED/.test(code)) kind = 'permission';
+  else if (code === 'PERSONA_REQUIRED') kind = 'persona';
+  else if (/^(INVALID_EXPRESSION_MODE|EXPRESSION_CUE_REQUIRED|EXPRESSION_IMAGE_REQUIRED)$/.test(code)) kind = 'input';
+  else if (code === 'AI_TASK_TIMEOUT') kind = 'timeout';
+  else if (/CANCEL/.test(code)) kind = 'cancelled';
+  else if (code === 'INVALID_AI_IMAGE_REFERENCE') kind = 'reference';
+  else if (code === 'AI_IMAGE_REFERENCE_LIMIT') kind = 'reference-limit';
+  else if (code === 'AI_TASK_INPUT_LIMIT' || code === 'USER_PROMPT_LIMIT') kind = 'input-limit';
+  return { kind: kind, code: code };
+}
+
+function normalizeImageResult(value, baseUrl) {
+  var current = value;
+  for (var depth = 0; depth < 7 && current != null; depth += 1) {
+    if (current && typeof current === 'object' && typeof current.url === 'string') break;
+    if (!current || typeof current !== 'object') return { referenceUrl: null, previewUrl: null, width: 0, height: 0 };
+    current = current.value != null ? current.value : current.result != null ? current.result : current.output != null ? current.output : current.data;
+  }
+  if (!current || typeof current.url !== 'string') return { referenceUrl: null, previewUrl: null, width: 0, height: 0 };
+  var referenceUrl = null;
+  var previewUrl = null;
+  try {
+    var base = new URL(baseUrl);
+    var resolved = new URL(current.url, base);
+    if (resolved.protocol === 'https:' && resolved.origin === base.origin && isCachePath(resolved.pathname) && /\.png$/i.test(resolved.pathname)) {
+      referenceUrl = resolved.pathname;
+      previewUrl = resolved.href;
+    }
+  } catch (_) {}
+  return {
+    referenceUrl: referenceUrl,
+    previewUrl: previewUrl,
+    width: Number.isFinite(Number(current.width)) ? Number(current.width) : 0,
+    height: Number.isFinite(Number(current.height)) ? Number(current.height) : 0,
+  };
+}
+
+module.exports = {
+  MAX_REFERENCE_BYTES: MAX_REFERENCE_BYTES,
+  MAX_USER_PROMPT_LENGTH: MAX_USER_PROMPT_LENGTH,
+  buildPrompt: buildPrompt,
+  classifyError: classifyError,
+  codedError: codedError,
+  isCachePath: isCachePath,
+  normalizeImageResult: normalizeImageResult,
+  normalizePersona: normalizePersona,
+  validateLocalImageDataUrl: validateLocalImageDataUrl,
+};

--- a/apps/cn.echootaku.persona-stickers/page/file-reader.js
+++ b/apps/cn.echootaku.persona-stickers/page/file-reader.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var domain = require('./domain.js');
+var ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+
+function readFileAsDataUrl(file, Reader) {
+  if (!file || ALLOWED_TYPES.indexOf(String(file.type || '').toLowerCase()) < 0) {
+    return Promise.reject(domain.codedError('INVALID_AI_IMAGE_REFERENCE', 'Only PNG, JPEG and WebP files are supported', 'type'));
+  }
+  var FileReaderClass = Reader || (typeof FileReader !== 'undefined' ? FileReader : null);
+  if (!FileReaderClass) return Promise.reject(domain.codedError('FILE_API_UNAVAILABLE', 'FileReader is unavailable'));
+  return new Promise(function (resolve, reject) {
+    var reader = new FileReaderClass();
+    reader.onload = function () {
+      if (typeof reader.result !== 'string') {
+        reject(domain.codedError('INVALID_AI_IMAGE_REFERENCE', 'FileReader returned an invalid result', 'format'));
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.onerror = function () { reject(domain.codedError('FILE_READ_FAILED', 'The image could not be read')); };
+    reader.onabort = function () { reject(domain.codedError('FILE_READ_CANCELLED', 'The image read was cancelled')); };
+    reader.readAsDataURL(file);
+  });
+}
+
+module.exports = { ALLOWED_TYPES: ALLOWED_TYPES, readFileAsDataUrl: readFileAsDataUrl };

--- a/apps/cn.echootaku.persona-stickers/page/index.js
+++ b/apps/cn.echootaku.persona-stickers/page/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var lifecycle = require('./lifecycle.js');
+var domApp = require('./dom-app.js');
+
+lifecycle.registerLifecycle(Tapp, function () {
+  return domApp.createDomApp({ Tapp: Tapp, document: document });
+});

--- a/apps/cn.echootaku.persona-stickers/page/lifecycle.js
+++ b/apps/cn.echootaku.persona-stickers/page/lifecycle.js
@@ -1,0 +1,28 @@
+'use strict';
+
+function registerLifecycle(tapp, createApp) {
+  var app = null;
+  var mounted = false;
+  var destroyed = false;
+
+  tapp.lifecycle.onReady(async function () {
+    if (destroyed || mounted) return;
+    mounted = true;
+    app = createApp();
+    await app.mount();
+  });
+  tapp.lifecycle.onPause(function () {
+    if (!destroyed && app && typeof app.pause === 'function') app.pause();
+  });
+  tapp.lifecycle.onResume(function () {
+    if (!destroyed && app && typeof app.resume === 'function') app.resume();
+  });
+  tapp.lifecycle.onDestroy(function () {
+    if (destroyed) return;
+    destroyed = true;
+    if (app && typeof app.destroy === 'function') app.destroy();
+    app = null;
+  });
+}
+
+module.exports = { registerLifecycle: registerLifecycle };

--- a/apps/cn.echootaku.persona-stickers/page/modal-accessibility.js
+++ b/apps/cn.echootaku.persona-stickers/page/modal-accessibility.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function hideBackground(element) {
+  if (!element) return;
+  element.inert = true;
+  element.setAttribute('aria-hidden', 'true');
+}
+
+function showBackground(element) {
+  if (!element) return;
+  element.inert = false;
+  element.removeAttribute('aria-hidden');
+}
+
+module.exports = { hideBackground: hideBackground, showBackground: showBackground };

--- a/apps/cn.echootaku.persona-stickers/page/task-runner.js
+++ b/apps/cn.echootaku.persona-stickers/page/task-runner.js
@@ -1,0 +1,187 @@
+'use strict';
+
+function taskIdOf(value) {
+  var current = value;
+  for (var depth = 0; depth < 6 && current && typeof current === 'object'; depth += 1) {
+    var id = current.taskId || current.task_id || current.id;
+    if (id) return String(id);
+    current = current.task || current.data || current.value;
+  }
+  return '';
+}
+
+function statusOf(value) {
+  return String(value && (value.status || value.state || (value.data && value.data.status)) || '').toLowerCase();
+}
+
+function resultOf(value) {
+  var current = value;
+  for (var depth = 0; depth < 7 && current != null; depth += 1) {
+    if (current && typeof current === 'object' && (current.format === 'image' || (current.value && current.value.url) || current.url)) return current;
+    if (!current || typeof current !== 'object') return null;
+    current = current.result != null ? current.result : current.output != null ? current.output : current.data != null ? current.data : current.value;
+  }
+  return null;
+}
+
+function failureOf(value, fallbackCode) {
+  var detail = value && value.error ? value.error : value;
+  var message = '';
+  var current = detail;
+  var code = '';
+  for (var depth = 0; depth < 6 && current; depth += 1) {
+    if (!code && typeof current.code === 'string') code = current.code;
+    if (!message && typeof current.message === 'string') message = current.message;
+    current = current.error || current.details || current.data || current.cause;
+  }
+  var error = new Error(message || fallbackCode || 'AI task failed');
+  error.code = String(code || fallbackCode || 'AI_TASK_FAILED').toUpperCase();
+  error.taskId = taskIdOf(value);
+  error.status = statusOf(value);
+  if (value && value.usage) error.usage = value.usage;
+  return error;
+}
+
+function createTaskRunner(options) {
+  options = options || {};
+  var tasks = options.tasks;
+  var setTimer = options.setTimeout || setTimeout;
+  var clearTimer = options.clearTimeout || clearTimeout;
+  var timeoutMs = Number(options.timeoutMs) || 315000;
+  var pollMs = Number(options.pollMs) || 1600;
+  var onState = typeof options.onState === 'function' ? options.onState : function () {};
+  var active = null;
+  var destroyed = false;
+  var paused = false;
+
+  function emit(status, extra) {
+    onState(Object.assign({ status: status }, extra || {}));
+  }
+
+  function cleanup(run) {
+    if (!run) return;
+    if (run.timeout) clearTimer(run.timeout);
+    if (run.pollTimer) clearTimer(run.pollTimer);
+    run.timeout = null;
+    run.pollTimer = null;
+    if (typeof run.unsubscribe === 'function') {
+      try { run.unsubscribe(); } catch (_) {}
+      run.unsubscribe = null;
+    }
+  }
+
+  function settle(run, error, result, status) {
+    if (!run || run.settled) return;
+    run.settled = true;
+    cleanup(run);
+    if (active === run) active = null;
+    emit(status || (error ? 'error' : 'success'), { error: error || null, result: result || null, taskId: run.taskId || '' });
+    if (error) run.reject(error); else run.resolve(result);
+  }
+
+  function inspect(run, value) {
+    if (!run || run.settled || destroyed) return true;
+    var result = resultOf(value);
+    if (result) { settle(run, null, result, 'success'); return true; }
+    var status = statusOf(value);
+    if (['failed', 'error', 'expired'].indexOf(status) >= 0) {
+      settle(run, failureOf(value, 'AI_TASK_FAILED'), null, 'error');
+      return true;
+    }
+    if (['cancelled', 'canceled'].indexOf(status) >= 0) {
+      settle(run, failureOf(value, 'AI_TASK_CANCELLED'), null, 'cancelled');
+      return true;
+    }
+    return false;
+  }
+
+  function schedulePoll(run) {
+    if (!run || run.settled || destroyed || paused || run.pollTimer) return;
+    run.pollTimer = setTimer(function () {
+      run.pollTimer = null;
+      if (run.settled || destroyed || paused) return;
+      Promise.resolve(tasks.get(run.taskId)).then(function (value) {
+        if (!inspect(run, value)) schedulePoll(run);
+      }).catch(function (error) { settle(run, failureOf(error, 'AI_TASK_STATUS_ERROR'), null, 'error'); });
+    }, pollMs);
+  }
+
+  function run(request) {
+    if (destroyed) return Promise.reject(failureOf(null, 'AI_TASK_DESTROYED'));
+    if (active) return Promise.reject(failureOf(null, 'AI_TASK_BUSY'));
+    emit('creating');
+    var runState = { taskId: '', settled: false, cancelWhenCreated: false, timeout: null, pollTimer: null, unsubscribe: null, resolve: null, reject: null };
+    var promise = new Promise(function (resolve, reject) { runState.resolve = resolve; runState.reject = reject; });
+    active = runState;
+    Promise.resolve().then(function () { return tasks.create(request); }).then(function (initial) {
+      if (runState.cancelWhenCreated) {
+        var lateTaskId = taskIdOf(initial);
+        if (lateTaskId) {
+          try { Promise.resolve(tasks.cancel(lateTaskId)).catch(function () {}); } catch (_) {}
+        }
+        return;
+      }
+      if (destroyed) { settle(runState, failureOf(null, 'AI_TASK_DESTROYED'), null, 'destroyed'); return; }
+      if (inspect(runState, initial)) return;
+      runState.taskId = taskIdOf(initial);
+      if (!runState.taskId) { settle(runState, failureOf(initial, 'AI_TASK_ID_MISSING'), null, 'error'); return; }
+      emit('waiting', { taskId: runState.taskId });
+      runState.timeout = setTimer(function () {
+        if (runState.settled) return;
+        try { Promise.resolve(tasks.cancel(runState.taskId)).catch(function () {}); } catch (_) {}
+        settle(runState, failureOf(null, 'AI_TASK_TIMEOUT'), null, 'timeout');
+      }, timeoutMs);
+      schedulePoll(runState);
+      try {
+        Promise.resolve(tasks.subscribe(runState.taskId, function (event) {
+          if (!event || runState.settled || destroyed) return;
+          if (event.event === 'result') { inspect(runState, event.data); return; }
+          if (event.event === 'error') { settle(runState, failureOf(event.data, 'AI_TASK_FAILED'), null, 'error'); return; }
+          inspect(runState, event.data);
+        })).then(function (unsubscribe) {
+          if (runState.settled || destroyed) { if (typeof unsubscribe === 'function') unsubscribe(); return; }
+          runState.unsubscribe = unsubscribe;
+        }).catch(function () {});
+      } catch (_) {}
+    }).catch(function (error) { settle(runState, failureOf(error, 'AI_TASK_CREATE_FAILED'), null, 'error'); });
+    return promise;
+  }
+
+  async function cancel() {
+    var runState = active;
+    if (!runState || runState.settled) return false;
+    runState.cancelWhenCreated = !runState.taskId;
+    if (runState.taskId) {
+      try { await tasks.cancel(runState.taskId); } catch (_) {}
+    }
+    settle(runState, failureOf(null, 'AI_TASK_CANCELLED'), null, 'cancelled');
+    return true;
+  }
+
+  function pause() {
+    paused = true;
+    if (active && active.pollTimer) { clearTimer(active.pollTimer); active.pollTimer = null; }
+  }
+
+  function resume() {
+    if (destroyed) return;
+    paused = false;
+    if (active && active.taskId && !active.settled) schedulePoll(active);
+  }
+
+  function destroy() {
+    if (destroyed) return;
+    destroyed = true;
+    var runState = active;
+    if (!runState || runState.settled) return;
+    runState.cancelWhenCreated = !runState.taskId;
+    if (runState.taskId) {
+      try { Promise.resolve(tasks.cancel(runState.taskId)).catch(function () {}); } catch (_) {}
+    }
+    settle(runState, failureOf(null, 'AI_TASK_DESTROYED'), null, 'destroyed');
+  }
+
+  return { run: run, cancel: cancel, pause: pause, resume: resume, destroy: destroy, isBusy: function () { return Boolean(active); } };
+}
+
+module.exports = { createTaskRunner: createTaskRunner, failureOf: failureOf, resultOf: resultOf, statusOf: statusOf, taskIdOf: taskIdOf };

--- a/apps/cn.echootaku.persona-stickers/preview.css
+++ b/apps/cn.echootaku.persona-stickers/preview.css
@@ -1,0 +1,58 @@
+.preview-canvas { position: relative; z-index: 1; width: 1440px; min-height: 900px; padding: 42px 50px 46px; color: var(--ink); }
+.preview-hero { width: 1340px; min-height: 92px; display: flex; align-items: center; justify-content: space-between; margin-bottom: 28px; }
+.preview-hero h1 { margin: 0; font: 850 48px/1 ui-rounded, "Arial Rounded MT Bold", "Microsoft YaHei UI", sans-serif; letter-spacing: -.045em; }
+.preview-hero p:not(.eyebrow) { margin: 10px 0 0; color: var(--muted); font-size: 16px; }
+.preview-live { display: inline-flex; align-items: center; gap: 9px; padding: 9px 13px; border: 1px solid rgba(33,133,104,.22); border-radius: 999px; color: var(--success); background: rgba(33,133,104,.08); font-size: 12px; font-weight: 850; }
+.preview-live i { width: 8px; height: 8px; border-radius: 50%; background: var(--success); box-shadow: 0 0 0 5px rgba(33,133,104,.1); }
+.preview-layout { width: 1340px; display: grid; grid-template-columns: 328px 1fr; grid-template-rows: 408px 275px; gap: 20px; }
+.preview-context { grid-row: 1 / 3; display: grid; align-content: start; gap: 20px; }
+.preview-persona-panel { padding: 22px; }
+.preview-persona { display: flex; align-items: center; gap: 14px; margin: 16px 0; padding: 14px; border: 1px solid rgba(var(--accent-rgb),.14); border-radius: 18px; background: var(--surface-soft); }
+.preview-avatar { width: 70px; aspect-ratio: 1; display: grid; place-items: center; border: 1px solid rgba(var(--accent-rgb),.24); border-radius: 22px 22px 27px 17px; background: linear-gradient(135deg, rgba(var(--accent-rgb),.22), rgba(255,128,90,.15)); color: var(--accent); font: 850 20px/1 ui-rounded, sans-serif; }
+.preview-persona > div:last-child { display: grid; gap: 5px; }
+.preview-persona strong { font-size: 17px; }
+.preview-persona span, .preview-persona-panel > p:last-child { color: var(--muted); font-size: 11px; line-height: 1.55; }
+.preview-composer h2, .preview-result h2 { margin: 0; font: 820 25px/1.18 ui-rounded, "Microsoft YaHei UI", sans-serif; letter-spacing: -.025em; }
+.preview-composer { padding: 22px 28px; }
+.preview-composer-head { display: flex; justify-content: space-between; align-items: flex-start; }
+.preview-composer-head > span { padding: 7px 10px; border-radius: 999px; color: var(--accent); background: rgba(var(--accent-rgb),.1); font-size: 10px; font-weight: 850; }
+.preview-modes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-top: 13px; }
+.preview-modes article { min-height: 80px; display: grid; grid-template-columns: 46px 1fr; grid-template-rows: auto auto; align-content: center; align-items: center; padding: 10px 12px; border: 1px solid var(--line); border-radius: 17px; background: rgba(255,255,255,.48); }
+.preview-modes article.selected { border-color: rgba(var(--accent-rgb),.62); background: rgba(var(--accent-rgb),.1); box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb),.1); }
+.preview-modes b { grid-row: 1 / 3; font-size: 27px; }
+.preview-modes article:nth-child(2) b { font: 800 10px/1 ui-monospace, monospace; }
+.preview-modes strong { font-size: 13px; }
+.preview-modes small { color: var(--muted); font-size: 9px; }
+.preview-cues { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; margin-top: 10px; }
+.preview-cues b { min-height: 52px; display: grid; place-items: center; align-content: center; gap: 3px; border: 1px solid var(--line); border-radius: 14px; background: rgba(255,255,255,.45); font-size: 20px; }
+.preview-cues b.active { border-color: rgba(var(--accent-rgb),.62); background: rgba(var(--accent-rgb),.1); }
+.preview-cues small { color: var(--muted); font-size: 9px; font-weight: 650; }
+.preview-prompt { display: grid; grid-template-columns: 230px 1fr; gap: 14px; align-items: center; margin-top: 10px; padding: 10px 12px; border: 1px solid rgba(var(--accent-rgb),.34); border-radius: 14px; background: linear-gradient(135deg, rgba(var(--accent-rgb),.09), rgba(255,128,90,.04)); }
+.preview-prompt span { display: grid; gap: 3px; }
+.preview-prompt strong { font-size: 11px; }
+.preview-prompt small { color: var(--accent); font-size: 8px; font-weight: 750; }
+.preview-prompt p { margin: 0; padding: 8px 10px; border: 1px solid var(--line); border-radius: 10px; background: rgba(255,255,255,.58); color: var(--muted); font-size: 9px; }
+.preview-generate { display: flex; align-items: center; justify-content: space-between; margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--line); }
+.preview-generate > span { display: grid; gap: 3px; }
+.preview-generate strong { font-size: 12px; }
+.preview-generate small { color: var(--muted); font-size: 9px; }
+.preview-generate > b { padding: 11px 18px; border-radius: 15px 15px 20px 12px; color: white; background: var(--accent); box-shadow: 0 11px 26px rgba(var(--accent-rgb),.25); font-size: 12px; }
+.preview-result { display: grid; grid-template-columns: 235px 1fr; gap: 28px; align-items: center; padding: 19px 28px; border-color: rgba(var(--accent-rgb),.28); background: rgba(var(--accent-rgb),.065); }
+.preview-sticker { position: relative; width: 235px; height: 235px; overflow: hidden; border: 1px solid var(--line); border-radius: 23px 23px 31px 17px; background: radial-gradient(circle at 50% 42%, #fff 0 35%, transparent 36%), linear-gradient(145deg, #f2edff, #dce6ff); box-shadow: 0 16px 34px rgba(50,61,93,.13); }
+.preview-face { position: absolute; left: 60px; top: 44px; width: 116px; height: 130px; border: 7px solid #5c5677; border-radius: 50% 50% 45% 45%; background: #ffd2b5; box-shadow: inset 0 20px 0 #8f76d4; }
+.preview-face i { position: absolute; top: 68px; width: 16px; height: 7px; border-top: 4px solid #514b68; border-radius: 50%; }
+.preview-face i:first-child { left: 24px; transform: rotate(12deg); }
+.preview-face i:nth-child(2) { right: 24px; transform: rotate(-12deg); }
+.preview-face span { position: absolute; left: 43px; top: 81px; color: #514b68; font: 800 21px/1 sans-serif; }
+.preview-ear { position: absolute; top: 34px; width: 52px; height: 63px; border: 6px solid #5c5677; background: #8f76d4; transform: rotate(30deg); }
+.preview-ear.left { left: 43px; border-radius: 12px 55px 20px 50px; }
+.preview-ear.right { right: 43px; border-radius: 55px 12px 50px 20px; transform: rotate(-30deg); }
+.preview-blush { position: absolute; top: 132px; width: 30px; height: 10px; border-radius: 50%; background: rgba(255,105,119,.45); }
+.preview-blush.left { left: 75px; }.preview-blush.right { right: 75px; }
+.preview-sticker em { position: absolute; right: 24px; top: 24px; color: var(--signal); font-size: 27px; font-style: normal; }
+.preview-result-copy p:not(.section-index) { max-width: 550px; margin: 11px 0 13px; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.preview-result-actions { display: flex; gap: 9px; margin-bottom: 9px; }
+.preview-result-actions b, .preview-result-actions span { padding: 9px 13px; border-radius: 11px; font-size: 10px; }
+.preview-result-actions b { color: #fff; background: var(--accent); }
+.preview-result-actions span { border: 1px solid rgba(var(--accent-rgb),.32); color: var(--accent); background: rgba(255,255,255,.5); font-weight: 800; }
+.preview-result-copy > small { color: var(--muted); font-size: 9px; }

--- a/apps/cn.echootaku.persona-stickers/preview.html
+++ b/apps/cn.echootaku.persona-stickers/preview.html
@@ -1,0 +1,45 @@
+<div class="studio-backdrop" aria-hidden="true"><span class="paper-shape paper-shape-a"></span><span class="paper-shape paper-shape-b"></span><span class="paper-dots"></span></div>
+<main class="preview-canvas">
+  <header class="preview-hero">
+    <div class="brand-lockup">
+      <div class="brand-stamp" aria-hidden="true"><span>☺</span><i></i></div>
+      <div><p class="eyebrow">PERSONA STICKER LAB</p><h1>人设表情工坊</h1><p>制作属于你 Agent 的表情包~</p></div>
+    </div>
+    <span class="preview-live"><i></i> Agent 人设已就绪</span>
+  </header>
+
+  <div class="preview-layout">
+    <aside class="preview-context">
+      <section class="panel preview-persona-panel">
+        <p class="section-index">AGENT PERSONA</p>
+        <div class="preview-persona">
+          <div class="preview-avatar"><span>AR</span></div>
+          <div><strong>Arael</strong><span>平静 · 思考中</span></div>
+        </div>
+        <p>人设图固定脸、发型、服装与标志特征。</p>
+      </section>
+    </aside>
+
+    <section class="panel preview-composer">
+      <div class="preview-composer-head"><div><p class="section-index">EXPRESSION CUE</p><h2>选择一种表情提示</h2></div><span>每次 1 张</span></div>
+      <div class="preview-modes">
+        <article class="selected"><b>😄</b><strong>Emoji</strong><small>用图形表达情绪</small></article>
+        <article><b>(≧▽≦)</b><strong>颜文字</strong><small>用字符描述神态</small></article>
+        <article><b>▧</b><strong>图片表情</strong><small>参考一张表情图</small></article>
+      </div>
+      <div class="preview-cues"><b>😀<small>开心</small></b><b>😭<small>大哭</small></b><b class="active">😳<small>害羞</small></b><b>🤔<small>思考</small></b><b>🥳<small>庆祝</small></b></div>
+      <div class="preview-prompt"><span><strong>补充提示词（高优先级）</strong><small>优先影响动作、表情、道具与构图</small></span><p>双手捂脸，害羞地从指缝偷看，脸颊通红。</p></div>
+      <div class="preview-generate"><span><strong>独立 PNG 表情</strong><small>1024 × 1024 · 单角色 · 无文字</small></span><b>✦　生成一张表情</b></div>
+    </section>
+
+    <section class="panel preview-result">
+      <div class="preview-sticker">
+        <div class="preview-ear left"></div><div class="preview-ear right"></div>
+        <div class="preview-face"><i></i><i></i><span>﹏</span></div>
+        <div class="preview-blush left"></div><div class="preview-blush right"></div>
+        <em>✦</em>
+      </div>
+      <div class="preview-result-copy"><p class="section-index">ONE PNG RESULT</p><h2>Agent 的新表情完成了</h2><p>高优先级提示已控制动作与神态，人设身份和单图规则保持不变。</p><div class="preview-result-actions"><b>查看大图</b><span>下载 PNG</span></div><small>Myriad 宿主代取当前缓存并保存为真实 PNG。</small></div>
+    </section>
+  </div>
+</main>

--- a/apps/cn.echootaku.persona-stickers/tests/app-controller.test.cjs
+++ b/apps/cn.echootaku.persona-stickers/tests/app-controller.test.cjs
@@ -1,0 +1,320 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createPersonaStickerController } = require('../page/app-controller.js');
+
+function imageResult(name = 'result') {
+  return { format: 'image', value: { url: `/api/brew/image-cache/ab/${name}.png`, width: 1024, height: 1024 } };
+}
+
+function tasksThatReturn(result = imageResult()) {
+  return { create: async () => result, subscribe: async () => () => {}, get: async () => ({}), cancel: async () => ({}) };
+}
+
+function readyPersona() {
+  return { enabled: true, name: 'Arael', moodBand: 'excited', activity: 'talking', portraitUrl: '/api/brew/image-cache/ab/agent.png' };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+test('loads the enabled Agent portrait and reports unavailable Persona without inventing a fallback', async () => {
+  const ready = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: tasksThatReturn(),
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/tapp/run/id',
+  });
+  await ready.mount();
+  assert.equal(ready.getState().persona.name, 'Arael');
+  assert.deepEqual(ready.getState().references.map((item) => [item.source, item.value]), [['persona', '/api/brew/image-cache/ab/agent.png']]);
+
+  const fallback = createPersonaStickerController({
+    personaGet: async () => { throw new Error('bridge unavailable'); },
+    tasks: tasksThatReturn(),
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/tapp/run/id',
+  });
+  await fallback.mount();
+  assert.equal(fallback.getState().persona.reason, 'unavailable');
+  assert.equal(fallback.getState().references.length, 0);
+});
+
+test('blocks generation before calling AI when the user has no usable Agent Persona portrait', async () => {
+  let calls = 0;
+  const controller = createPersonaStickerController({
+    personaGet: async () => ({ enabled: false, portraitUrl: null }),
+    tasks: { ...tasksThatReturn(), create: async () => { calls += 1; return imageResult(); } },
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+
+  await assert.rejects(
+    controller.generate({ mode: 'emoji', cue: '😭' }),
+    (error) => error.code === 'PERSONA_REQUIRED',
+  );
+  assert.equal(calls, 0);
+  assert.equal(controller.getState().error.kind, 'persona');
+});
+
+test('keeps exactly one uploaded expression image and replaces it when another is selected', async () => {
+  const readFiles = [];
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    readFile: async (file) => { readFiles.push(file.name); return 'data:image/png;base64,iVBORw0KGgo='; },
+    tasks: tasksThatReturn(),
+    hasImagePermission: () => true,
+    attemptId: () => 'fixed',
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+  await controller.addFiles([{ name: 'first.png', type: 'image/png', size: 8 }]);
+  await controller.addFiles([{ name: 'second.png', type: 'image/png', size: 8 }]);
+
+  assert.deepEqual(readFiles, ['first.png', 'second.png']);
+  assert.deepEqual(controller.getState().references.map((item) => item.source), ['persona', 'upload']);
+  assert.equal(controller.getState().references[1].name, 'second.png');
+});
+
+test('keeps the latest expression image when overlapping file reads finish out of order', async () => {
+  const reads = new Map();
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    readFile: (file) => {
+      const gate = deferred();
+      reads.set(file.name, gate);
+      return gate.promise;
+    },
+    tasks: tasksThatReturn(),
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+
+  const first = controller.addFiles([{ name: 'first.png', type: 'image/png', size: 8 }]);
+  const second = controller.addFiles([{ name: 'second.png', type: 'image/png', size: 8 }]);
+  reads.get('second.png').resolve('data:image/png;base64,iVBORw0KGgo=');
+  await second;
+  reads.get('first.png').resolve('data:image/png;base64,iVBORw0KGgo=');
+  await first;
+
+  assert.equal(controller.getState().references[1].name, 'second.png');
+});
+
+test('rejects selecting more than one expression image at once', async () => {
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    readFile: async () => 'data:image/png;base64,iVBORw0KGgo=',
+    tasks: tasksThatReturn(),
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+
+  await assert.rejects(
+    controller.addFiles([
+      { name: 'one.png', type: 'image/png', size: 8 },
+      { name: 'two.png', type: 'image/png', size: 8 },
+    ]),
+    (error) => error.code === 'AI_IMAGE_REFERENCE_LIMIT' && error.reason === 'count',
+  );
+  assert.deepEqual(controller.getState().references.map((item) => item.source), ['persona']);
+});
+
+test('creates one 1024 square Emoji task using only the Agent portrait', async () => {
+  const requests = [];
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: { ...tasksThatReturn(), create: async (request) => { requests.push(request); return imageResult('emoji'); } },
+    hasImagePermission: () => true,
+    attemptId: () => 'attempt-emoji',
+    baseUrl: 'https://myriad.example/tapp/run/id',
+  });
+  await controller.mount();
+  const result = await controller.generate({ mode: 'emoji', cue: '😭' });
+
+  assert.equal(requests.length, 1);
+  assert.deepEqual(requests[0].input.referenceImages, ['/api/brew/image-cache/ab/agent.png']);
+  assert.equal(requests[0].input.width, 1024);
+  assert.equal(requests[0].input.height, 1024);
+  assert.match(requests[0].input.prompt, /Emoji cue: 😭/);
+  assert.doesNotMatch(requests[0].input.prompt, /panel|sheet|grid/i);
+  assert.equal(requests[0].operation, 'image');
+  assert.equal(requests[0].output.format, 'image');
+  assert.equal(requests[0].delivery, 'result');
+  assert.equal(requests[0].idempotencyKey, 'persona-stickers-attempt-emoji');
+  assert.equal(result.referenceUrl, '/api/brew/image-cache/ab/emoji.png');
+});
+
+test('passes the optional user direction into the generated prompt', async () => {
+  const requests = [];
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: { ...tasksThatReturn(), create: async (request) => { requests.push(request); return imageResult('directed'); } },
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/tapp/run/id',
+  });
+  await controller.mount();
+  await controller.generate({ mode: 'emoji', cue: '😭', userPrompt: '双手抱头，眼泪向两侧喷出。' });
+
+  assert.match(requests[0].input.prompt, /PRIMARY USER CREATIVE DIRECTION/);
+  assert.match(requests[0].input.prompt, /双手抱头，眼泪向两侧喷出。/);
+});
+
+test('downloads the latest generated PNG cache through the public host file bridge', async () => {
+  const downloads = [];
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: tasksThatReturn(imageResult('download-me')),
+    fileDownload: async (content, filename, mimeType) => { downloads.push({ content, filename, mimeType }); },
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/tapp/run/id',
+  });
+  await controller.mount();
+  await controller.generate({ mode: 'emoji', cue: '😀', userPrompt: '' });
+  const downloaded = await controller.downloadPng();
+
+  assert.deepEqual(downloaded, { filename: 'persona-sticker.png', format: 'image/png' });
+  assert.equal(downloads.length, 1);
+  assert.deepEqual(downloads[0], {
+    content: '/api/brew/image-cache/ab/download-me.png',
+    filename: 'persona-sticker.png',
+    mimeType: undefined,
+  });
+});
+
+test('does not invoke the PNG download bridge when no generated result exists', async () => {
+  let calls = 0;
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: tasksThatReturn(),
+    fileDownload: async () => { calls += 1; },
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+
+  await assert.rejects(controller.downloadPng(), (error) => error.code === 'RESULT_REQUIRED');
+  assert.equal(calls, 0);
+});
+
+test('reports a distinct error when the public host PNG download bridge is unavailable', async () => {
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: tasksThatReturn(imageResult('ready-without-download')),
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+  await controller.generate({ mode: 'emoji', cue: '😀' });
+
+  await assert.rejects(controller.downloadPng(), (error) => error.code === 'DOWNLOAD_API_UNAVAILABLE');
+});
+
+test('creates image-reference mode with the Agent portrait first and one expression image second', async () => {
+  const requests = [];
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    readFile: async () => 'data:image/png;base64,iVBORw0KGgo=',
+    tasks: { ...tasksThatReturn(), create: async (request) => { requests.push(request); return imageResult('image-mode'); } },
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+  await controller.addFiles([{ name: 'expression.png', type: 'image/png', size: 8 }]);
+  await controller.generate({ mode: 'image', cue: '' });
+
+  assert.deepEqual(requests[0].input.referenceImages, [
+    '/api/brew/image-cache/ab/agent.png',
+    'data:image/png;base64,iVBORw0KGgo=',
+  ]);
+  assert.match(requests[0].input.prompt, /Reference image 2 is only the expression, pose, and composition reference/i);
+});
+
+test('requires the single expression image before creating an image-reference task', async () => {
+  let calls = 0;
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: { ...tasksThatReturn(), create: async () => { calls += 1; return imageResult(); } },
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+
+  await assert.rejects(
+    controller.generate({ mode: 'image', cue: '' }),
+    (error) => error.code === 'EXPRESSION_IMAGE_REQUIRED',
+  );
+  assert.equal(calls, 0);
+});
+
+test('does not silently retry without references when the provider rejects an image edit', async () => {
+  let calls = 0;
+  const controller = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: {
+      ...tasksThatReturn(),
+      create: async () => { calls += 1; const error = new Error('unsupported references'); error.code = 'AI_PROVIDER_ERROR'; throw error; },
+    },
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await controller.mount();
+
+  await assert.rejects(controller.generate({ mode: 'emoji', cue: '😀' }), (error) => error.code === 'AI_PROVIDER_ERROR');
+  assert.equal(calls, 1);
+  assert.equal(controller.getState().error.kind, 'provider');
+});
+
+test('reports missing API and permission before creating a task', async () => {
+  const noPermission = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    tasks: { create: async () => { throw new Error('must not call'); } },
+    hasImagePermission: () => false,
+    baseUrl: 'https://myriad.example/',
+  });
+  await noPermission.mount();
+  await assert.rejects(noPermission.generate({ mode: 'emoji', cue: '😀' }), (error) => error.code === 'PERMISSION_DENIED');
+
+  const noApi = createPersonaStickerController({ personaGet: async () => readyPersona(), tasks: null, hasImagePermission: () => true, baseUrl: 'https://myriad.example/' });
+  await noApi.mount();
+  await assert.rejects(noApi.generate({ mode: 'emoji', cue: '😀' }), (error) => error.code === 'AI_API_UNAVAILABLE');
+});
+
+test('destroy clears in-memory image payloads and ignores late Persona or file results', async () => {
+  const persona = deferred();
+  const localFile = deferred();
+  const controller = createPersonaStickerController({
+    personaGet: () => persona.promise,
+    readFile: () => localFile.promise,
+    tasks: tasksThatReturn(),
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+
+  const mounting = controller.mount();
+  controller.destroy();
+  persona.resolve(readyPersona());
+  await mounting;
+  assert.equal(controller.getState().references.length, 0);
+  assert.equal(controller.getState().persona.reason, 'unavailable');
+
+  const other = createPersonaStickerController({
+    personaGet: async () => readyPersona(),
+    readFile: () => localFile.promise,
+    tasks: tasksThatReturn(),
+    hasImagePermission: () => true,
+    baseUrl: 'https://myriad.example/',
+  });
+  await other.mount();
+  const adding = other.addFiles([{ name: 'late.png', type: 'image/png', size: 8 }]);
+  other.destroy();
+  localFile.resolve('data:image/png;base64,iVBORw0KGgo=');
+  await assert.rejects(adding, (error) => error.code === 'PAGE_DESTROYED');
+  assert.equal(other.getState().references.length, 0);
+  assert.equal(other.getState().error, null);
+});

--- a/apps/cn.echootaku.persona-stickers/tests/domain.test.cjs
+++ b/apps/cn.echootaku.persona-stickers/tests/domain.test.cjs
@@ -1,0 +1,131 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const domain = require('../page/domain.js');
+
+function persona() {
+  return {
+    enabled: true,
+    name: 'Arael',
+    moodBand: 'calm',
+    activity: 'idle',
+    portraitUrl: '/api/brew/image-cache/ab/agent.png',
+  };
+}
+
+test('accepts PNG JPEG and WebP signatures and rejects a mismatched payload', () => {
+  const png = 'data:image/png;base64,iVBORw0KGgo=';
+  const jpeg = 'data:image/jpeg;base64,/9j/4AAQSkY=';
+  const webp = 'data:image/webp;base64,UklGRgAAAABXRUJQ';
+
+  assert.equal(domain.validateLocalImageDataUrl(png).mime, 'image/png');
+  assert.equal(domain.validateLocalImageDataUrl(jpeg).mime, 'image/jpeg');
+  assert.equal(domain.validateLocalImageDataUrl(webp).mime, 'image/webp');
+  assert.throws(
+    () => domain.validateLocalImageDataUrl('data:image/png;base64,SGVsbG8='),
+    (error) => error.code === 'INVALID_AI_IMAGE_REFERENCE',
+  );
+});
+
+test('normalizes Persona cards and only exposes an eligible cache portrait reference', () => {
+  assert.deepEqual(domain.normalizePersona(null), {
+    enabled: false,
+    name: 'Agent',
+    moodBand: 'calm',
+    activity: 'idle',
+    portraitUrl: null,
+    reason: 'unavailable',
+  });
+  assert.equal(domain.normalizePersona({ enabled: false, name: 'Arael', portraitUrl: '/api/brew/image-cache/ab/a.png' }).portraitUrl, null);
+  assert.equal(domain.normalizePersona({ enabled: true, name: 'Arael', moodBand: 'excited', activity: 'talking', portraitUrl: '/api/brew/image-cache/ab/a.png' }).portraitUrl, '/api/brew/image-cache/ab/a.png');
+  assert.equal(domain.normalizePersona({ enabled: true, name: 'Arael', portraitUrl: 'https://example.com/a.png' }).portraitUrl, null);
+});
+
+test('builds one PNG-style sticker without promising an alpha channel', () => {
+  const prompt = domain.buildPrompt({ persona: persona(), mode: 'emoji', cue: '😭' });
+
+  assert.match(prompt, /exactly one standalone sticker/i);
+  assert.doesNotMatch(prompt, /on a transparent background/i);
+  assert.match(prompt, /do not draw a transparency checkerboard pattern/i);
+  assert.match(prompt, /Emoji cue: 😭/);
+  assert.match(prompt, /do not draw or print the emoji glyph/i);
+  assert.doesNotMatch(prompt, /panel|sheet|grid/i);
+});
+
+test('builds one sticker from a kaomoji cue without rendering the source characters', () => {
+  const prompt = domain.buildPrompt({ persona: persona(), mode: 'kaomoji', cue: '(╥﹏╥)' });
+
+  assert.match(prompt, /Kaomoji cue: \(╥﹏╥\)/);
+  assert.match(prompt, /do not draw or print the kaomoji characters/i);
+  assert.match(prompt, /same face, hair, outfit, colors, body proportions, and signature accessories/i);
+});
+
+test('uses a second image only as expression pose and composition guidance', () => {
+  const prompt = domain.buildPrompt({ persona: persona(), mode: 'image', cue: '' });
+
+  assert.match(prompt, /Reference image 1 is the canonical Agent appearance/i);
+  assert.match(prompt, /Reference image 2 is only the expression, pose, and composition reference/i);
+  assert.match(prompt, /must not replace the Agent identity/i);
+});
+
+test('makes the optional user direction the dominant creative instruction without weakening output constraints', () => {
+  const direction = '双手抱头蹲下，眼泪像喷泉一样向两侧飞出，动作要非常夸张。';
+  const prompt = domain.buildPrompt({ persona: persona(), mode: 'emoji', cue: '😭', userPrompt: direction });
+
+  assert.match(prompt, /PRIMARY USER CREATIVE DIRECTION/);
+  assert.match(prompt, new RegExp(direction));
+  assert.ok(prompt.indexOf(direction) < prompt.indexOf('Emoji cue: 😭'));
+  assert.match(prompt, /Treat this direction as the dominant creative instruction/i);
+  assert.match(prompt, /exactly one standalone sticker/i);
+  assert.doesNotMatch(prompt, /on a transparent background/i);
+  assert.match(prompt, /do not draw a transparency checkerboard pattern/i);
+  assert.match(prompt, /no text/i);
+});
+
+test('omits an empty user direction and rejects one longer than 800 characters', () => {
+  const withoutDirection = domain.buildPrompt({ persona: persona(), mode: 'emoji', cue: '😭', userPrompt: '   ' });
+  assert.doesNotMatch(withoutDirection, /PRIMARY USER CREATIVE DIRECTION/);
+  assert.throws(
+    () => domain.buildPrompt({ persona: persona(), mode: 'emoji', cue: '😭', userPrompt: '描'.repeat(801) }),
+    (error) => error.code === 'USER_PROMPT_LIMIT',
+  );
+});
+
+test('rejects an unknown mode and an empty text cue', () => {
+  assert.throws(
+    () => domain.buildPrompt({ persona: persona(), mode: 'unknown', cue: '😭' }),
+    (error) => error.code === 'INVALID_EXPRESSION_MODE',
+  );
+  assert.throws(
+    () => domain.buildPrompt({ persona: persona(), mode: 'emoji', cue: '   ' }),
+    (error) => error.code === 'EXPRESSION_CUE_REQUIRED',
+  );
+});
+
+test('maps provider, permission, Persona, input and cancellation failures without hiding codes', () => {
+  assert.deepEqual(domain.classifyError({ code: 'AI_PROVIDER_ERROR' }), { kind: 'provider', code: 'AI_PROVIDER_ERROR' });
+  assert.equal(domain.classifyError({ code: 'PERMISSION_DENIED' }).kind, 'permission');
+  assert.equal(domain.classifyError({ code: 'PERSONA_REQUIRED' }).kind, 'persona');
+  assert.equal(domain.classifyError({ code: 'EXPRESSION_CUE_REQUIRED' }).kind, 'input');
+  assert.equal(domain.classifyError({ code: 'EXPRESSION_IMAGE_REQUIRED' }).kind, 'input');
+  assert.equal(domain.classifyError({ code: 'AI_TASK_TIMEOUT' }).kind, 'timeout');
+  assert.equal(domain.classifyError({ code: 'AI_TASK_CANCELLED' }).kind, 'cancelled');
+  assert.equal(domain.classifyError({ code: 'INVALID_AI_IMAGE_REFERENCE' }).kind, 'reference');
+  assert.equal(domain.classifyError({ code: 'AI_IMAGE_REFERENCE_LIMIT' }).kind, 'reference-limit');
+  assert.equal(domain.classifyError({ code: 'USER_PROMPT_LIMIT' }).kind, 'input-limit');
+});
+
+test('accepts same-origin PNG cache results but rejects unsafe cross-origin and non-PNG URLs', () => {
+  assert.deepEqual(domain.normalizeImageResult(
+    { format: 'image', value: { url: '/api/brew/image-cache/ab/result.png', width: 1024, height: 1024 } },
+    'https://myriad.example/tapp/run/id',
+  ), {
+    referenceUrl: '/api/brew/image-cache/ab/result.png',
+    previewUrl: 'https://myriad.example/api/brew/image-cache/ab/result.png',
+    width: 1024,
+    height: 1024,
+  });
+  assert.equal(domain.normalizeImageResult({ value: { url: '/api/brew/image-cache/ab/result.webp' } }, 'https://myriad.example/').previewUrl, null);
+  assert.equal(domain.normalizeImageResult({ value: { url: 'https://evil.example/a.png' } }, 'https://myriad.example/').previewUrl, null);
+  assert.equal(domain.normalizeImageResult({ value: { url: 'javascript:alert(1)' } }, 'https://myriad.example/').previewUrl, null);
+});

--- a/apps/cn.echootaku.persona-stickers/tests/file-reader.test.cjs
+++ b/apps/cn.echootaku.persona-stickers/tests/file-reader.test.cjs
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { readFileAsDataUrl } = require('../page/file-reader.js');
+
+test('reads local references with FileReader.readAsDataURL', async () => {
+  const calls = [];
+  class FakeFileReader {
+    readAsDataURL(file) {
+      calls.push(file);
+      this.result = 'data:image/png;base64,iVBORw0KGgo=';
+      this.onload();
+    }
+  }
+  const file = { name: 'persona.png', type: 'image/png', size: 8 };
+
+  const result = await readFileAsDataUrl(file, FakeFileReader);
+
+  assert.equal(result, 'data:image/png;base64,iVBORw0KGgo=');
+  assert.deepEqual(calls, [file]);
+});
+test('rejects unsupported MIME types before reading file contents', async () => {
+  class NeverReader { readAsDataURL() { throw new Error('must not read'); } }
+
+  await assert.rejects(
+    readFileAsDataUrl({ name: 'persona.gif', type: 'image/gif', size: 10 }, NeverReader),
+    (error) => error.code === 'INVALID_AI_IMAGE_REFERENCE',
+  );
+});

--- a/apps/cn.echootaku.persona-stickers/tests/lifecycle.test.cjs
+++ b/apps/cn.echootaku.persona-stickers/tests/lifecycle.test.cjs
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { registerLifecycle } = require('../page/lifecycle.js');
+
+test('mounts once and forwards pause, resume and destroy to the active page', async () => {
+  const hooks = {};
+  const calls = [];
+  const tapp = {
+    lifecycle: {
+      onReady(callback) { hooks.ready = callback; },
+      onPause(callback) { hooks.pause = callback; },
+      onResume(callback) { hooks.resume = callback; },
+      onDestroy(callback) { hooks.destroy = callback; },
+    },
+  };
+
+  registerLifecycle(tapp, () => ({
+    mount: async () => { calls.push('mount'); },
+    pause: () => { calls.push('pause'); },
+    resume: () => { calls.push('resume'); },
+    destroy: () => { calls.push('destroy'); },
+  }));
+
+  await hooks.ready();
+  await hooks.ready();
+  hooks.pause();
+  hooks.resume();
+  hooks.destroy();
+  hooks.resume();
+
+  assert.deepEqual(calls, ['mount', 'pause', 'resume', 'destroy']);
+});

--- a/apps/cn.echootaku.persona-stickers/tests/modal-accessibility.test.cjs
+++ b/apps/cn.echootaku.persona-stickers/tests/modal-accessibility.test.cjs
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const modalAccessibility = require('../page/modal-accessibility.js');
+
+function fakeElement() {
+  const attributes = new Map();
+  return {
+    inert: false,
+    setAttribute(name, value) { attributes.set(name, String(value)); },
+    removeAttribute(name) { attributes.delete(name); },
+    getAttribute(name) { return attributes.has(name) ? attributes.get(name) : null; },
+  };
+}
+
+test('opening a modal removes background content from pointer, focus and accessibility navigation', () => {
+  const background = fakeElement();
+
+  modalAccessibility.hideBackground(background);
+
+  assert.equal(background.inert, true);
+  assert.equal(background.getAttribute('aria-hidden'), 'true');
+});
+
+test('closing a modal restores background content to pointer, focus and accessibility navigation', () => {
+  const background = fakeElement();
+  modalAccessibility.hideBackground(background);
+
+  modalAccessibility.showBackground(background);
+
+  assert.equal(background.inert, false);
+  assert.equal(background.getAttribute('aria-hidden'), null);
+});

--- a/apps/cn.echootaku.persona-stickers/tests/package-contract.test.cjs
+++ b/apps/cn.echootaku.persona-stickers/tests/package-contract.test.cjs
@@ -1,0 +1,128 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appRoot = path.resolve(__dirname, '..');
+
+test('declares real layer entries without retired manifest fields', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(appRoot, 'manifest.json'), 'utf8'));
+  assert.equal(manifest.version, '0.3.3');
+  assert.match(manifest.description, /Agent.*单张.*表情图片/);
+  assert.deepEqual(manifest.permissions, ['ai:image']);
+  assert.deepEqual(manifest.ai, {
+    protocolVersion: 2,
+    operations: ['image'],
+    modelTier: 'standard',
+    contextSources: [],
+    outputFormats: ['image'],
+  });
+  assert.equal(manifest.core.entry, 'core.js');
+  assert.equal(manifest.page.entry, 'page/index.js');
+  assert.equal(fs.existsSync(path.join(appRoot, manifest.core.entry)), true);
+  assert.equal(fs.existsSync(path.join(appRoot, manifest.page.entry)), true);
+  for (const retired of ['main', 'hasPage', 'cssMode', 'pageStyles', 'pageTemplate', 'pageModules']) {
+    assert.equal(Object.hasOwn(manifest, retired), false, retired);
+  }
+});
+
+test('ships three cue modes, one shared priority prompt, one image input, and an accessible result viewer', () => {
+  const html = fs.readFileSync(path.join(appRoot, 'page.html'), 'utf8');
+  const zh = JSON.parse(fs.readFileSync(path.join(appRoot, 'i18n', 'zh-CN.json'), 'utf8'));
+  const preview = fs.readFileSync(path.join(appRoot, 'preview.html'), 'utf8');
+  const modes = [...html.matchAll(/<input[^>]+name="expression-mode"[^>]+value="(emoji|kaomoji|image)"[^>]*>/g)]
+    .map((match) => match[1])
+    .sort();
+  const fileInput = html.match(/<input[^>]+data-file-input[^>]*>/);
+  const personaStatus = html.match(/<[^>]+data-persona-status[^>]*>/);
+  const personaDetail = html.match(/<[^>]+data-persona-detail[^>]*>/);
+
+  assert.deepEqual(modes, ['emoji', 'image', 'kaomoji']);
+  assert.ok(fileInput, 'expression image input is required');
+  assert.ok(personaStatus, 'persona status node is required');
+  assert.ok(personaDetail, 'persona detail node is required');
+  assert.doesNotMatch(personaStatus[0], /data-i18n=/);
+  assert.doesNotMatch(personaDetail[0], /data-i18n=/);
+  assert.doesNotMatch(fileInput[0], /\bmultiple\b/);
+  assert.match(html, /<textarea[^>]+data-user-prompt[^>]+maxlength="800"[^>]*>/);
+  assert.match(html, /data-result-viewer[^>]+role="dialog"[^>]+aria-modal="true"/);
+  assert.match(html, /data-page-content/);
+  assert.match(html, /data-action="open-preview"/);
+  assert.match(html, /data-action="download-png"/);
+  assert.equal((html.match(/data-download-status/g) || []).length, 2);
+  assert.doesNotMatch(html, /data-action="download-svg"/);
+  assert.match(html, /制作属于你 Agent 的表情包~/);
+  assert.equal(zh.app.subtitle, '制作属于你 Agent 的表情包~');
+  assert.match(preview, /制作属于你 Agent 的表情包~/);
+  assert.doesNotMatch(html, /recipe-panel|recipe\.title|一张图，两种职责/);
+  assert.doesNotMatch(html, /透明背景/);
+  assert.doesNotMatch(html, /grid-count|use-result|retry-single/);
+});
+
+test('keeps the modal above app chrome and uses neutral dark surfaces without a transparency pattern', () => {
+  const css = fs.readFileSync(path.join(appRoot, 'page.css'), 'utf8');
+
+  assert.match(css, /\.result-viewer\s*\{[^}]*z-index:\s*(?:[5-9]\d|[1-9]\d{2,})\b/s);
+  assert.doesNotMatch(css, /#(?:151a2a|111625|222941|090c15|101527|0a0d18)\b/i);
+  const viewerStage = css.match(/\.result-viewer-stage\s*\{([^}]*)\}/s);
+  assert.ok(viewerStage, 'result viewer stage styles are required');
+  assert.doesNotMatch(viewerStage[1], /background-image\s*:/);
+});
+
+test('uses only the governed file bridge for export and keeps other risky data APIs out', () => {
+  const sources = fs.readdirSync(path.join(appRoot, 'page'))
+    .filter((name) => name.endsWith('.js'))
+    .map((name) => fs.readFileSync(path.join(appRoot, 'page', name), 'utf8'))
+    .join('\n');
+  assert.equal(/Tapp\.storage|Tapp\.federation|\bfetch\s*\(|createObjectURL|\.download\s*=(?!=)/.test(sources), false);
+  assert.match(sources, /tapp\.file\.download/);
+});
+
+test('catalog and snapshot describe the single-sticker Agent workflow', () => {
+  const catalog = fs.readFileSync(path.join(appRoot, 'catalog.json'), 'utf8');
+  const preview = fs.readFileSync(path.join(appRoot, 'preview.html'), 'utf8');
+
+  assert.match(catalog, /Agent/);
+  assert.match(catalog, /单张/);
+  assert.doesNotMatch(catalog, /宫格|grid|最多 4 张|up to four/);
+  assert.match(preview, /Emoji/);
+  assert.match(preview, /颜文字/);
+  assert.match(preview, /图片表情/);
+  assert.match(preview, /高优先级/);
+  assert.match(preview, /查看大图/);
+  assert.match(preview, /下载 PNG/);
+  assert.match(catalog, /高优先级/);
+  assert.match(catalog, /下载.*PNG/);
+  assert.doesNotMatch(catalog, /透明背景|transparent background|透過背景/i);
+  assert.doesNotMatch(preview, /preview-recipe|透明背景|transparent background|透過背景/i);
+  assert.doesNotMatch(preview, /宫格|preview-sheet/);
+});
+
+test('ships matching zh-CN en-US and ja-JP translation key sets', () => {
+  function keys(value, prefix = '') {
+    return Object.entries(value).flatMap(([key, child]) => {
+      const next = prefix ? `${prefix}.${key}` : key;
+      return child && typeof child === 'object' && !Array.isArray(child) ? keys(child, next) : [next];
+    }).sort();
+  }
+  const locales = ['zh-CN', 'en-US', 'ja-JP'].map((locale) =>
+    JSON.parse(fs.readFileSync(path.join(appRoot, 'i18n', `${locale}.json`), 'utf8')),
+  );
+  assert.deepEqual(keys(locales[1]), keys(locales[0]));
+  assert.deepEqual(keys(locales[2]), keys(locales[0]));
+
+  for (const locale of locales) {
+    assert.equal(typeof locale.mode.image, 'string');
+    assert.equal(typeof locale.persona.requiredTitle, 'string');
+    assert.equal(typeof locale.output.title, 'string');
+    assert.equal(typeof locale.prompt.title, 'string');
+    assert.equal(typeof locale.prompt.priority, 'string');
+    assert.equal(typeof locale.action.preview, 'string');
+    assert.equal(typeof locale.action.downloadPng, 'string');
+    assert.equal(typeof locale.result.downloadBoundary, 'string');
+    assert.equal(typeof locale.errors.persona, 'string');
+    assert.equal(typeof locale.errors.expressionImage, 'string');
+    assert.equal(locale.field?.grid, undefined);
+    assert.equal(locale.recipe, undefined);
+  }
+});

--- a/apps/cn.echootaku.persona-stickers/tests/task-runner.test.cjs
+++ b/apps/cn.echootaku.persona-stickers/tests/task-runner.test.cjs
@@ -1,0 +1,267 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createTaskRunner } = require('../page/task-runner.js');
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function fakeClock() {
+  let nextId = 0;
+  const timers = new Map();
+  return {
+    setTimeout(fn) { const id = ++nextId; timers.set(id, fn); return id; },
+    clearTimeout(id) { timers.delete(id); },
+    runAll() { const callbacks = [...timers.values()]; timers.clear(); callbacks.forEach((fn) => fn()); },
+    size() { return timers.size; },
+  };
+}
+
+function timedClock() {
+  let currentTime = 0;
+  let nextId = 0;
+  const timers = new Map();
+  return {
+    now() { return currentTime; },
+    setTimeout(fn, delay) {
+      const id = ++nextId;
+      timers.set(id, { at: currentTime + Number(delay || 0), fn });
+      return id;
+    },
+    clearTimeout(id) { timers.delete(id); },
+    async advanceTo(targetTime) {
+      while (true) {
+        const next = [...timers.entries()]
+          .filter(([, timer]) => timer.at <= targetTime)
+          .sort((left, right) => left[1].at - right[1].at)[0];
+        if (!next) break;
+        currentTime = next[1].at;
+        timers.delete(next[0]);
+        next[1].fn();
+        await flushAsyncWork();
+      }
+      currentTime = targetTime;
+    },
+  };
+}
+
+function flushAsyncWork() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test('emits creating, waiting and success for an image task result', async () => {
+  const events = [];
+  let subscriber;
+  let unsubscribed = 0;
+  const tasks = {
+    create: async () => ({ taskId: 'task-1', status: 'queued' }),
+    subscribe: async (_id, callback) => { subscriber = callback; return () => { unsubscribed += 1; }; },
+    get: async () => ({ taskId: 'task-1', status: 'running' }),
+    cancel: async () => ({}),
+  };
+  const clock = fakeClock();
+  const runner = createTaskRunner({ tasks, setTimeout: clock.setTimeout, clearTimeout: clock.clearTimeout, onState: (state) => events.push(state.status) });
+  const completion = runner.run({ operation: 'image' });
+  await flushAsyncWork();
+  subscriber({ event: 'result', data: { format: 'image', value: { url: '/api/brew/image-cache/ab/result.png', width: 1024, height: 1024 } } });
+
+  const result = await completion;
+  assert.equal(result.value.url, '/api/brew/image-cache/ab/result.png');
+  assert.deepEqual(events.slice(0, 3), ['creating', 'waiting', 'success']);
+  assert.equal(unsubscribed, 1);
+  assert.equal(clock.size(), 0);
+});
+
+test('preserves AI_PROVIDER_ERROR from a failed terminal state', async () => {
+  let subscriber;
+  const tasks = {
+    create: async () => ({ taskId: 'task-provider' }),
+    subscribe: async (_id, callback) => { subscriber = callback; return () => {}; },
+    get: async () => ({ status: 'running' }),
+    cancel: async () => ({}),
+  };
+  const clock = fakeClock();
+  const runner = createTaskRunner({ tasks, setTimeout: clock.setTimeout, clearTimeout: clock.clearTimeout });
+  const completion = runner.run({ operation: 'image' });
+  await flushAsyncWork();
+  subscriber({ event: 'error', data: { status: 'failed', error: { code: 'AI_PROVIDER_ERROR', message: 'provider failed' } } });
+
+  await assert.rejects(completion, (error) => error.code === 'AI_PROVIDER_ERROR' && error.message === 'provider failed');
+});
+
+test('times out, cancels the remote task, and releases timers', async () => {
+  const cancelled = [];
+  const tasks = {
+    create: async () => ({ taskId: 'task-timeout' }),
+    subscribe: () => new Promise(() => {}),
+    get: async () => ({ status: 'running' }),
+    cancel: async (taskId) => { cancelled.push(taskId); },
+  };
+  const clock = fakeClock();
+  const runner = createTaskRunner({ tasks, setTimeout: clock.setTimeout, clearTimeout: clock.clearTimeout });
+  const completion = runner.run({ operation: 'image' });
+  await flushAsyncWork();
+  clock.runAll();
+
+  await assert.rejects(completion, (error) => error.code === 'AI_TASK_TIMEOUT');
+  assert.deepEqual(cancelled, ['task-timeout']);
+  assert.equal(clock.size(), 0);
+});
+
+test('observes a backend terminal state after the 300 second execution limit', async () => {
+  const clock = timedClock();
+  const tasks = {
+    create: async () => ({ taskId: 'task-300s-terminal', status: 'queued' }),
+    subscribe: async () => () => {},
+    get: async () => clock.now() >= 300000
+      ? {
+          taskId: 'task-300s-terminal',
+          status: 'succeeded',
+          result: {
+            format: 'image',
+            value: { url: '/api/brew/image-cache/ab/300s-terminal.png', width: 1024, height: 1024 },
+          },
+        }
+      : { taskId: 'task-300s-terminal', status: 'running' },
+    cancel: async () => ({}),
+  };
+  const runner = createTaskRunner({
+    tasks,
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout,
+  });
+  const completion = runner.run({ operation: 'image' }).then(
+    (value) => ({ value }),
+    (error) => ({ error }),
+  );
+  await flushAsyncWork();
+  await clock.advanceTo(302000);
+
+  const outcome = await completion;
+  if (outcome.error) throw outcome.error;
+  assert.equal(outcome.value.value.url, '/api/brew/image-cache/ab/300s-terminal.png');
+});
+
+test('polls to completion while the task event subscription is still pending', async () => {
+  const clock = timedClock();
+  const tasks = {
+    create: async () => ({ taskId: 'task-poll-fallback', status: 'queued' }),
+    subscribe: () => new Promise(() => {}),
+    get: async () => ({
+      taskId: 'task-poll-fallback',
+      status: 'succeeded',
+      result: {
+        format: 'image',
+        value: { url: '/api/brew/image-cache/ab/poll-fallback.png', width: 1024, height: 1024 },
+      },
+    }),
+    cancel: async () => ({}),
+  };
+  const runner = createTaskRunner({
+    tasks,
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout,
+  });
+  const completion = runner.run({ operation: 'image' }).then(
+    (value) => ({ type: 'result', value }),
+    (error) => ({ type: 'error', error }),
+  );
+  await flushAsyncWork();
+  await clock.advanceTo(2000);
+
+  const outcome = await Promise.race([
+    completion,
+    flushAsyncWork().then(() => ({ type: 'pending' })),
+  ]);
+  assert.equal(outcome.type, 'result');
+  assert.equal(outcome.value.value.url, '/api/brew/image-cache/ab/poll-fallback.png');
+});
+
+test('manual cancellation maps to a cancelled terminal state', async () => {
+  const gate = deferred();
+  const tasks = {
+    create: async () => ({ taskId: 'task-cancel' }),
+    subscribe: async () => gate.promise,
+    get: async () => ({ status: 'running' }),
+    cancel: async () => ({}),
+  };
+  const clock = fakeClock();
+  const runner = createTaskRunner({ tasks, setTimeout: clock.setTimeout, clearTimeout: clock.clearTimeout });
+  const completion = runner.run({ operation: 'image' });
+  await flushAsyncWork();
+  await runner.cancel();
+
+  await assert.rejects(completion, (error) => error.code === 'AI_TASK_CANCELLED');
+  assert.equal(clock.size(), 0);
+});
+
+test('manual cancellation during task creation cancels the remote task once its id arrives', async () => {
+  const createGate = deferred();
+  const cancelled = [];
+  const tasks = {
+    create: () => createGate.promise,
+    subscribe: async () => () => {},
+    get: async () => ({ status: 'running' }),
+    cancel: async (taskId) => { cancelled.push(taskId); },
+  };
+  const clock = fakeClock();
+  const runner = createTaskRunner({ tasks, setTimeout: clock.setTimeout, clearTimeout: clock.clearTimeout });
+  const completion = runner.run({ operation: 'image' });
+  await flushAsyncWork();
+  await runner.cancel();
+
+  await assert.rejects(completion, (error) => error.code === 'AI_TASK_CANCELLED');
+  createGate.resolve({ taskId: 'task-late-cancel', status: 'queued' });
+  await flushAsyncWork();
+
+  assert.deepEqual(cancelled, ['task-late-cancel']);
+  assert.equal(clock.size(), 0);
+});
+
+test('destroy during task creation cancels the remote task once its id arrives', async () => {
+  const createGate = deferred();
+  const cancelled = [];
+  const tasks = {
+    create: () => createGate.promise,
+    subscribe: async () => () => {},
+    get: async () => ({ status: 'running' }),
+    cancel: async (taskId) => { cancelled.push(taskId); },
+  };
+  const clock = fakeClock();
+  const runner = createTaskRunner({ tasks, setTimeout: clock.setTimeout, clearTimeout: clock.clearTimeout });
+  const completion = runner.run({ operation: 'image' });
+  await flushAsyncWork();
+  runner.destroy();
+
+  await assert.rejects(completion, (error) => error.code === 'AI_TASK_DESTROYED');
+  createGate.resolve({ taskId: 'task-late-destroy', status: 'queued' });
+  await flushAsyncWork();
+
+  assert.deepEqual(cancelled, ['task-late-destroy']);
+  assert.equal(clock.size(), 0);
+});
+
+test('destroy unsubscribes, clears timers and prevents late results from settling as success', async () => {
+  let subscriber;
+  let unsubscribed = 0;
+  const tasks = {
+    create: async () => ({ taskId: 'task-destroy' }),
+    subscribe: async (_id, callback) => { subscriber = callback; return () => { unsubscribed += 1; }; },
+    get: async () => ({ status: 'running' }),
+    cancel: async () => ({}),
+  };
+  const clock = fakeClock();
+  const runner = createTaskRunner({ tasks, setTimeout: clock.setTimeout, clearTimeout: clock.clearTimeout });
+  const completion = runner.run({ operation: 'image' });
+  await flushAsyncWork();
+  runner.destroy();
+  subscriber({ event: 'result', data: { format: 'image', value: { url: '/api/brew/image-cache/late.png' } } });
+
+  await assert.rejects(completion, (error) => error.code === 'AI_TASK_DESTROYED');
+  assert.equal(unsubscribed, 1);
+  assert.equal(clock.size(), 0);
+});


### PR DESCRIPTION
## 变更说明

- 新增 `cn.echootaku.persona-stickers`：使用当前用户 Agent 人设生成一张独立 PNG 表情
- 支持 Emoji、颜文字与单张图片表情参考三种输入，并提供高优先级用户提示词
- 提供生成结果大图预览、可访问的模态交互与宿主管理的 PNG 下载
- 版本：0.3.3
- 未修改根目录 `index.json`

## 类型

- [x] 新应用
- [ ] 更新已有应用
- [ ] 修复

## 检查清单

- [x] 一次 PR 只改一个 app
- [x] `manifest.id` 与目录一致
- [x] 非 README 改动已提升版本
- [x] 权限变化已说明：仅申请 `ai:image`
- [x] 本地校验通过
- [x] 已生成 `.tapp` 并记录版本、大小与 SHA-256
- [x] 已在 Myriad 本地安装并完成 Page 与核心流程实机验证（本应用不提供 Widget）
- [x] `.tapp`、截图、日志和测试数据未进入提交

## 验证

- 应用测试：45/45 通过
- `validate-app`：通过，无警告
- `validate-previews`：通过，2 个预览目标
- `sync-index validate --app cn.echootaku.persona-stickers`：通过
- `myriad-tapp check --json`：通过，`diagnostics: []`
- `myriad-tapp permissions --json`：声明与所需权限均仅为 `ai:image`，无缺失权限
- `check-pr-scope upstream/main HEAD`：通过，仅包含 `apps/cn.echootaku.persona-stickers/`

## 安装包与实机验证

- 包文件：`cn.echootaku.persona-stickers-0.3.3.tapp`（仅本地）
- 大小：103,654 字节
- SHA-256：`86c3b556af743d97ea03b528c24995caed79b1db3a2fbd83259cd52b7d6c1063`
- Myriad 环境/版本：当前本地 Myriad 环境（版本号未提供）
- 已验证：用户已手动安装 0.3.3 并完成测试，未报告新的问题
