### PR TITLE
fix(cn.echootaku.github-workbench): retarget widget categories for CLI 0.1.3

### DIFF
--- a/apps/cn.echootaku.github-workbench/manifest.json
+++ b/apps/cn.echootaku.github-workbench/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "cn.echootaku.github-workbench",
   "name": "GitHub 工作台",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "minSystemVersion": "0.3.23",
   "description": "集中查看待审 PR、分配给我的 Issue、失败 Actions 与仓库发布动态。",
   "locales": {
@@ -58,7 +58,7 @@
       "name": "GitHub 工作台概览",
       "description": "查看待审 PR、Issue 与失败 Actions 数量。",
       "icon": "github",
-      "category": "stats",
+      "category": "developer",
       "defaultSize": "4x2",
       "sizes": [
         "2x2",


### PR DESCRIPTION
Replace retired `widgets[].category` values (`stats` / `activity` / `visualization`) with the eight purpose IDs required by `@myriad-you/tapp-cli@0.1.3`.

`manifest.version`: `0.1.3` → `0.1.4`.

- `github-workbench-overview`: `developer`

Verified with `node tapp-cli/bin/myriad-tapp.mjs check apps/cn.echootaku.github-workbench --json`.