### PR TITLE
docs: 同步 Widget 分类为八个用途 ID

### DIFF
--- a/development/tapp/API_REFERENCE.md
+++ b/development/tapp/API_REFERENCE.md
@@ -743,6 +743,8 @@ await Tapp.widget.updateConfig("my-widget", {
 });
 ```
 
+`category` 是 **Widget 分类**，与应用用途同一套稳定 ID（`ai` / `data` / `developer` / `game` / `media` / `productivity` / `social` / `utility`），两处独立声明。省略则按 `utility` 归片。只能写这八个规范 ID。限制与库侧筛片见 [Manifest · Widget 分类](MANIFEST.md#widget-分类)。
+
 在 **Widget 沙箱**内还提供当前 Dashboard 实例专用 API（无需 `widget:register`）：
 
 ```javascript

--- a/development/tapp/MANIFEST.md
+++ b/development/tapp/MANIFEST.md
@@ -168,7 +168,9 @@ Manifest 采用严格字段校验：未声明字段、拼写错误以及已经�
 | `utility`      | 无法归入上述用途的通用工具 |
 
 Page、Widget 和 headless core 是运行形态，由 `page`、`widgets` 和
-`backgroundRequirements` 表达，不得填入 `category`。`demo` 和 `test`
+`backgroundRequirements` 表达，不得填入 `category`。每张 Widget 另有独立的
+`widgets[].category`：同一套稳定 ID，字段分开声明，见 [Widget 分类](#widget-分类)。
+`demo` 和 `test`
 属于发布阶段，应使用商店标签表达。宿主会把旧值 `tools`、`games`、
 `development`、`music`、`visualization` 等规范为上述 ID；新包应直接使用规范值。
 界面仅翻译显示名称，Manifest 和商店索引不存储本地化分类文本。
@@ -338,16 +340,14 @@ Page、Core 与其余获授能力仍可正常使用。
 | `icon`          | string   | ❌   | Widget 图标（emoji 或 URL）                                    |
 | `defaultSize`   | string   | ✅   | 默认尺寸（如 "2x2"）                                           |
 | `sizes`         | string[] | ✅   | 支持的尺寸列表                                                 |
-| `category`      | string   | ❌   | Widget 分类（stats, activity, visualization, utility, custom） |
+| `category`      | string   | ❌   | Widget 自己的分类，不是顶层应用用途；见 [Widget 分类](#widget-分类) |
 | `templates`     | object   | ❌   | HTML 模板（按尺寸覆盖）                                        |
 | `settings`      | object[] | ❌   | 每个 Dashboard 实例独立的设置声明                              |
 | `refreshPolicy` | object   | ❌   | 宿主管理的刷新策略                                             |
 
 单个 Tapp 最多声明或动态注册 64 个 Widget；每个 Widget 最多声明 10 个尺寸，且
 `defaultSize` 必须包含在 `sizes` 中。超出限制会在安装或注册时被后端拒绝。
-Widget `category` 只接受表中列出的五个稳定 ID；旧值 `tool` 会规范为 `utility`，
-其他未知值会在 Manifest 解析或动态注册时被拒绝。旧数据库记录仍可读取，但不会再写入
-新的非规范分类。
+`widgets[].category` 的取值与小组件库归片见 [Widget 分类](#widget-分类)。
 顶层 `settings` 是整个 Tapp 共用的全局设置；`widgets[].settings` 则属于单个 Dashboard
 Widget 实例，因此同一种 Widget 添加两次时可以采用不同配置。实例设置会由 Dashboard
 设置面板保存并通过 `props.config`、`Tapp.widget.getInstanceSettings()` 提供给沙箱。
@@ -365,6 +365,32 @@ Widget 实例，因此同一种 Widget 添加两次时可以采用不同配置�
 模板按 `Widget ID + 尺寸` 隔离。同一个 Tapp 的多个 Widget 可以各自声明不同的 `2x2`
 模板，不会互相覆盖。商店索引中的 `download.widget_templates` 也必须使用
 `{ "widgetId": { "2x2": "path/to/template.html" } }` 结构。
+
+### Widget 分类
+
+`widgets[].category` 与顶层 `category` 是两处独立声明，使用**同一套**用途稳定 ID
+（见 [应用分类](#应用分类)）。一张 Widget 不必跟应用用途相同：`media` 应用也可以
+有一张 `utility` 卡片。小组件库没有单独的「第三方」桶；Tapp Widget 与内置件共用
+同一排主题筛片，库侧只读本字段，按 `tapp:<ID>` 原样归片，不看顶层
+`manifest.category`，也不按 `tappId` 分桶。
+
+| ID             | 用途                       | 库筛片           |
+| -------------- | -------------------------- | ---------------- |
+| `ai`           | AI 应用                    | `tapp:ai`        |
+| `data`         | 数据处理、管理与展示       | `tapp:data`      |
+| `developer`    | 开发、调试与部署工具       | `tapp:developer` |
+| `game`         | 游戏                       | `tapp:game`      |
+| `media`        | 音频、视频与其他媒体体验   | `tapp:media`     |
+| `productivity` | 笔记、任务与效率工具       | `tapp:productivity` |
+| `social`       | 社交、消息与协作           | `tapp:social`    |
+| `utility`      | 无法归入上述用途的通用工具 | `tapp:utility`   |
+
+**限制**
+
+- 可选。不写则库侧按 `utility`。
+- 只能写上表八个小写规范 ID。其它值在 Manifest 解析或 `Tapp.widget.register`
+  时被拒绝。
+- 界面只翻译显示名称；Manifest 和注册载荷不存本地化分类文本。
 
 ### templates 配置说明
 

--- a/development/tapp/PLAYGROUND_GENERATION_CONTEXT.md
+++ b/development/tapp/PLAYGROUND_GENERATION_CONTEXT.md
@@ -314,8 +314,10 @@ Bridge 默认 payload 约 **1 MiB**；正式运行特例：`file.download` 文�
   `storage:write`。`Tapp.file.download` 是 public，不要为了把生成文件存到本机去申请
   `storage:read`。不要再声明已移除的 `storage`。确认和全屏分别需要
   `ui:confirm` 与 `ui:fullscreen`。
-- 应用分类和 Widget 分类不是同一枚举；Widget 分类仅允许 `stats`、`activity`、
-  `visualization`、`utility`、`custom`。声明 `widgets` 时安装校验要求声明权限含
+- 应用分类和 Widget 分类是两处独立声明，使用同一套稳定 ID：`ai`、`data`、
+  `developer`、`game`、`media`、`productivity`、`social`、`utility`。Widget
+  `category` 只能写这些规范值；不写则小组件库按实用工具。筛片按声明原样归入对应
+  主题（写 `media` 进媒体）。声明 `widgets` 时安装校验要求声明权限含
   `widget:register`；不要把它理解成「普通用户运行时可以动态注册 Widget」。
 - 顶层 `manifest.settings` 是安装级设置；用户个人偏好放入 `Tapp.storage`，要给访客看的
   站长数据放入 `Tapp.shared`，单个 Widget 实例偏好放入对应的 `widgets[].settings`。

--- a/development/tapp/WIDGET.md
+++ b/development/tapp/WIDGET.md
@@ -1021,6 +1021,7 @@ Tapp.lifecycle.onReady(async () => {
     name: "数据统计",
     defaultSize: "2x2",
     sizes: ["1x1", "2x2", "4x2"],
+    category: "data",
   });
 });
 ```
@@ -1034,7 +1035,8 @@ Tapp.lifecycle.onReady(async () => {
       "id": "stats",
       "name": "数据统计",
       "defaultSize": "2x2",
-      "sizes": ["1x1", "2x2", "4x2"]
+      "sizes": ["1x1", "2x2", "4x2"],
+      "category": "data"
     }
   ]
 }
@@ -1043,6 +1045,14 @@ Tapp.lifecycle.onReady(async () => {
 两种注册不是同一生命周期：Manifest Widget 在安装/更新时由后端完整对账，删除声明会删除
 注册；`Tapp.widget.register()` 是当前 sandbox 的动态注册，调用必须携带宿主管理的 Runtime
 Grant，且不能覆盖或注销 Manifest Widget。静态 Widget 优先写入 Manifest。
+
+`category` 是 **Widget 自己的分类**，和顶层应用用途是两处独立声明，但使用同一套
+稳定 ID：`ai`、`data`、`developer`、`game`、`media`、`productivity`、`social`、
+`utility`。不必跟应用用途相同。完整规则、库侧归片与限制见
+[Manifest · Widget 分类](MANIFEST.md#widget-分类)。
+
+**限制**：只能写这八个规范 ID。不写则小组件库按「实用工具」。写成 `media` 就进
+「媒体」片；没有单独的「第三方」桶。
 
 ---
 

--- a/tapp-cli/src/generated/contract.json
+++ b/tapp-cli/src/generated/contract.json
@@ -453,9 +453,6 @@
       "homepage",
       "repository"
     ],
-    "widgetCategoryAliases": [
-      "tool"
-    ],
     "widgetLayerDirectory": "widget",
     "widgetManifestPermission": "widget:register",
     "widgetRefreshModes": {
@@ -1310,12 +1307,16 @@
         "type": "object"
       },
       "TappWidgetCategory": {
+        "description": "Widget 自己的分类。与顶层 [`TappCategory`] 使用同一套稳定 ID，只认规范值。",
         "enum": [
-          "stats",
-          "activity",
-          "visualization",
-          "utility",
-          "custom"
+          "ai",
+          "data",
+          "developer",
+          "game",
+          "media",
+          "productivity",
+          "social",
+          "utility"
         ],
         "type": "string"
       },

--- a/tapp-cli/src/generated/manifest.schema.json
+++ b/tapp-cli/src/generated/manifest.schema.json
@@ -832,12 +832,16 @@
       "type": "object"
     },
     "TappWidgetCategory": {
+      "description": "Widget 自己的分类。与顶层 [`TappCategory`] 使用同一套稳定 ID，只认规范值。",
       "enum": [
-        "stats",
-        "activity",
-        "visualization",
-        "utility",
-        "custom"
+        "ai",
+        "data",
+        "developer",
+        "game",
+        "media",
+        "productivity",
+        "social",
+        "utility"
       ],
       "type": "string"
     },

--- a/tapp-cli/src/project.mjs
+++ b/tapp-cli/src/project.mjs
@@ -36,10 +36,7 @@ const CATEGORIES = new Set([
 ])
 const WIDGET_SIZES = new Set(contract.rules.widgetSizes)
 const BACKGROUND_REQUIREMENTS = new Set(contract.rules.backgroundRequirements)
-const WIDGET_CATEGORIES = new Set([
-  ...schemaEnum('TappWidgetCategory'),
-  ...contract.rules.widgetCategoryAliases,
-])
+const WIDGET_CATEGORIES = new Set(schemaEnum('TappWidgetCategory'))
 const WIDGET_REFRESH_MODES = new Set(schemaEnum('TappWidgetRefreshMode'))
 const SETTING_TYPES = new Set(contract.rules.settingTypes)
 const AI_OPERATIONS = new Set(schemaEnum('TappAiOperation'))


### PR DESCRIPTION
## 变更说明

镜像 Myriad 主仓这次 Widget 分类改动：`widgets[].category` 与顶层应用用途使用同一套稳定 ID（`ai` / `data` / `developer` / `game` / `media` / `productivity` / `social` / `utility`），只能写这八个规范值。

同时更新仓库内 CLI 的 `TappWidgetCategory` 枚举，并去掉 `widgetCategoryAliases`，避免贡献者按新文档写分类后被旧 `myriad-tapp check` 拒掉。

未改根 `index.json`，未改任何 `apps/<id>/`。

## 类型

- [ ] 新应用（`apps/<id>/`）
- [ ] 更新已有应用（版本 / 功能 / 修复）
- [x] 文档或脚本 / CI
- [ ] 其他

## 检查清单

- [x] **一次 PR 只改一个 app**（本 PR 为零 app）
- [x] **没有修改** 根目录 `index.json`
- [x] 本地：`node scripts/check-pr-scope.mjs` 通过（docs/scripts only）

## 对齐说明

契约以 Myriad 主仓为准。本仓 `development/tapp/` 是贡献者镜像。

下列已上架应用的 Widget 仍写着旧分类，后续各自单独 PR 改 Manifest（一次一个 app，并 bump version），否则新宿主安装会拒绝：

- `com.myriad.doudizhu`、`ink.kei.arknights`、`cn.echootaku.github-workbench`、`cn.xciy.xingchen.widgets`：`stats`
- `cn.xciy.rocom.merchant`：`activity`
- `cn.echootaku.sponsors`、`cn.astelysin.signature-board`、`cn.xciy.xingchen.widgets`：`visualization`


Made with [Cursor](https://cursor.com)