### PR TITLE
fix(cn.xciy.rocom.merchant): retarget widget categories for CLI 0.1.3

### DIFF
--- a/apps/cn.xciy.rocom.merchant/manifest.json
+++ b/apps/cn.xciy.rocom.merchant/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "cn.xciy.rocom.merchant",
   "name": "洛克王国情报台",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "查看远行商人、活动日历、最新公告与精灵图鉴。",
   "locales": {
     "en-US": {
@@ -48,7 +48,7 @@
       "name": "远行商人速览",
       "description": "在桌面查看当前轮次、倒计时与商品。",
       "icon": "M",
-      "category": "activity",
+      "category": "utility",
       "defaultSize": "2x2",
       "sizes": [
         "2x2",


### PR DESCRIPTION
Replace retired `widgets[].category` values (`stats` / `activity` / `visualization`) with the eight purpose IDs required by `@myriad-you/tapp-cli@0.1.3`.

`manifest.version`: `1.4.3` → `1.4.4`.

- `rocom-merchant-overview`: `utility`

Verified with `node tapp-cli/bin/myriad-tapp.mjs check apps/cn.xciy.rocom.merchant --json`.