### PR TITLE
fix(tapp-cli): declare global Tapp in generated SDK types

### DIFF
--- a/development/tapp/QUICKSTART.md
+++ b/development/tapp/QUICKSTART.md
@@ -10,9 +10,9 @@ Tapp (Third-party App) 是 Myriad 的扩展应用系统，允许开发者创建�
 Agent 和 CI 应固定包版本、显式指定 `myriad-tapp` binary，并始终使用 `--json`：
 
 ```bash
-npx --yes --package=@myriad-you/tapp-cli@0.1.3 myriad-tapp init ./my-tapp --type page
-npx --yes --package=@myriad-you/tapp-cli@0.1.3 myriad-tapp check ./my-tapp --json
-npx --yes --package=@myriad-you/tapp-cli@0.1.3 myriad-tapp pack ./my-tapp --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.4 myriad-tapp init ./my-tapp --type page
+npx --yes --package=@myriad-you/tapp-cli@0.1.4 myriad-tapp check ./my-tapp --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.4 myriad-tapp pack ./my-tapp --json
 ```
 
 任何非零退出状态都表示失败。`check` 返回状态 `1` 时，读取 `diagnostics`、修复项目并重新
@@ -25,7 +25,7 @@ npx --yes --package=@myriad-you/tapp-cli@0.1.3 myriad-tapp pack ./my-tapp --json
 starter：
 
 ```bash
-npm install --global @myriad-you/tapp-cli@0.1.3
+npm install --global @myriad-you/tapp-cli@0.1.4
 myriad-tapp init ./my-tapp --type page
 ```
 

--- a/tapp-cli/README.md
+++ b/tapp-cli/README.md
@@ -8,7 +8,7 @@ authority; this CLI catches common contract problems before upload.
 - Node.js 20 or newer;
 - access to a Myriad instance when you are ready to install the generated package.
 
-The examples pin `@myriad-you/tapp-cli` to `0.1.3`. Keep the version explicit in
+The examples pin `@myriad-you/tapp-cli` to `0.1.4`. Keep the version explicit in
 automation and upgrade it deliberately when a newer release is available.
 
 ## For agents
@@ -18,9 +18,9 @@ accepts npm's temporary-install prompt; `--package` makes the selected package a
 binary unambiguous in CI.
 
 ```bash
-npx --yes --package=@myriad-you/tapp-cli@0.1.3 myriad-tapp init ./my-tapp --type page
-npx --yes --package=@myriad-you/tapp-cli@0.1.3 myriad-tapp check ./my-tapp --json
-npx --yes --package=@myriad-you/tapp-cli@0.1.3 myriad-tapp pack ./my-tapp --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.4 myriad-tapp init ./my-tapp --type page
+npx --yes --package=@myriad-you/tapp-cli@0.1.4 myriad-tapp check ./my-tapp --json
+npx --yes --package=@myriad-you/tapp-cli@0.1.4 myriad-tapp pack ./my-tapp --json
 ```
 
 Treat a non-zero status as failure. When `check --json` returns status `1`, repair
@@ -31,7 +31,7 @@ For a checked-in dependency, pin the package in the lockfile and invoke its bina
 through `npm exec`:
 
 ```bash
-npm install --save-dev --save-exact @myriad-you/tapp-cli@0.1.3
+npm install --save-dev --save-exact @myriad-you/tapp-cli@0.1.4
 npm exec -- myriad-tapp check . --json
 ```
 
@@ -43,7 +43,7 @@ exit status described in [Automation contract](#automation-contract).
 Install the pinned CLI globally when you want a short interactive command:
 
 ```bash
-npm install --global @myriad-you/tapp-cli@0.1.3
+npm install --global @myriad-you/tapp-cli@0.1.4
 ```
 
 Create a starter, edit its `manifest.json` and source files, then validate and

--- a/tapp-cli/package-lock.json
+++ b/tapp-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@myriad-you/tapp-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@myriad-you/tapp-cli",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "typescript": "^6.0.3"

--- a/tapp-cli/package.json
+++ b/tapp-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myriad-you/tapp-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Offline project tooling for Myriad Tapps",
   "type": "module",
   "files": [

--- a/tapp-cli/scripts/sdk-dts.mjs
+++ b/tapp-cli/scripts/sdk-dts.mjs
@@ -392,10 +392,11 @@ ${localMembers()}
 ${genericLines.join('\n')}
 }
 
-declare const Tapp: TappSdk
-
-interface Window {
-  Tapp: TappSdk
+declare global {
+  const Tapp: TappSdk
+  interface Window {
+    Tapp: TappSdk
+  }
 }
 
 export {}

--- a/tapp-cli/src/generated/tapp-sdk.d.ts
+++ b/tapp-cli/src/generated/tapp-sdk.d.ts
@@ -556,10 +556,11 @@ export interface TappSdk {
   }
 }
 
-declare const Tapp: TappSdk
-
-interface Window {
-  Tapp: TappSdk
+declare global {
+  const Tapp: TappSdk
+  interface Window {
+    Tapp: TappSdk
+  }
 }
 
 export {}

--- a/tapp-cli/test/project.test.mjs
+++ b/tapp-cli/test/project.test.mjs
@@ -91,7 +91,8 @@ describe('Tapp project core', () => {
       'utf8',
     )
     assert.match(sdkDts, /export interface TappSdk/)
-    assert.match(sdkDts, /declare const Tapp: TappSdk/)
+    assert.match(sdkDts, /declare global \{/)
+    assert.match(sdkDts, /const Tapp: TappSdk/)
     assert.match(sdkDts, /showNotification/)
     assert.match(sdkDts, /federation/)
   })

--- a/tapp-cli/test/sdk-types.test.mjs
+++ b/tapp-cli/test/sdk-types.test.mjs
@@ -68,3 +68,35 @@ it('types AI task inputs and snapshots and rejects malformed inputs', async () =
     await rm(directory, { recursive: true, force: true })
   }
 })
+
+it('exposes global Tapp to referenced JavaScript without importing the SDK module', async () => {
+  const shipped = await readFile(new URL('../src/generated/tapp-sdk.d.ts', import.meta.url), 'utf8')
+  const directory = await mkdtemp(join(tmpdir(), 'tapp-global-'))
+  try {
+    await writeFile(join(directory, 'tapp-sdk.d.ts'), shipped)
+    await writeFile(
+      join(directory, 'page.js'),
+      `/// <reference path="./tapp-sdk.d.ts" />
+Tapp.lifecycle.onReady(async () => {
+  await Tapp.storage.get('ready')
+})
+`,
+    )
+    const program = ts.createProgram([join(directory, 'page.js')], {
+      allowJs: true,
+      checkJs: true,
+      noEmit: true,
+      target: ts.ScriptTarget.ES2022,
+      lib: ['lib.es2022.d.ts', 'lib.dom.d.ts'],
+      types: [],
+    })
+    assert.deepEqual(
+      ts.getPreEmitDiagnostics(program).map((diagnostic) =>
+        ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+      ),
+      [],
+    )
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
`tapp-sdk.d.ts` exports `TappSdk`, so TypeScript treats it as a module. File-scope `declare const Tapp` is not a global, and editors report **找不到名称“Tapp”** / **Cannot find name 'Tapp'** on `/// <reference path=\"./types/tapp-sdk.d.ts\" />` JS.

This PR moves the binding into `declare global` and pins the in-repo CLI to **0.1.4**. Host counterpart: Myriad-You/Myriad#349.

Does not publish npm from this repo. After `@myriad-you/tapp-cli@0.1.4` is on the registry, `init` copies the fixed types into new projects.