### PR TITLE
fix(cn.astelysin.signature-board): retarget widget categories for CLI 0.1.3

### DIFF
--- a/apps/cn.astelysin.signature-board/manifest.json
+++ b/apps/cn.astelysin.signature-board/manifest.json
@@ -1,9 +1,11 @@
 {
   "id": "cn.astelysin.signature-board",
   "name": "共享签名板",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "让 Myriad 访客在共享画布上签名、涂鸦并浏览公开历史。",
-  "author": { "name": "Astelysin" },
+  "author": {
+    "name": "Astelysin"
+  },
   "category": "social",
   "minSystemVersion": "0.3.36",
   "themeColor": "#8b5cf6",
@@ -30,9 +32,12 @@
       "name": "共享签名板",
       "description": "在主页展示最近发布的签名板快照。",
       "icon": "✍️",
-      "category": "visualization",
+      "category": "social",
       "defaultSize": "4x2",
-      "sizes": ["2x2", "4x2"],
+      "sizes": [
+        "2x2",
+        "4x2"
+      ],
       "entry": "widget/entry.js",
       "templates": {
         "2x2": "templates/widget-2x2.html",


### PR DESCRIPTION
Replace retired `widgets[].category` values (`stats` / `activity` / `visualization`) with the eight purpose IDs required by `@myriad-you/tapp-cli@0.1.3`.

`manifest.version`: `0.4.0` → `0.4.1`.

- `board-preview`: `social`

Verified with `node tapp-cli/bin/myriad-tapp.mjs check apps/cn.astelysin.signature-board --json`.