### PR TITLE
fix(com.myriad.doudizhu): retarget widget categories for CLI 0.1.3

### DIFF
--- a/apps/com.myriad.doudizhu/manifest.json
+++ b/apps/com.myriad.doudizhu/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com.myriad.doudizhu",
   "name": "斗地主",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minSystemVersion": "0.3.0",
   "description": "三人单机斗地主：经典牌桌与若泉绮羽㥹銯麏主题、完整规则、智能提示与本地 AI",
   "locales": {
@@ -53,7 +53,7 @@
       "name": "今日斗地主",
       "description": "展示今日胜负、净积分与最近一局结果",
       "icon": "spade",
-      "category": "stats",
+      "category": "game",
       "defaultSize": "2x2",
       "sizes": [
         "1x1",


### PR DESCRIPTION
Replace retired `widgets[].category` values (`stats` / `activity` / `visualization`) with the eight purpose IDs required by `@myriad-you/tapp-cli@0.1.3`.

`manifest.version`: `1.0.1` → `1.0.2`.

- `daily-record`: `game`

Verified with `node tapp-cli/bin/myriad-tapp.mjs check apps/com.myriad.doudizhu --json`.